### PR TITLE
test: add operator console e2e smoke

### DIFF
--- a/docs/progress/0022-frontend-e2e-test-pipeline.md
+++ b/docs/progress/0022-frontend-e2e-test-pipeline.md
@@ -23,9 +23,7 @@
 
 ## 남은 일
 
-- 송금 성공 흐름 E2E를 추가한다.
-- 송금 실패와 오류 메시지 E2E를 추가한다.
-- 운영자 manual review 화면이 생기면 outbox requeue E2E를 추가한다.
+- manual review fixture 생성 방식이 정리되면 운영자 requeue 성공 E2E를 추가한다.
 
 ## 관련 문서
 

--- a/docs/progress/0036-operator-manual-review-console-ui.md
+++ b/docs/progress/0036-operator-manual-review-console-ui.md
@@ -29,7 +29,7 @@
 
 - 운영자 승인 워크플로우는 아직 없다.
 - operator/admin role 분리와 실제 로그인 연동은 후속 작업이다.
-- 운영자 콘솔 E2E는 manual review fixture 생성 방식이 정리된 뒤 추가한다.
+- 운영자 콘솔 smoke E2E는 추가되었고, requeue 성공 E2E는 manual review fixture 생성 방식이 정리된 뒤 추가한다.
 - relay health와 pruning 화면은 별도 운영자 콘솔 확장 작업으로 분리한다.
 
 ## 관련 문서

--- a/docs/progress/0037-operator-console-e2e-smoke.md
+++ b/docs/progress/0037-operator-console-e2e-smoke.md
@@ -1,0 +1,34 @@
+# 0037. Operator Console E2E Smoke
+
+## 스펙 목표
+
+- 운영자 manual review 콘솔이 브라우저 E2E에서 실제로 렌더링되는지 확인한다.
+- 잘못된 admin token이 운영 API 인증 오류로 표시되는지 확인한다.
+- local admin header로 manual review 조회 시 empty state가 표시되는지 확인한다.
+
+## 완료 결과
+
+- Playwright E2E에 운영자 콘솔 smoke 시나리오를 추가했다.
+- 운영자 `Admin token`, `Operator ID` 기본값을 브라우저에서 검증한다.
+- 잘못된 token으로 `ADMIN_AUTHENTICATION_REQUIRED` error state를 검증한다.
+- `local-ops-token`으로 manual review 조회 성공 메시지와 empty state를 검증한다.
+- local test guide의 E2E 통과 기준과 검증 시나리오 목록을 갱신했다.
+
+## 검증
+
+- `npm --prefix frontend run e2e`
+- `npm --prefix frontend run test`
+- `npm --prefix frontend run build`
+- `git diff --check`
+
+## 남은 일
+
+- manual review fixture 생성 방식이 정리되면 requeue 성공과 audit trail E2E를 추가한다.
+- relay health와 pruning 화면이 운영자 콘솔에 추가되면 별도 E2E 시나리오로 확장한다.
+
+## 관련 문서
+
+- `docs/testing/local-test-guide.md`
+- `docs/progress/0022-frontend-e2e-test-pipeline.md`
+- `docs/progress/0036-operator-manual-review-console-ui.md`
+- `issue-drafts/0037-operator-console-e2e-smoke.md`

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -52,10 +52,11 @@ ADR은 “왜 그렇게 결정했는가”를 기록하고, 이 폴더는 “각
 | 0034 | [HTTP Outbox Broker Adapter](0034-http-outbox-broker-adapter.md) | 완료 |
 | 0035 | [PostgreSQL Scenario Testcontainers CI](0035-postgresql-scenario-testcontainers-ci.md) | 완료 |
 | 0036 | [Operator Manual Review Console UI](0036-operator-manual-review-console-ui.md) | 완료 |
+| 0037 | [Operator Console E2E Smoke](0037-operator-console-e2e-smoke.md) | 완료 |
 
 ## 현재 기준선
 
 - 최신 병합 기준: `main`
-- 최신 완료 기능: Operator Manual Review Console UI
+- 최신 완료 기능: Operator Console E2E Smoke
 - 현재 릴리스 후보: `v0.6.0`
-- 아직 미완료: 운영자 relay health/pruning 화면, Kafka/RabbitMQ/SQS adapter, consumer idempotency, operator/admin token 분리, pruning 실행 이력, external alert channel, 승인 워크플로우, GitHub Wiki 동기화, broker-specific Testcontainers 정책
+- 아직 미완료: 운영자 relay health/pruning 화면, Kafka/RabbitMQ/SQS adapter, consumer idempotency, operator/admin token 분리, pruning 실행 이력, external alert channel, 승인 워크플로우, GitHub Wiki 동기화, broker-specific Testcontainers 정책, manual review requeue full E2E fixture

--- a/docs/testing/local-test-guide.md
+++ b/docs/testing/local-test-guide.md
@@ -167,9 +167,11 @@ npm --prefix frontend run e2e
 통과 기준:
 
 ```text
-Running 1 test using 1 worker
+Running 3 tests using 1 worker
 ✓  1 [chromium] › e2e/wallet-flow.spec.ts
-1 passed
+✓  2 [chromium] › e2e/wallet-flow.spec.ts
+✓  3 [chromium] › e2e/wallet-flow.spec.ts
+3 passed
 ```
 
 현재 E2E 시나리오는 다음을 검증한다.
@@ -180,6 +182,8 @@ Running 1 test using 1 worker
 - 송금 실행 후 출금 지갑 잔액이 `129,000 KRW`로 감소한다.
 - 잔액 부족 송금 시 `INSUFFICIENT_BALANCE` 오류가 표시된다.
 - 최근 operation, `LEDGER_RECORDED`, `CHARGE_COMPLETED`, `TRANSFER_COMPLETED` outbox event가 표시된다.
+- 운영자 콘솔에서 잘못된 admin token의 `ADMIN_AUTHENTICATION_REQUIRED` 오류가 표시된다.
+- 운영자 콘솔에서 local admin header로 manual review empty state가 표시된다.
 
 ## CI 대응 관계
 

--- a/frontend/e2e/wallet-flow.spec.ts
+++ b/frontend/e2e/wallet-flow.spec.ts
@@ -47,3 +47,26 @@ test('잔액 부족 송금은 오류 메시지를 표시한다', async ({ page }
 
   await expect(page.getByText('INSUFFICIENT_BALANCE: Insufficient balance: wallet-002')).toBeVisible();
 });
+
+test('운영자는 manual review 콘솔의 인증 오류와 empty state를 확인한다', async ({ page }) => {
+  await page.goto('/');
+
+  const operatorConsole = page.locator('.operator-console');
+
+  await expect(operatorConsole.getByRole('heading', { name: 'Manual review outbox를 운영자가 직접 확인합니다.' })).toBeVisible();
+  await expect(operatorConsole.getByLabel('운영자 Admin Token')).toHaveValue('local-ops-token');
+  await expect(operatorConsole.getByLabel('운영자 ID')).toHaveValue('local-operator');
+  await expect(operatorConsole.getByText('Manual review 대기 event가 없습니다.')).toBeVisible();
+  await expect(operatorConsole.getByText('선택된 outbox event가 없습니다.')).toBeVisible();
+
+  await operatorConsole.getByLabel('운영자 Admin Token').fill('wrong-token');
+  await operatorConsole.getByRole('button', { name: 'Manual review 조회' }).click();
+
+  await expect(operatorConsole.getByText(/ADMIN_AUTHENTICATION_REQUIRED/)).toBeVisible();
+
+  await operatorConsole.getByLabel('운영자 Admin Token').fill('local-ops-token');
+  await operatorConsole.getByRole('button', { name: 'Manual review 조회' }).click();
+
+  await expect(operatorConsole.getByText('Manual review event 조회가 완료되었습니다.')).toBeVisible();
+  await expect(operatorConsole.getByText('Manual review 대기 event가 없습니다.')).toBeVisible();
+});

--- a/issue-drafts/0037-operator-console-e2e-smoke.md
+++ b/issue-drafts/0037-operator-console-e2e-smoke.md
@@ -1,0 +1,45 @@
+# [Test] 운영자 콘솔 E2E smoke 추가
+
+## 배경
+
+운영자 manual review 콘솔은 UI와 프론트 단위 테스트가 추가되었지만, MVP 출시 관점에서는 브라우저에서 운영자 영역이 실제로 렌더링되고 운영 API 인증 오류와 empty state가 보이는지 확인하는 E2E gate가 필요하다.
+
+## 목표
+
+- Playwright E2E에서 운영자 콘솔 렌더링을 검증한다.
+- 잘못된 admin token 입력 시 운영 API 인증 오류가 화면에 표시되는지 검증한다.
+- local admin token으로 manual review 조회 시 empty state가 화면에 표시되는지 검증한다.
+
+## 범위
+
+- `frontend/e2e/wallet-flow.spec.ts`에 운영자 콘솔 smoke 시나리오를 추가한다.
+- `docs/testing/local-test-guide.md`의 E2E 통과 기준을 갱신한다.
+- 진행 흔적 문서를 추가한다.
+
+## 범위 제외
+
+- manual review event fixture 생성
+- requeue 성공 E2E
+- requeue audit trail full E2E
+- 백엔드 API 계약 변경
+
+## 인수 조건
+
+- [x] 운영자 콘솔 heading이 브라우저 E2E에서 보인다.
+- [x] 기본 `Admin token`, `Operator ID` 값이 보인다.
+- [x] 잘못된 admin token으로 조회하면 `ADMIN_AUTHENTICATION_REQUIRED`가 보인다.
+- [x] `local-ops-token`으로 조회하면 manual review empty state가 보인다.
+- [x] local test guide가 현재 E2E 시나리오 수와 검증 대상을 반영한다.
+
+## 테스트
+
+- `npm --prefix frontend run e2e`
+- `npm --prefix frontend run test`
+- `npm --prefix frontend run build`
+- `git diff --check`
+
+## 리스크와 트레이드오프
+
+- requeue 성공까지 E2E로 묶으려면 manual review 상태를 안정적으로 만드는 fixture가 필요하다.
+- 이번 단계에서는 fixture 없이 항상 재현 가능한 운영자 콘솔 smoke를 먼저 고정한다.
+- full requeue E2E는 상태 fixture 정책을 별도 작업으로 정리한 뒤 추가한다.

--- a/issue-drafts/README.md
+++ b/issue-drafts/README.md
@@ -78,6 +78,8 @@
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/73
 - `0036-operator-manual-review-console-ui.md`: 운영자 manual review console UI 작업 초안
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/77
+- `0037-operator-console-e2e-smoke.md`: 운영자 콘솔 E2E smoke 작업 초안
+  - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/79
 
 ## GitHub CLI로 생성
 


### PR DESCRIPTION
Closes #79

## Summary
- Add Playwright E2E smoke coverage for the operator manual review console.
- Verify default operator headers, invalid admin token error state, and manual review empty state with local credentials.
- Update local test guide and progress/issue draft documentation for the new E2E gate.

## Validation
- npm --prefix frontend run e2e
- npm --prefix frontend run test
- npm --prefix frontend run build
- git diff --check

## Notes
- This intentionally does not add full requeue success E2E yet; that still needs a stable manual review fixture policy.
