### PR TITLE
docs: add unreleased release candidate notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,10 +257,12 @@ Proposed | Accepted | Deprecated | Superseded
 - `v0.4.0`: 원장 모델, 감사 로그
 - `v0.5.0`: PostgreSQL 스키마 migration, 정산 배치 후보
 - `v0.6.0`: outbox 재처리, manual review, requeue 감사 이력, 첫 GitHub Release 기준선
+- `unreleased`: 1차 MVP 출시 후보 검증 기준선
 
 현재 릴리스 노트:
 
 - [v0.6.0 Release Notes](docs/releases/v0.6.0.md)
+- [Unreleased Release Candidate Notes](docs/releases/unreleased.md)
 
 릴리스 노트에는 반드시 다음을 포함합니다.
 

--- a/docs/progress/0038-unreleased-release-candidate-notes.md
+++ b/docs/progress/0038-unreleased-release-candidate-notes.md
@@ -1,0 +1,32 @@
+# 0038. Unreleased Release Candidate Notes
+
+## 스펙 목표
+
+- `v0.6.0` 이후 누적 변경분을 릴리스 후보 문서로 추적한다.
+- 1차 MVP 출시 판단 기준과 검증 게이트를 명확히 한다.
+- 출시 전 blocker와 후속 후보를 분리한다.
+
+## 완료 결과
+
+- `docs/releases/unreleased.md`를 추가했다.
+- 후보 범위에 시나리오 테스트, React 화면, 운영자 콘솔, 운영 API 보안, PostgreSQL scenario CI를 정리했다.
+- 릴리스 후보 검증 명령과 GitHub Actions gate를 명시했다.
+- 현재 MVP 출시 전 blocker와 후속 개선 후보를 분리했다.
+- README, progress index, issue draft index에서 release candidate 문서를 찾을 수 있게 연결했다.
+
+## 검증
+
+- `rg -n "unreleased|Release Candidate" README.md docs issue-drafts`
+- `git diff --check`
+
+## 남은 일
+
+- 실제 tag 발행 전 `unreleased`를 버전 릴리스 노트로 승격한다.
+- GitHub Wiki에 MVP 개요와 테스트 전략 요약을 반영한다.
+
+## 관련 문서
+
+- `docs/releases/unreleased.md`
+- `docs/releases/v0.6.0.md`
+- `docs/reviews/current-validation-documentation-audit.md`
+- `issue-drafts/0038-unreleased-release-candidate-notes.md`

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -53,10 +53,11 @@ ADR은 “왜 그렇게 결정했는가”를 기록하고, 이 폴더는 “각
 | 0035 | [PostgreSQL Scenario Testcontainers CI](0035-postgresql-scenario-testcontainers-ci.md) | 완료 |
 | 0036 | [Operator Manual Review Console UI](0036-operator-manual-review-console-ui.md) | 완료 |
 | 0037 | [Operator Console E2E Smoke](0037-operator-console-e2e-smoke.md) | 완료 |
+| 0038 | [Unreleased Release Candidate Notes](0038-unreleased-release-candidate-notes.md) | 완료 |
 
 ## 현재 기준선
 
 - 최신 병합 기준: `main`
-- 최신 완료 기능: Operator Console E2E Smoke
-- 현재 릴리스 후보: `v0.6.0`
+- 최신 완료 기능: Unreleased Release Candidate Notes
+- 현재 릴리스 후보: `unreleased`
 - 아직 미완료: 운영자 relay health/pruning 화면, Kafka/RabbitMQ/SQS adapter, consumer idempotency, operator/admin token 분리, pruning 실행 이력, external alert channel, 승인 워크플로우, GitHub Wiki 동기화, broker-specific Testcontainers 정책, manual review requeue full E2E fixture

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,89 @@
+# Unreleased Release Candidate Notes
+
+## 릴리스 성격
+
+`unreleased`는 `v0.6.0` 이후 `main`에 누적된 1차 MVP 출시 후보 변경분을 추적한다.
+
+이 문서는 GitHub Release가 아니라, 다음 실제 tag를 만들기 전 현재 개발분이 “시연 가능하고 검증 가능한가”를 판단하기 위한 기준선이다.
+
+## 후보 범위
+
+- 시나리오 기반 테스트 파이프라인 분리
+- 검증 요약 기반 코드 하드닝
+- React 사용자 화면 MVP
+- Playwright 기반 Frontend E2E gate
+- 백엔드/프론트 로컬 테스트 가이드
+- 충전/송금 성공·실패 E2E 시나리오
+- Vitest와 Testing Library 기반 프론트 컴포넌트 테스트
+- Outbox publisher port
+- 운영 API 인증/인가와 Spring Security role model
+- Outbox relay scheduler
+- Outbox relay 실행 기록, health summary, alert 판정
+- 운영 API 접근 감사 로그
+- 운영 로그 pruning
+- HTTP outbox broker adapter와 contract test
+- PostgreSQL scenario Testcontainers CI gate
+- 운영자 manual review console UI
+- 운영자 console E2E smoke
+
+## MVP 출시 판단 기준
+
+1차 MVP 출시 후보는 다음 조건을 만족해야 한다.
+
+- 핵심 사용자 흐름인 잔액 조회, 충전, 송금, 거래내역 확인이 화면과 API에서 동작한다.
+- 돈 이동 결과가 원장, 감사 로그, operation step log, outbox event로 추적된다.
+- 운영자는 manual review outbox를 화면에서 조회하고, requeue와 audit trail을 확인할 수 있다.
+- 운영 API는 local admin token과 operator id로 보호된다.
+- PostgreSQL profile이 Flyway migration과 Testcontainers scenario로 검증된다.
+- 프론트 build, unit, E2E가 CI에서 분리 검증된다.
+- 백엔드 unit/API, scenario, PostgreSQL scenario가 CI에서 분리 검증된다.
+- README, ADR, progress, issue draft, local test guide가 현재 상태와 모순되지 않는다.
+
+## 검증 게이트
+
+릴리스 후보 PR 또는 tag 전에는 다음 명령을 통과해야 한다.
+
+```bash
+./gradlew check
+./gradlew scenarioTest
+./gradlew postgresScenarioTest
+npm --prefix frontend run test
+npm --prefix frontend run build
+npm --prefix frontend run e2e
+docker compose config
+git diff --check
+```
+
+GitHub Actions에서는 다음 job이 통과해야 한다.
+
+- `Gradle Check`
+- `Scenario Test`
+- `PostgreSQL Scenario Test`
+- `Frontend Unit Test`
+- `Frontend Build`
+- `Frontend E2E`
+
+## 알려진 제약
+
+- 운영자 requeue 성공 E2E는 아직 manual review fixture 생성 정책이 필요하다.
+- 운영자 relay health와 pruning 화면은 아직 없다.
+- 운영자 승인 워크플로우와 external alert channel은 아직 없다.
+- admin token과 operator identity는 local header 기반이며 실제 로그인과 분리되어 있다.
+- Kafka/RabbitMQ/SQS 같은 broker-specific adapter는 아직 없다.
+- GitHub Wiki 동기화는 아직 수동 후보 문서 수준이다.
+
+## 출시 전 blocker
+
+- 릴리스 tag 이름과 version bump 기준을 결정한다.
+- `unreleased` 내용을 실제 버전 릴리스 노트로 승격한다.
+- 로컬 시연 smoke 결과를 릴리스 PR에 첨부한다.
+- GitHub Wiki에 MVP 개요, 운영자 콘솔, 테스트 전략 요약을 반영한다.
+
+## 후속 후보
+
+- 운영자 requeue full E2E fixture
+- release smoke script 또는 actuator 기반 health check
+- relay health/pruning operator UI
+- broker-specific Testcontainers contract
+- consumer idempotency
+- external alert channel

--- a/docs/reviews/current-validation-documentation-audit.md
+++ b/docs/reviews/current-validation-documentation-audit.md
@@ -28,7 +28,7 @@
 | 등급 | 항목 | 판단 |
 | --- | --- | --- |
 | P1 | Wiki draft 최신화 | 일부 내용이 최근 구현 상태보다 오래됨 |
-| P1 | 다음 릴리스 후보 문서 | `v0.6.0` 이후 변경분의 unreleased/release candidate 문서가 없음 |
+| P1 | 다음 릴리스 후보 문서 | `docs/releases/unreleased.md`로 후속 보강 완료 |
 | P2 | QA 시나리오 Wiki | README 권장 Wiki 구조에는 있으나 초안 파일이 없음 |
 | P2 | Architecture Decisions Wiki | README 권장 Wiki 구조에는 있으나 초안 파일이 없음 |
 | P2 | MCP and Skills Wiki | README 권장 Wiki 구조에는 있으나 초안 파일이 없음 |
@@ -115,7 +115,8 @@
 판단:
 
 - 아직 새 버전을 발행하지 않았다면 문제는 아니다.
-- 다만 릴리스 관리 관점에서는 `docs/releases/unreleased.md` 또는 `docs/releases/v0.7.0-candidate.md`가 있으면 현재 개발분 검증 기준이 더 명확해진다.
+- `docs/releases/unreleased.md`를 추가해 현재 개발분 검증 기준을 추적한다.
+- 실제 tag 발행 전에는 `unreleased`를 버전 릴리스 노트로 승격해야 한다.
 
 ### P2. QA Scenarios Wiki 초안
 
@@ -166,8 +167,8 @@ README의 권장 Wiki 구조에는 `MCP-and-Skills`가 있다.
 1. Wiki draft 최신화
    - `wiki-drafts/Domain-Rules.md`
    - `wiki-drafts/README.md`
-2. 다음 릴리스 후보 문서 추가
-   - `docs/releases/unreleased.md` 또는 `docs/releases/v0.7.0-candidate.md`
+2. 다음 릴리스 후보 문서 유지
+   - `docs/releases/unreleased.md`를 실제 tag 발행 전 버전 릴리스 노트로 승격
 3. QA/Architecture/MCP Wiki 초안 추가
    - `wiki-drafts/QA-Scenarios.md`
    - `wiki-drafts/Architecture-Decisions.md`

--- a/issue-drafts/0038-unreleased-release-candidate-notes.md
+++ b/issue-drafts/0038-unreleased-release-candidate-notes.md
@@ -1,0 +1,47 @@
+# [Docs] Unreleased 릴리스 후보 문서 추가
+
+## 배경
+
+문서 검증 감사에서 `v0.6.0` 이후 병합된 변경분을 추적하는 릴리스 후보 문서가 없다는 P1 gap이 확인되었다.
+
+1차 MVP 출시를 진행하려면 “현재 main이 어디까지 준비되었고, 어떤 검증을 통과해야 하며, 무엇이 blocker인지”를 릴리스 후보 문서로 고정해야 한다.
+
+## 목표
+
+- `docs/releases/unreleased.md`를 추가한다.
+- `v0.6.0` 이후 누적 변경분을 후보 범위로 정리한다.
+- MVP 출시 판단 기준, 검증 게이트, 알려진 제약, 출시 전 blocker를 문서화한다.
+- README와 progress/issue draft index에서 문서를 찾을 수 있게 연결한다.
+
+## 범위
+
+- 릴리스 후보 문서 추가
+- 진행 흔적 문서 추가
+- README release history 링크 갱신
+- progress/issue draft index 갱신
+
+## 범위 제외
+
+- 실제 release tag 발행
+- GitHub Release 생성
+- version bump
+- GitHub Wiki 반영
+
+## 인수 조건
+
+- [x] `docs/releases/unreleased.md`가 있다.
+- [x] `v0.6.0` 이후 주요 변경분이 후보 범위로 정리된다.
+- [x] MVP 출시 판단 기준과 검증 명령이 명시된다.
+- [x] 출시 전 blocker와 후속 후보가 분리된다.
+- [x] README, progress, issue draft index가 문서를 연결한다.
+
+## 검증
+
+- `rg -n "unreleased|Release Candidate" README.md docs issue-drafts`
+- `git diff --check`
+
+## 리스크와 트레이드오프
+
+- `unreleased` 문서는 실제 release note가 아니라 후보 기준선이다.
+- 실제 tag 발행 전에는 version 이름과 포함 범위를 다시 확정해야 한다.
+- Wiki 반영은 별도 작업으로 분리해 GitHub 저장소 문서와 Wiki의 책임을 유지한다.

--- a/issue-drafts/README.md
+++ b/issue-drafts/README.md
@@ -80,6 +80,8 @@
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/77
 - `0037-operator-console-e2e-smoke.md`: 운영자 콘솔 E2E smoke 작업 초안
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/79
+- `0038-unreleased-release-candidate-notes.md`: Unreleased 릴리스 후보 문서 작업 초안
+  - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/81
 
 ## GitHub CLI로 생성
 


### PR DESCRIPTION
Closes #81

## Summary
- Add `docs/releases/unreleased.md` as the current MVP release candidate baseline.
- List post-v0.6.0 candidate scope, release readiness criteria, validation gates, constraints, and blockers.
- Link the candidate document from README, progress, issue drafts, and the validation documentation audit.

## Validation
- rg -n "unreleased|Release Candidate" README.md docs issue-drafts
- git diff --check

## Notes
- This does not create a release tag or GitHub Release. The candidate note should be promoted to a versioned release note before tagging.
