### PR TITLE
feat: add operator manual review console

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Operational log pruning scheduler도 기본 비활성화입니다. 자동 prunin
 
 `postgres` 프로필의 스키마 기준은 Flyway migration입니다. 초기 migration은 `src/main/resources/db/migration`에 두며, 기존 `src/main/resources/db/postgresql` SQL 파일은 H2 테스트와 수동 비교를 위해 일시적으로 유지합니다.
 
-React 사용자 화면은 [React User Frontend](docs/frontend/react-user-frontend.md)를 따릅니다. 백엔드는 `./gradlew bootRun`으로 실행하고, 프론트는 `frontend`에서 `npm install`, `npm run dev`로 실행합니다. 로컬 검증은 [Local Test Guide](docs/testing/local-test-guide.md)를 기준으로 합니다.
+React 사용자 화면과 운영자 manual review 콘솔은 [React User Frontend](docs/frontend/react-user-frontend.md)를 따릅니다. 백엔드는 `./gradlew bootRun`으로 실행하고, 프론트는 `frontend`에서 `npm install`, `npm run dev`로 실행합니다. 로컬 검증은 [Local Test Guide](docs/testing/local-test-guide.md)를 기준으로 합니다.
 
 ## 문서화 전략
 

--- a/docs/frontend/react-user-frontend.md
+++ b/docs/frontend/react-user-frontend.md
@@ -4,6 +4,8 @@
 
 이 화면은 백엔드 API가 만든 금융 도메인 결과를 사람이 직접 검증하기 위한 사용자 화면이다. 잔액, 거래내역, 충전, 송금, 원장, 감사 로그, step log, outbox event를 하나의 흐름으로 확인한다.
 
+운영자 콘솔 영역에서는 manual review outbox를 조회하고, requeue를 실행하며, requeue audit trail을 확인한다.
+
 ## 디자인 기준
 
 - UI 생성과 수정은 `DESIGN-apple.md`를 따른다.
@@ -66,11 +68,31 @@ cd frontend && npm run e2e
 - 충전 요청
 - 송금 요청
 - 원장, 감사 로그, step log, outbox event 조회
+- 운영자 token/operator header 입력
+- manual review outbox 조회
+- manual review outbox requeue
+- requeue audit trail 조회
 
 ## 범위 제외
 
-- 인증/인가
-- 운영자 승인 화면
+- 실제 로그인/OIDC/IAM
+- 운영자 승인 워크플로우
 - React 라우팅
-- 프론트 단위 테스트
 - 운영 배포 파이프라인
+
+## 운영자 콘솔
+
+운영자 콘솔은 현재 백엔드의 header 기반 운영 API를 그대로 사용한다.
+
+| 입력 | 기본값 | 용도 |
+| --- | --- | --- |
+| Admin token | `local-ops-token` | `X-Admin-Token` header |
+| Operator ID | `local-operator` | `X-Operator-Id` header |
+| Requeue reason | `broker recovered from operator console` | requeue audit reason |
+
+화면 상태는 다음 기준으로 표시한다.
+
+- manual review event가 없으면 empty state를 표시한다.
+- API 오류는 error callout으로 표시한다.
+- outbox status는 status badge로 표시한다.
+- requeue 성공 후에는 선택한 event의 audit trail을 유지해서 운영 조치 증거를 확인한다.

--- a/docs/progress/0036-operator-manual-review-console-ui.md
+++ b/docs/progress/0036-operator-manual-review-console-ui.md
@@ -1,0 +1,41 @@
+# 0036. Operator Manual Review Console UI
+
+## 스펙 목표
+
+- 운영자가 화면에서 manual review outbox를 조회한다.
+- 선택한 event를 reason과 함께 requeue한다.
+- requeue audit trail을 화면에서 확인한다.
+- Apple 스타일 기준으로 card, status badge, empty/error state를 정리한다.
+
+## 완료 결과
+
+- React 화면에 `Operator console` 섹션을 추가했다.
+- `X-Admin-Token`, `X-Operator-Id` 입력 UI를 추가했다.
+- `GET /api/v1/outbox-events/manual-review` 조회 UI를 추가했다.
+- `POST /api/v1/outbox-events/{outboxEventId}/requeue` 실행 UI를 추가했다.
+- `GET /api/v1/outbox-events/{outboxEventId}/requeue-audits` 조회 UI를 추가했다.
+- manual review empty state와 API error callout을 추가했다.
+- outbox status badge와 운영자 card layout을 Apple 스타일 기준으로 정리했다.
+- 프론트 unit test에 empty state, requeue, audit trail 검증을 추가했다.
+
+## 검증
+
+- `cd frontend && npm run test`
+- `cd frontend && npm run build`
+- `cd frontend && npm run e2e`
+- `git diff --check`
+
+## 남은 일
+
+- 운영자 승인 워크플로우는 아직 없다.
+- operator/admin role 분리와 실제 로그인 연동은 후속 작업이다.
+- 운영자 콘솔 E2E는 manual review fixture 생성 방식이 정리된 뒤 추가한다.
+- relay health와 pruning 화면은 별도 운영자 콘솔 확장 작업으로 분리한다.
+
+## 관련 문서
+
+- `docs/frontend/react-user-frontend.md`
+- `issue-drafts/0036-operator-manual-review-console-ui.md`
+- `docs/adr/0024-react-user-frontend-mvp.md`
+- `docs/adr/0019-outbox-manual-review-api.md`
+- `docs/adr/0020-outbox-requeue-audit-trail.md`

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -51,10 +51,11 @@ ADR은 “왜 그렇게 결정했는가”를 기록하고, 이 폴더는 “각
 | 0033 | [Spring Security Role Model](0033-spring-security-role-model.md) | 완료 |
 | 0034 | [HTTP Outbox Broker Adapter](0034-http-outbox-broker-adapter.md) | 완료 |
 | 0035 | [PostgreSQL Scenario Testcontainers CI](0035-postgresql-scenario-testcontainers-ci.md) | 완료 |
+| 0036 | [Operator Manual Review Console UI](0036-operator-manual-review-console-ui.md) | 완료 |
 
 ## 현재 기준선
 
 - 최신 병합 기준: `main`
-- 최신 완료 기능: PostgreSQL Scenario Testcontainers CI
+- 최신 완료 기능: Operator Manual Review Console UI
 - 현재 릴리스 후보: `v0.6.0`
-- 아직 미완료: 운영자 manual review 화면, Kafka/RabbitMQ/SQS adapter, consumer idempotency, operator/admin token 분리, pruning 실행 이력, external alert channel, 승인 워크플로우, GitHub Wiki 동기화, broker-specific Testcontainers 정책
+- 아직 미완료: 운영자 relay health/pruning 화면, Kafka/RabbitMQ/SQS adapter, consumer idempotency, operator/admin token 분리, pruning 실행 이력, external alert channel, 승인 워크플로우, GitHub Wiki 동기화, broker-specific Testcontainers 정책

--- a/docs/testing/local-test-guide.md
+++ b/docs/testing/local-test-guide.md
@@ -124,6 +124,8 @@ Vitest와 Testing Library로 React 컴포넌트 테스트를 실행한다.
 - 충전/송금 금액 입력 상태 독립성
 - 충전 요청 payload
 - 잔액 부족 송금 오류 메시지
+- 운영자 manual review empty state
+- 운영자 requeue 요청 payload와 audit trail 표시
 
 ### `npm run build`
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -7,9 +7,43 @@ type MockFetchState = {
   balanceAmount: number;
   operationId: string | null;
   operationType: 'CHARGE' | 'TRANSFER' | null;
+  manualReviewEvents: MockOutboxEvent[];
+  requeueAudits: MockRequeueAudit[];
 };
 
-function setupFetch(state: MockFetchState = { balanceAmount: 125000, operationId: null, operationType: null }) {
+type MockOutboxEvent = {
+  outboxEventId: string;
+  operationId: string;
+  eventType: string;
+  aggregateType: string;
+  aggregateId: string;
+  payload: string;
+  status: string;
+  occurredAt: string;
+  attemptCount: number;
+  nextRetryAt: string | null;
+  claimedAt: string | null;
+  leaseExpiresAt: string | null;
+  publishedAt: string | null;
+  lastError: string | null;
+};
+
+type MockRequeueAudit = {
+  auditId: string;
+  outboxEventId: string;
+  operationId: string;
+  requeuedAt: string;
+  operator: string;
+  reason: string;
+};
+
+function setupFetch(state: MockFetchState = {
+  balanceAmount: 125000,
+  operationId: null,
+  operationType: null,
+  manualReviewEvents: [],
+  requeueAudits: [],
+}) {
   const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = input.toString();
     const method = init?.method ?? 'GET';
@@ -43,6 +77,35 @@ function setupFetch(state: MockFetchState = { balanceAmount: 125000, operationId
 
     if (url.endsWith('/audit-events')) {
       return jsonResponse([]);
+    }
+
+    if (url.includes('/outbox-events/manual-review')) {
+      return jsonResponse(state.manualReviewEvents);
+    }
+
+    if (url.includes('/requeue-audits')) {
+      const outboxEventId = url.split('/outbox-events/')[1].split('/requeue-audits')[0];
+      return jsonResponse(state.requeueAudits.filter((audit) => audit.outboxEventId === outboxEventId));
+    }
+
+    if (url.includes('/outbox-events/') && url.endsWith('/requeue') && method === 'POST') {
+      expect(init?.headers).toMatchObject({
+        'X-Admin-Token': 'local-ops-token',
+        'X-Operator-Id': 'local-operator',
+      });
+      const outboxEventId = url.split('/outbox-events/')[1].split('/requeue')[0];
+      const requeuedEvent = state.manualReviewEvents.find((event) => event.outboxEventId === outboxEventId);
+      const body = JSON.parse(String(init?.body));
+      state.manualReviewEvents = state.manualReviewEvents.filter((event) => event.outboxEventId !== outboxEventId);
+      state.requeueAudits.push({
+        auditId: 'outbox-requeue-audit-001',
+        outboxEventId,
+        operationId: requeuedEvent?.operationId ?? 'op-operator-001',
+        requeuedAt: '2026-05-02T00:00:00Z',
+        operator: 'local-operator',
+        reason: body.reason,
+      });
+      return emptyResponse(204);
     }
 
     if (url.endsWith('/step-logs')) {
@@ -121,6 +184,33 @@ function jsonResponse(body: unknown, status = 200) {
     status,
     json: async () => body,
   } as Response;
+}
+
+function emptyResponse(status = 204) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => null,
+  } as Response;
+}
+
+function manualReviewEvent(): MockOutboxEvent {
+  return {
+    outboxEventId: 'outbox-manual-001',
+    operationId: 'op-manual-001',
+    eventType: 'CHARGE_COMPLETED',
+    aggregateType: 'WALLET',
+    aggregateId: 'wallet-001',
+    payload: '{}',
+    status: 'MANUAL_REVIEW',
+    occurredAt: '2026-05-02T00:00:00Z',
+    attemptCount: 3,
+    nextRetryAt: null,
+    claimedAt: null,
+    leaseExpiresAt: null,
+    publishedAt: null,
+    lastError: 'broker unavailable',
+  };
 }
 
 function operationResult({
@@ -232,6 +322,53 @@ describe('App', () => {
 
     await waitFor(() => {
       expect(screen.getByText('INSUFFICIENT_BALANCE: Insufficient balance: wallet-002')).toBeVisible();
+    });
+  });
+
+  it('manual review outbox가 없으면 운영자 empty state를 표시한다', async () => {
+    const user = userEvent.setup();
+    setupFetch();
+
+    render(<App />);
+
+    await screen.findByText('125,000 KRW');
+    await user.click(screen.getByRole('button', { name: 'Manual review 조회' }));
+
+    expect(await screen.findByText('Manual review event 조회가 완료되었습니다.')).toBeVisible();
+    expect(screen.getByText('Manual review 대기 event가 없습니다.')).toBeVisible();
+  });
+
+  it('manual review outbox를 requeue하고 audit trail을 표시한다', async () => {
+    const user = userEvent.setup();
+    const fetchMock = setupFetch({
+      balanceAmount: 125000,
+      operationId: null,
+      operationType: null,
+      manualReviewEvents: [manualReviewEvent()],
+      requeueAudits: [],
+    });
+
+    render(<App />);
+
+    await screen.findByText('125,000 KRW');
+    await user.click(screen.getByRole('button', { name: 'Manual review 조회' }));
+
+    expect(await screen.findAllByText('outbox-manual-001')).toHaveLength(2);
+    expect(screen.getAllByText('MANUAL_REVIEW')).toHaveLength(2);
+
+    await user.clear(screen.getByLabelText('Requeue 사유'));
+    await user.type(screen.getByLabelText('Requeue 사유'), 'broker recovered');
+    await user.click(screen.getByRole('button', { name: 'Requeue 실행' }));
+
+    expect(await screen.findByText('Requeue가 완료되었습니다. 감사 이력을 확인하세요.')).toBeVisible();
+    expect(screen.getAllByText('broker recovered')).toHaveLength(2);
+    expect(screen.getByText('local-operator')).toBeVisible();
+    expect(screen.getByText('REQUEUED')).toBeVisible();
+
+    const requeueCall = fetchMock.mock.calls.find(([url]) => url.toString().endsWith('/requeue'));
+    expect(requeueCall).toBeDefined();
+    expect(JSON.parse(String(requeueCall?.[1]?.body))).toMatchObject({
+      reason: 'broker recovered',
     });
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -65,9 +65,26 @@ type OperationOutboxEvent = {
   outboxEventId: string;
   operationId: string;
   eventType: string;
+  aggregateType: string;
+  aggregateId: string;
+  payload: string;
   status: string;
+  occurredAt: string;
   attemptCount: number;
+  nextRetryAt: string | null;
+  claimedAt: string | null;
+  leaseExpiresAt: string | null;
+  publishedAt: string | null;
   lastError: string | null;
+};
+
+type OperationOutboxRequeueAudit = {
+  auditId: string;
+  outboxEventId: string;
+  operationId: string;
+  requeuedAt: string;
+  operator: string;
+  reason: string;
 };
 
 type ApiError = {
@@ -109,6 +126,21 @@ async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
   return response.json() as Promise<T>;
 }
 
+async function requestEmpty(url: string, init?: RequestInit): Promise<void> {
+  const response = await fetch(url, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...init?.headers,
+    },
+    ...init,
+  });
+
+  if (!response.ok) {
+    const error = (await response.json()) as ApiError;
+    throw new Error(`${error.code}: ${error.message}`);
+  }
+}
+
 function formatMoney(money?: Money): string {
   if (!money) {
     return '-';
@@ -131,8 +163,20 @@ export function App() {
   const [lastOperation, setLastOperation] = useState<WalletOperationResult | null>(null);
   const [statusMessage, setStatusMessage] = useState('Spring Boot API를 실행한 뒤 데이터를 불러오세요.');
   const [isLoading, setIsLoading] = useState(false);
+  const [adminToken, setAdminToken] = useState('local-ops-token');
+  const [operatorId, setOperatorId] = useState('local-operator');
+  const [manualReviewEvents, setManualReviewEvents] = useState<OperationOutboxEvent[]>([]);
+  const [selectedOutboxEventId, setSelectedOutboxEventId] = useState('');
+  const [requeueReason, setRequeueReason] = useState('broker recovered from operator console');
+  const [requeueAudits, setRequeueAudits] = useState<OperationOutboxRequeueAudit[]>([]);
+  const [operatorStatusMessage, setOperatorStatusMessage] = useState('운영자 token과 operator id를 입력한 뒤 manual review를 조회하세요.');
+  const [isOperatorLoading, setIsOperatorLoading] = useState(false);
 
   const heroBalance = useMemo(() => formatMoney(apiState.balance?.money), [apiState.balance]);
+  const selectedManualReviewEvent = useMemo(
+    () => manualReviewEvents.find((event) => event.outboxEventId === selectedOutboxEventId) ?? null,
+    [manualReviewEvents, selectedOutboxEventId],
+  );
 
   async function runAction(action: () => Promise<void>, successMessage: string) {
     setIsLoading(true);
@@ -145,6 +189,26 @@ export function App() {
     } finally {
       setIsLoading(false);
     }
+  }
+
+  async function runOperatorAction(action: () => Promise<void>, successMessage: string) {
+    setIsOperatorLoading(true);
+    setOperatorStatusMessage('운영 조치 처리 중입니다.');
+    try {
+      await action();
+      setOperatorStatusMessage(successMessage);
+    } catch (error) {
+      setOperatorStatusMessage(error instanceof Error ? error.message : '운영 조치 중 알 수 없는 오류가 발생했습니다.');
+    } finally {
+      setIsOperatorLoading(false);
+    }
+  }
+
+  function operatorHeaders(): HeadersInit {
+    return {
+      'X-Admin-Token': adminToken,
+      'X-Operator-Id': operatorId,
+    };
   }
 
   async function loadWalletEvidence(nextWalletId = walletId, nextOperationId = operationId) {
@@ -164,6 +228,47 @@ export function App() {
       : [[], []];
 
     setApiState({ balance, transactions, ledgerEntries, auditEvents, stepLogs, outboxEvents });
+  }
+
+  async function loadManualReviewEvents() {
+    const events = await requestJson<OperationOutboxEvent[]>('/api/v1/outbox-events/manual-review?limit=20', {
+      headers: operatorHeaders(),
+    });
+    setManualReviewEvents(events);
+    if (events.length === 0) {
+      return;
+    }
+    if (!events.some((event) => event.outboxEventId === selectedOutboxEventId)) {
+      setSelectedOutboxEventId(events[0].outboxEventId);
+    }
+  }
+
+  async function loadRequeueAudits(outboxEventId = selectedOutboxEventId) {
+    if (!outboxEventId) {
+      setRequeueAudits([]);
+      return;
+    }
+    const audits = await requestJson<OperationOutboxRequeueAudit[]>(
+      `/api/v1/outbox-events/${outboxEventId}/requeue-audits`,
+      { headers: operatorHeaders() },
+    );
+    setRequeueAudits(audits);
+  }
+
+  async function submitRequeue(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const outboxEventId = selectedOutboxEventId;
+    await runOperatorAction(async () => {
+      await requestEmpty(`/api/v1/outbox-events/${outboxEventId}/requeue`, {
+        method: 'POST',
+        headers: operatorHeaders(),
+        body: JSON.stringify({ reason: requeueReason }),
+      });
+      await Promise.all([
+        loadManualReviewEvents(),
+        loadRequeueAudits(outboxEventId),
+      ]);
+    }, 'Requeue가 완료되었습니다. 감사 이력을 확인하세요.');
   }
 
   async function submitCharge(event: FormEvent<HTMLFormElement>) {
@@ -288,6 +393,143 @@ export function App() {
         )}
       </section>
 
+      <section className="operator-console" aria-labelledby="operator-console-title">
+        <div className="section-heading">
+          <p className="eyebrow">Operator console</p>
+          <h2 id="operator-console-title">Manual review outbox를 운영자가 직접 확인합니다.</h2>
+          <p>
+            장애로 격리된 outbox event를 조회하고, 원인 조치 후 requeue하며, operator와 reason 감사 이력을 확인합니다.
+          </p>
+        </div>
+
+        <div className="operator-grid">
+          <article className="panel operator-card">
+            <div className="card-heading">
+              <p className="eyebrow">Access</p>
+              <h3>운영자 header</h3>
+            </div>
+            <label>
+              Admin token
+              <input aria-label="운영자 Admin Token" value={adminToken} onChange={(event) => setAdminToken(event.target.value)} />
+            </label>
+            <label>
+              Operator ID
+              <input aria-label="운영자 ID" value={operatorId} onChange={(event) => setOperatorId(event.target.value)} />
+            </label>
+            <button
+              type="button"
+              onClick={() => runOperatorAction(loadManualReviewEvents, 'Manual review event 조회가 완료되었습니다.')}
+              disabled={isOperatorLoading}
+            >
+              Manual review 조회
+            </button>
+            <StatusCallout message={operatorStatusMessage} tone={operatorStatusMessage.includes(':') ? 'error' : 'info'} />
+          </article>
+
+          <article className="panel operator-card operator-list-card">
+            <div className="card-heading inline-heading">
+              <div>
+                <p className="eyebrow">Manual review</p>
+                <h3>격리된 outbox</h3>
+              </div>
+              <span className="count-pill">{manualReviewEvents.length}</span>
+            </div>
+            {manualReviewEvents.length === 0 ? (
+              <EmptyState
+                title="Manual review 대기 event가 없습니다."
+                description="조회 결과가 비어 있으면 운영 조치가 필요한 outbox가 없다는 뜻입니다."
+              />
+            ) : (
+              <ul className="operator-event-list">
+                {manualReviewEvents.map((event) => (
+                  <li key={event.outboxEventId}>
+                    <button
+                      type="button"
+                      className={event.outboxEventId === selectedOutboxEventId ? 'event-row selected' : 'event-row'}
+                      onClick={() => {
+                        setSelectedOutboxEventId(event.outboxEventId);
+                        void runOperatorAction(() => loadRequeueAudits(event.outboxEventId), 'Requeue audit 조회가 완료되었습니다.');
+                      }}
+                    >
+                      <span>
+                        <strong>{event.outboxEventId}</strong>
+                        <small>{event.operationId} · {event.eventType}</small>
+                      </span>
+                      <StatusBadge status={event.status} />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </article>
+
+          <article className="panel operator-card requeue-card">
+            <div className="card-heading">
+              <p className="eyebrow">Requeue</p>
+              <h3>재처리와 감사 이력</h3>
+            </div>
+            {!selectedOutboxEventId ? (
+              <EmptyState
+                title="선택된 outbox event가 없습니다."
+                description="manual review event를 선택하면 requeue reason과 audit trail을 확인할 수 있습니다."
+              />
+            ) : (
+              <>
+                <div className="selected-event-card">
+                  <StatusBadge status={selectedManualReviewEvent?.status ?? 'REQUEUED'} />
+                  <strong>{selectedOutboxEventId}</strong>
+                  <span>{selectedManualReviewEvent?.lastError ?? 'manual review 목록에서는 제외되었습니다.'}</span>
+                  <small>
+                    {selectedManualReviewEvent
+                      ? `attempt ${selectedManualReviewEvent.attemptCount} · ${selectedManualReviewEvent.occurredAt}`
+                      : '감사 이력으로 재처리 결과를 확인하세요.'}
+                  </small>
+                </div>
+                <form className="requeue-form" onSubmit={submitRequeue}>
+                  <label>
+                    Requeue reason
+                    <textarea
+                      aria-label="Requeue 사유"
+                      value={requeueReason}
+                      onChange={(event) => setRequeueReason(event.target.value)}
+                    />
+                  </label>
+                  <div className="operator-actions">
+                    <button type="submit" disabled={isOperatorLoading || !selectedManualReviewEvent || requeueReason.trim().length === 0}>
+                      Requeue 실행
+                    </button>
+                    <button
+                      type="button"
+                      className="secondary-button"
+                      onClick={() => runOperatorAction(() => loadRequeueAudits(), 'Requeue audit 조회가 완료되었습니다.')}
+                      disabled={isOperatorLoading}
+                    >
+                      Audit 조회
+                    </button>
+                  </div>
+                </form>
+                <div className="audit-trail">
+                  <h4>Requeue audit</h4>
+                  {requeueAudits.length === 0 ? (
+                    <p className="empty compact-empty">아직 requeue audit이 없습니다.</p>
+                  ) : (
+                    <ul>
+                      {requeueAudits.map((audit) => (
+                        <li key={audit.auditId}>
+                          <strong>{audit.operator}</strong>
+                          <span>{audit.reason}</span>
+                          <small>{audit.requeuedAt}</small>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              </>
+            )}
+          </article>
+        </div>
+      </section>
+
       <section id="evidence" className="evidence-layout">
         <EvidencePanel title="거래내역" items={apiState.transactions.map((item) => `${item.type} · ${item.direction} · ${formatMoney(item.money)} · ${item.description}`)} />
         <EvidencePanel title="원장" items={apiState.ledgerEntries.map((item) => `${item.operationId} · ${item.direction} · 잔액 ${formatMoney(item.balanceAfter)}`)} />
@@ -296,6 +538,27 @@ export function App() {
         <EvidencePanel title="Outbox" items={apiState.outboxEvents.map((item) => `${item.outboxEventId} · ${item.eventType} · ${item.status} · attempt ${item.attemptCount}`)} />
       </section>
     </main>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  return <span className={`status-badge status-${status.toLowerCase().replaceAll('_', '-')}`}>{status}</span>;
+}
+
+function StatusCallout({ message, tone }: { message: string; tone: 'info' | 'error' }) {
+  return (
+    <p className={tone === 'error' ? 'status-callout error-callout' : 'status-callout'}>
+      {message}
+    </p>
+  );
+}
+
+function EmptyState({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="empty-state">
+      <strong>{title}</strong>
+      <p>{description}</p>
+    </div>
   );
 }
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -31,6 +31,10 @@ button {
   transition: background-color 160ms ease, transform 160ms ease;
 }
 
+textarea {
+  font: inherit;
+}
+
 button:hover {
   background: #0071e3;
   transform: translateY(-1px);
@@ -247,6 +251,281 @@ h3 {
   overflow-x: auto;
 }
 
+.operator-console {
+  padding: 64px 12px 12px;
+  background: #f5f5f7;
+}
+
+.section-heading {
+  max-width: 980px;
+  padding: 0 36px 32px;
+}
+
+.section-heading h2 {
+  max-width: 820px;
+  margin-bottom: 16px;
+}
+
+.section-heading p:last-child {
+  max-width: 720px;
+  color: #333333;
+  font-size: 17px;
+  line-height: 1.47;
+}
+
+.operator-grid {
+  display: grid;
+  grid-template-columns: minmax(260px, 0.8fr) minmax(320px, 1fr) minmax(360px, 1.2fr);
+  gap: 12px;
+}
+
+.operator-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 460px;
+  padding: 32px;
+}
+
+.card-heading {
+  margin-bottom: 24px;
+}
+
+.card-heading h3 {
+  margin-bottom: 0;
+}
+
+.inline-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.operator-card label {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 17px;
+  color: #333333;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.operator-card input,
+.operator-card textarea {
+  width: 100%;
+  border: 1px solid #e0e0e0;
+  background: #ffffff;
+  color: #1d1d1f;
+}
+
+.operator-card input {
+  height: 44px;
+  border-radius: 9999px;
+  padding: 12px 20px;
+}
+
+.operator-card textarea {
+  min-height: 104px;
+  resize: vertical;
+  border-radius: 18px;
+  padding: 14px 16px;
+  line-height: 1.47;
+}
+
+.status-callout {
+  margin: 24px 0 0;
+  border-radius: 18px;
+  padding: 17px;
+  background: #fafafc;
+  color: #333333;
+  font-size: 14px;
+  line-height: 1.43;
+}
+
+.error-callout {
+  border: 1px solid #ffd6d6;
+  background: #fff5f5;
+  color: #9a1b1b;
+}
+
+.count-pill,
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  border-radius: 9999px;
+  padding: 6px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: -0.12px;
+}
+
+.count-pill {
+  background: #f5f5f7;
+  color: #333333;
+}
+
+.status-badge {
+  background: #f5f5f7;
+  color: #333333;
+}
+
+.status-manual-review {
+  background: #fff2cc;
+  color: #6f4c00;
+}
+
+.status-pending {
+  background: #eaf4ff;
+  color: #0057a8;
+}
+
+.status-published {
+  background: #eaf8ef;
+  color: #176b36;
+}
+
+.status-failed {
+  background: #fff5f5;
+  color: #9a1b1b;
+}
+
+.status-processing {
+  background: #f1edff;
+  color: #4c2a91;
+}
+
+.status-requeued {
+  background: #f5f5f7;
+  color: #7a7a7a;
+}
+
+.empty-state {
+  display: grid;
+  place-content: center;
+  min-height: 260px;
+  border: 1px solid #f0f0f0;
+  border-radius: 18px;
+  padding: 32px;
+  text-align: center;
+  background: #fafafc;
+}
+
+.empty-state strong {
+  margin-bottom: 8px;
+  font-size: 17px;
+}
+
+.empty-state p {
+  max-width: 360px;
+  margin: 0;
+  color: #7a7a7a;
+  font-size: 14px;
+  line-height: 1.43;
+}
+
+.operator-event-list,
+.audit-trail ul {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.event-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  border: 1px solid #f0f0f0;
+  border-radius: 18px;
+  padding: 17px;
+  background: #ffffff;
+  color: #1d1d1f;
+  text-align: left;
+  transform: none;
+}
+
+.event-row:hover,
+.event-row.selected {
+  border-color: #0066cc;
+  background: #fafafc;
+  transform: none;
+}
+
+.event-row span {
+  display: grid;
+  gap: 6px;
+}
+
+.event-row small,
+.selected-event-card small,
+.audit-trail small {
+  color: #7a7a7a;
+  font-size: 12px;
+  line-height: 1.3;
+}
+
+.selected-event-card {
+  display: grid;
+  gap: 10px;
+  margin-bottom: 24px;
+  border-radius: 18px;
+  padding: 24px;
+  background: #272729;
+  color: #ffffff;
+}
+
+.selected-event-card span {
+  color: #cccccc;
+  font-size: 14px;
+  line-height: 1.43;
+}
+
+.requeue-form {
+  display: grid;
+  gap: 12px;
+}
+
+.operator-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.secondary-button {
+  background: #ffffff;
+  color: #0066cc;
+}
+
+.secondary-button:hover {
+  background: #f5f5f7;
+}
+
+.audit-trail {
+  margin-top: 28px;
+}
+
+.audit-trail h4 {
+  margin: 0 0 12px;
+  font-size: 17px;
+}
+
+.audit-trail li {
+  display: grid;
+  gap: 6px;
+  border-top: 1px solid #f0f0f0;
+  padding-top: 12px;
+  font-size: 14px;
+  line-height: 1.43;
+}
+
+.compact-empty {
+  min-height: auto;
+}
+
 .evidence-panel {
   min-height: 280px;
 }
@@ -271,7 +550,8 @@ h3 {
 
 @media (max-width: 960px) {
   .hero-tile,
-  .workspace-grid {
+  .workspace-grid,
+  .operator-grid {
     grid-template-columns: 1fr;
   }
 
@@ -287,5 +567,9 @@ h3 {
   .status-strip {
     align-items: stretch;
     flex-direction: column;
+  }
+
+  .section-heading {
+    padding: 0 12px 24px;
   }
 }

--- a/issue-drafts/0036-operator-manual-review-console-ui.md
+++ b/issue-drafts/0036-operator-manual-review-console-ui.md
@@ -1,0 +1,67 @@
+# [Feature] Operator Manual Review Console UI
+
+## 작업 요약
+
+운영자 화면에 manual review outbox 조회, requeue 실행, requeue audit 확인 UI를 추가하고 Apple 스타일 기준으로 card, status badge, empty/error state를 정리한다.
+
+## 배경과 문제
+
+- 백엔드에는 manual review, requeue, requeue audit 운영 API가 있다.
+- 현재 사용자 화면은 일반 지갑 흐름 중심이라 운영자가 장애 outbox를 화면에서 검증하기 어렵다.
+- 포트폴리오형 운영 하네스에서는 백엔드 운영 API를 사람이 확인 가능한 콘솔로 노출해야 한다.
+
+## 범위
+
+### 하는 것
+
+- 운영자 token/operator 입력 UI를 추가한다.
+- manual review outbox 목록을 조회한다.
+- 선택한 outbox event를 reason과 함께 requeue한다.
+- 선택한 outbox event의 requeue audit 목록을 조회한다.
+- Apple 스타일 기준으로 card, status badge, empty/error state를 정리한다.
+- 관련 프론트 테스트와 문서를 갱신한다.
+
+### 하지 않는 것
+
+- 운영자 로그인/OIDC/IAM은 도입하지 않는다.
+- 승인 워크플로우는 이번 범위에 포함하지 않는다.
+- 백엔드 API 계약은 변경하지 않는다.
+
+## 수용 기준
+
+- [x] 화면에서 운영자 token/operator를 입력할 수 있다.
+- [x] manual review outbox 목록을 조회할 수 있다.
+- [x] manual review event가 없으면 empty state를 보여준다.
+- [x] requeue reason 입력 후 requeue를 실행할 수 있다.
+- [x] 선택한 outbox event의 requeue audit을 조회할 수 있다.
+- [x] 401/403/API 오류를 error state로 표시한다.
+- [x] Apple 스타일 기준의 card/status badge/empty/error state가 적용된다.
+- [x] 프론트 unit test와 build가 통과한다.
+
+## 도메인 규칙과 불변식
+
+- requeue는 운영자 식별자와 reason을 필요로 한다.
+- requeue audit은 운영자 행위의 증거이므로 화면에서 확인 가능해야 한다.
+- manual review event가 없다는 상태는 실패가 아니라 정상 empty state다.
+
+## 하네스 역할 체크
+
+- 기획자: 운영자가 장애 outbox를 화면에서 확인하고 조치할 수 있어야 한다.
+- 도메인 전문가: requeue는 감사 이력과 함께 검증되어야 한다.
+- 코드 개발자 A: 기존 API 계약을 유지하고 프론트 상태만 확장한다.
+- 코드 개발자 B: 일반 사용자 지갑 흐름과 운영자 콘솔 상태가 과도하게 섞이지 않도록 한다.
+- QA: empty/error/requeue success/audit 조회를 테스트한다.
+- 릴리스 관리자: 로컬 테스트와 프론트 실행 문서를 갱신한다.
+
+## 검증
+
+```bash
+cd frontend
+npm run test
+npm run build
+npm run e2e
+```
+
+## 관련 Issue
+
+- GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/77

--- a/issue-drafts/README.md
+++ b/issue-drafts/README.md
@@ -76,6 +76,8 @@
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/71
 - `0035-postgresql-scenario-testcontainers-ci.md`: PostgreSQL scenario와 Testcontainers CI gate 작업 초안
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/73
+- `0036-operator-manual-review-console-ui.md`: 운영자 manual review console UI 작업 초안
+  - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/77
 
 ## GitHub CLI로 생성
 


### PR DESCRIPTION
Closes #77

## Summary
- Add React operator console for manual review outbox lookup, requeue execution, and requeue audit lookup.
- Normalize Apple-style card, status badge, empty state, and error callout patterns for the operator area.
- Document the feature scope, validation evidence, and local test guide updates.

## Validation
- npm --prefix frontend run test
- npm --prefix frontend run build
- npm --prefix frontend run e2e
- git diff --check

## Notes
- No backend API contract change; this UI uses existing admin outbox endpoints with `X-Admin-Token` and `X-Operator-Id` headers.
