### PR TITLE
fix: separate frontend amount state

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -123,7 +123,8 @@ function uniqueKey(): string {
 export function App() {
   const [walletId, setWalletId] = useState('wallet-001');
   const [targetWalletId, setTargetWalletId] = useState('wallet-002');
-  const [amount, setAmount] = useState('5000');
+  const [chargeAmount, setChargeAmount] = useState('5000');
+  const [transferAmount, setTransferAmount] = useState('5000');
   const [description, setDescription] = useState('프론트 테스트');
   const [operationId, setOperationId] = useState('');
   const [apiState, setApiState] = useState<ApiState>(initialApiState);
@@ -171,7 +172,7 @@ export function App() {
       const result = await requestJson<WalletOperationResult>(`/api/v1/wallets/${walletId}/charges`, {
         method: 'POST',
         body: JSON.stringify({
-          amount: Number(amount),
+          amount: Number(chargeAmount),
           currency: 'KRW',
           idempotencyKey: uniqueKey(),
           description,
@@ -190,7 +191,7 @@ export function App() {
         method: 'POST',
         body: JSON.stringify({
           targetWalletId,
-          amount: Number(amount),
+          amount: Number(transferAmount),
           currency: 'KRW',
           idempotencyKey: uniqueKey(),
           description,
@@ -245,7 +246,7 @@ export function App() {
           </label>
           <label>
             금액
-            <input value={amount} type="number" min="1" onChange={(event) => setAmount(event.target.value)} />
+            <input value={chargeAmount} type="number" min="1" onChange={(event) => setChargeAmount(event.target.value)} />
           </label>
           <label>
             설명
@@ -267,7 +268,7 @@ export function App() {
           </label>
           <label>
             금액
-            <input value={amount} type="number" min="1" onChange={(event) => setAmount(event.target.value)} />
+            <input value={transferAmount} type="number" min="1" onChange={(event) => setTransferAmount(event.target.value)} />
           </label>
           <button type="submit" disabled={isLoading}>송금하기</button>
         </form>


### PR DESCRIPTION
## 요약

- 충전 폼과 송금 폼이 공유하던 금액 상태를 분리했습니다.
- 충전 요청은 `chargeAmount`, 송금 요청은 `transferAmount`를 사용합니다.

## 관련 Issue

Closes #45

## 원인

React 사용자 화면에서 두 폼이 하나의 `amount` state를 공유해 한쪽 입력 변경이 다른 폼에도 반영되었습니다.

## 검증

- [x] `npm --prefix frontend run build`
- [x] `git diff --check`
