### PR TITLE
docs: add validation documentation audit

### DIFF
--- a/docs/reviews/current-validation-documentation-audit.md
+++ b/docs/reviews/current-validation-documentation-audit.md
@@ -1,0 +1,186 @@
+# Current Validation Documentation Audit
+
+## 점검 일자
+
+- 2026-05-04
+
+## 점검 범위
+
+- 현재 기준 브랜치: `main`
+- 최신 병합 PR: #74 `test: add PostgreSQL scenario CI gate`
+- 연결 Issue: #73
+- 점검 대상:
+  - README
+  - ADR
+  - Progress Reports
+  - Issue drafts
+  - GitHub Issue/PR/CI 상태
+  - Local/Scenario/PostgreSQL/Frontend 테스트 가이드
+  - Wiki drafts
+  - Release notes
+
+## 결론
+
+현재 개발분의 핵심 검증 문서는 대부분 갖춰져 있다.
+
+다만 포트폴리오형 운영 하네스 관점에서는 다음 문서 공백이 남아 있다.
+
+| 등급 | 항목 | 판단 |
+| --- | --- | --- |
+| P1 | Wiki draft 최신화 | 일부 내용이 최근 구현 상태보다 오래됨 |
+| P1 | 다음 릴리스 후보 문서 | `v0.6.0` 이후 변경분의 unreleased/release candidate 문서가 없음 |
+| P2 | QA 시나리오 Wiki | README 권장 Wiki 구조에는 있으나 초안 파일이 없음 |
+| P2 | Architecture Decisions Wiki | README 권장 Wiki 구조에는 있으나 초안 파일이 없음 |
+| P2 | MCP and Skills Wiki | README 권장 Wiki 구조에는 있으나 초안 파일이 없음 |
+| P3 | `.dev/rules` 기반 자동 체크 규칙 | `check` 스킬 기준 rule directory가 없음 |
+
+## 확인된 정상 항목
+
+### README
+
+- 프로젝트 목적, 배경, 기술 선택, 하네스 운영 모델이 정리되어 있다.
+- 테스트 게이트에 `test`, `scenarioTest`, `postgresScenarioTest`, frontend unit/build/e2e가 반영되어 있다.
+- ADR-0036까지 링크가 연결되어 있다.
+
+### ADR
+
+- ADR-0001부터 ADR-0036까지 존재한다.
+- 최신 PostgreSQL scenario CI 결정은 ADR-0036에 기록되어 있다.
+- Spring Boot 4의 `spring-boot-flyway` 모듈 필요성도 ADR-0036에 반영되어 있다.
+
+### Progress Reports
+
+- 0000부터 0035까지 단계별 완료 흔적이 있다.
+- 최신 완료 기능은 PostgreSQL Scenario Testcontainers CI로 갱신되어 있다.
+- 각 progress 문서는 목표, 완료 결과, 검증, 남은 일을 포함한다.
+
+### Issue / PR / CI
+
+- Issue #73은 닫힘 상태다.
+- PR #74는 병합 완료 상태다.
+- PR #74의 CI check는 모두 성공했다.
+  - Gradle Check
+  - Scenario Test
+  - PostgreSQL Scenario Test
+  - Frontend Build
+  - Frontend Unit Test
+  - Frontend E2E
+
+### 테스트 가이드
+
+- `docs/testing/local-test-guide.md`에 `postgresScenarioTest`와 CI 대응 관계가 반영되어 있다.
+- `docs/testing/scenario-test-strategy.md`에 `postgres-scenario` tag와 `PostgresWalletScenarioFlowTest`가 반영되어 있다.
+- `docs/development/local-setup.md`에 Docker/Testcontainers 필요 조건이 반영되어 있다.
+
+## 누락 또는 보완 후보
+
+### P1. Wiki draft 최신화
+
+`wiki-drafts/Domain-Rules.md` 일부 문장은 최신 구현과 맞지 않는다.
+
+예:
+
+- 원장/감사 로그가 아직 인메모리라고 표현된 부분이 있다.
+- 실제 PostgreSQL 컨테이너 검증을 후속 작업으로 남긴다고 표현된 부분이 있다.
+- relay/publisher와 메시지 브로커가 전부 후속 작업이라고 표현된 부분이 있다.
+- 인증/인가를 후속 작업으로 남긴다고 표현된 부분이 있다.
+
+현재 상태:
+
+- PostgreSQL profile에서 원장/감사 로그가 DB에 저장된다.
+- Testcontainers PostgreSQL 검증과 PostgreSQL scenario CI gate가 있다.
+- HTTP outbox broker adapter가 있다.
+- Spring Security 기반 운영 API role model이 있다.
+
+판단:
+
+- ADR과 Progress는 최신이지만, Wiki draft가 도메인 설명 문서라면 최신화가 필요하다.
+- 단, 과거 progress 문서의 “남은 일”은 당시 시점 기록이므로 소급 수정 대상이 아니다.
+
+### P1. 다음 릴리스 후보 문서
+
+현재 GitHub Release와 `docs/releases/v0.6.0.md`는 존재한다.
+
+하지만 `v0.6.0` 이후 병합된 작업들이 많다.
+
+- outbox relay scheduler
+- outbox relay run monitoring
+- admin API access audit
+- operational log pruning
+- relay health metrics/alert
+- Spring Security role model
+- HTTP outbox broker adapter
+- PostgreSQL scenario CI gate
+
+판단:
+
+- 아직 새 버전을 발행하지 않았다면 문제는 아니다.
+- 다만 릴리스 관리 관점에서는 `docs/releases/unreleased.md` 또는 `docs/releases/v0.7.0-candidate.md`가 있으면 현재 개발분 검증 기준이 더 명확해진다.
+
+### P2. QA Scenarios Wiki 초안
+
+README의 권장 Wiki 구조에는 `QA-Scenarios`가 있다.
+
+현재는 `docs/testing/scenario-test-strategy.md`와 테스트 코드가 QA 시나리오 역할을 일부 수행한다.
+
+판단:
+
+- 코드 검증 기준은 존재한다.
+- 포트폴리오형 설명 문서로는 QA 시나리오 Wiki 초안이 있으면 좋다.
+
+### P2. Architecture Decisions Wiki 초안
+
+README의 권장 Wiki 구조에는 `Architecture-Decisions`가 있다.
+
+현재는 `docs/adr/README.md`가 ADR 목록 역할을 수행한다.
+
+판단:
+
+- source of truth는 충분하다.
+- Wiki에는 비기술 독자가 읽기 쉬운 결정 지도 형태가 있으면 좋다.
+
+### P2. MCP and Skills Wiki 초안
+
+README의 권장 Wiki 구조에는 `MCP-and-Skills`가 있다.
+
+현재 `skills/` 동기화와 Codex 스킬 사용 흔적은 있지만 Wiki 초안은 없다.
+
+판단:
+
+- 기능 검증에는 영향이 낮다.
+- 하네스 운영 포트폴리오 관점에서는 보강 가치가 있다.
+
+### P3. `.dev/rules` 기반 자동 체크 규칙
+
+`check` 스킬은 `.dev/rules` 디렉터리를 기준으로 변경 누락을 자동 검증하도록 설계되어 있다.
+
+현재 repo에는 `.dev/rules`가 없다.
+
+판단:
+
+- 지금은 문서와 PR 템플릿 중심으로 충분히 운영 가능하다.
+- 반복 누락이 늘어나면 `.dev/rules`에 문서 동기화 규칙을 추가하는 것이 좋다.
+
+## 권장 후속 작업
+
+1. Wiki draft 최신화
+   - `wiki-drafts/Domain-Rules.md`
+   - `wiki-drafts/README.md`
+2. 다음 릴리스 후보 문서 추가
+   - `docs/releases/unreleased.md` 또는 `docs/releases/v0.7.0-candidate.md`
+3. QA/Architecture/MCP Wiki 초안 추가
+   - `wiki-drafts/QA-Scenarios.md`
+   - `wiki-drafts/Architecture-Decisions.md`
+   - `wiki-drafts/MCP-and-Skills.md`
+4. 자동 점검 규칙 도입 검토
+   - `.dev/rules/documentation-sync.md`
+   - `.dev/rules/testing-gates.md`
+
+## 최종 판정
+
+- 기능 검증 문서: PASS
+- ADR/Progress 추적: PASS
+- Issue/PR/CI 연결: PASS
+- 릴리스 최신 추적: WARN
+- Wiki 최신성: WARN
+- 자동 누락 점검 규칙: OPTIONAL


### PR DESCRIPTION
## 변경 내용
- Closes #75
- 현재 main 기준 검증 문서 누락 여부를 리뷰 문서로 정리했습니다.
- README, ADR, Progress, Issue/PR/CI, 테스트 가이드, Wiki draft, Release notes를 교차 점검했습니다.
- PASS/WARN/OPTIONAL 항목과 후속 보완 우선순위를 정리했습니다.

## 문서 기준
- Review: `docs/reviews/current-validation-documentation-audit.md`
- ADR: 신규 결정 없음
- Wiki: 최신화 필요 항목을 후속 작업으로 식별

## 하네스 역할 검토
| 역할 | 검토 결과 |
| --- | --- |
| 기획자 | 문서를 기준으로 현재 개발분 검증 가능 여부를 확인했습니다. |
| 도메인 전문가 | Wiki Domain Rules의 최신성 경고를 식별했습니다. |
| 코드 개발자 A | 코드 변경 없이 문서 감사 결과만 추가했습니다. |
| 코드 개발자 B | 릴리스 후보 문서와 Wiki 초안 공백을 분리했습니다. |
| QA | CI/테스트 게이트와 문서 반영 여부를 확인했습니다. |
| 릴리스 관리자 | v0.6.0 이후 변경분의 unreleased 문서 필요성을 식별했습니다. |

## 테스트
```text
git diff --check
rg -n "/Users/imwoo94|study/ai-repo|\\.codex" docs/reviews/current-validation-documentation-audit.md || true
```

코드 변경 없음.

## 대안과 트레이드오프
- 바로 Wiki/Release 문서를 수정할 수도 있지만, 이번 작업은 누락 점검과 우선순위 식별에 집중했습니다.
- 실제 최신화는 후속 작업으로 분리하는 편이 변경 범위와 리뷰 기준이 명확합니다.
