### PR TITLE
chore: add mvp local smoke script

### DIFF
--- a/docs/progress/0040-mvp-local-smoke-script.md
+++ b/docs/progress/0040-mvp-local-smoke-script.md
@@ -1,0 +1,33 @@
+# 0040. MVP Local Smoke Script
+
+## 스펙 목표
+
+- 릴리스 시연 전 이미 실행 중인 백엔드와 프론트가 최소 연결 상태를 만족하는지 빠르게 확인한다.
+- 사용자 API, 운영자 API 인증 계약, 프론트 HTML 응답을 하나의 명령으로 검증한다.
+- 릴리스 후보 문서의 local smoke blocker를 실행 가능한 스크립트로 바꾼다.
+
+## 완료 결과
+
+- `scripts/mvp-local-smoke.sh`를 추가했다.
+- 백엔드 지갑 잔액 API 응답을 확인한다.
+- 운영자 manual review API가 local admin header로 응답하는지 확인한다.
+- 잘못된 admin token이 `ADMIN_AUTHENTICATION_REQUIRED`를 반환하는지 확인한다.
+- Vite 프론트 HTML 응답을 확인한다.
+- local test guide와 unreleased release candidate notes에 smoke 명령을 연결했다.
+
+## 검증
+
+- `scripts/mvp-local-smoke.sh`
+- `git diff --check`
+
+## 남은 일
+
+- actuator 기반 health check를 추가할지 별도 ADR에서 결정한다.
+- smoke script가 서버를 직접 기동/중지하는 방식은 필요해질 때 별도 작업으로 분리한다.
+
+## 관련 문서
+
+- `scripts/mvp-local-smoke.sh`
+- `docs/testing/local-test-guide.md`
+- `docs/releases/unreleased.md`
+- `issue-drafts/0040-mvp-local-smoke-script.md`

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -55,10 +55,11 @@ ADR은 “왜 그렇게 결정했는가”를 기록하고, 이 폴더는 “각
 | 0037 | [Operator Console E2E Smoke](0037-operator-console-e2e-smoke.md) | 완료 |
 | 0038 | [Unreleased Release Candidate Notes](0038-unreleased-release-candidate-notes.md) | 완료 |
 | 0039 | [Refresh MVP Wiki Drafts](0039-refresh-mvp-wiki-drafts.md) | 완료 |
+| 0040 | [MVP Local Smoke Script](0040-mvp-local-smoke-script.md) | 완료 |
 
 ## 현재 기준선
 
 - 최신 병합 기준: `main`
-- 최신 완료 기능: Refresh MVP Wiki Drafts
+- 최신 완료 기능: MVP Local Smoke Script
 - 현재 릴리스 후보: `unreleased`
-- 아직 미완료: 운영자 relay health/pruning 화면, Kafka/RabbitMQ/SQS adapter, consumer idempotency, operator/admin token 분리, pruning 실행 이력, external alert channel, 승인 워크플로우, GitHub Wiki 게시/동기화, broker-specific Testcontainers 정책, manual review requeue full E2E fixture
+- 아직 미완료: 운영자 relay health/pruning 화면, Kafka/RabbitMQ/SQS adapter, consumer idempotency, operator/admin token 분리, pruning 실행 이력, external alert channel, 승인 워크플로우, GitHub Wiki 게시/동기화, broker-specific Testcontainers 정책, manual review requeue full E2E fixture, actuator health check

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -50,6 +50,7 @@
 npm --prefix frontend run test
 npm --prefix frontend run build
 npm --prefix frontend run e2e
+scripts/mvp-local-smoke.sh
 docker compose config
 git diff --check
 ```
@@ -76,13 +77,13 @@ GitHub Actions에서는 다음 job이 통과해야 한다.
 
 - 릴리스 tag 이름과 version bump 기준을 결정한다.
 - `unreleased` 내용을 실제 버전 릴리스 노트로 승격한다.
-- 로컬 시연 smoke 결과를 릴리스 PR에 첨부한다.
+- `scripts/mvp-local-smoke.sh` 실행 결과를 릴리스 PR에 첨부한다.
 - GitHub Wiki에 MVP 개요, 운영자 콘솔, 테스트 전략 요약을 반영한다.
 
 ## 후속 후보
 
 - 운영자 requeue full E2E fixture
-- release smoke script 또는 actuator 기반 health check
+- actuator 기반 health check
 - relay health/pruning operator UI
 - broker-specific Testcontainers contract
 - consumer idempotency

--- a/docs/testing/local-test-guide.md
+++ b/docs/testing/local-test-guide.md
@@ -185,6 +185,23 @@ Running 3 tests using 1 worker
 - 운영자 콘솔에서 잘못된 admin token의 `ADMIN_AUTHENTICATION_REQUIRED` 오류가 표시된다.
 - 운영자 콘솔에서 local admin header로 manual review empty state가 표시된다.
 
+## MVP 로컬 smoke
+
+백엔드와 프론트를 이미 띄운 상태에서 릴리스 시연 전 최소 연결 상태를 빠르게 확인한다.
+
+```bash
+scripts/mvp-local-smoke.sh
+```
+
+검증 대상:
+
+- 백엔드 지갑 잔액 API 응답
+- 운영자 manual review API의 local admin header 성공 응답
+- 잘못된 admin token의 `ADMIN_AUTHENTICATION_REQUIRED` 응답
+- Vite 프론트 HTML 응답
+
+기본 URL은 `http://127.0.0.1:8080`, `http://127.0.0.1:5173`이다. 필요하면 `AI_REPO_BACKEND_URL`, `AI_REPO_FRONTEND_URL`, `AI_REPO_OPS_ADMIN_TOKEN`, `AI_REPO_SMOKE_OPERATOR_ID`로 override한다.
+
 ## CI 대응 관계
 
 | CI job | 로컬 명령 |

--- a/issue-drafts/0040-mvp-local-smoke-script.md
+++ b/issue-drafts/0040-mvp-local-smoke-script.md
@@ -1,0 +1,43 @@
+# [Chore] MVP 로컬 smoke 스크립트 추가
+
+## 배경
+
+`docs/releases/unreleased.md`는 릴리스 PR에 로컬 시연 smoke 결과를 첨부해야 한다고 명시한다. 하지만 현재는 이미 실행 중인 백엔드와 프론트를 빠르게 확인하는 스크립트가 없어 수동 curl 절차에 의존한다.
+
+## 목표
+
+- 이미 실행 중인 Spring Boot와 Vite 서버를 대상으로 MVP smoke를 수행한다.
+- 사용자 API, 운영자 API 인증 계약, 프론트 HTML 응답을 확인한다.
+- local test guide와 release candidate notes에 실행 명령을 연결한다.
+
+## 범위
+
+- `scripts/mvp-local-smoke.sh` 추가
+- `docs/testing/local-test-guide.md` 갱신
+- `docs/releases/unreleased.md` 갱신
+- 진행 흔적 문서 추가
+
+## 범위 제외
+
+- 서버 자동 기동/중지
+- actuator 도입
+- 배포 환경 smoke
+- GitHub Actions job 추가
+
+## 인수 조건
+
+- [x] 백엔드 지갑 잔액 API가 응답하지 않으면 실패한다.
+- [x] 운영자 manual review API가 local admin header로 응답하지 않으면 실패한다.
+- [x] 잘못된 admin token 응답에 `ADMIN_AUTHENTICATION_REQUIRED`가 없으면 실패한다.
+- [x] 프론트 HTML에 `AI Repo Fintech Lab`이 없으면 실패한다.
+- [x] 명령과 환경 변수 override 방법이 문서화된다.
+
+## 검증
+
+- `scripts/mvp-local-smoke.sh`
+- `git diff --check`
+
+## 리스크와 트레이드오프
+
+- 이 스크립트는 이미 실행 중인 서버를 확인한다. 서버 기동과 종료까지 책임지지 않는다.
+- CI 회귀 검증은 기존 Gradle, frontend unit/build/E2E, PostgreSQL scenario job이 담당한다.

--- a/issue-drafts/README.md
+++ b/issue-drafts/README.md
@@ -84,6 +84,8 @@
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/81
 - `0039-refresh-mvp-wiki-drafts.md`: MVP Wiki 초안 최신화 작업 초안
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/83
+- `0040-mvp-local-smoke-script.md`: MVP 로컬 smoke 스크립트 작업 초안
+  - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/85
 
 ## GitHub CLI로 생성
 

--- a/scripts/mvp-local-smoke.sh
+++ b/scripts/mvp-local-smoke.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BACKEND_URL="${AI_REPO_BACKEND_URL:-http://127.0.0.1:8080}"
+FRONTEND_URL="${AI_REPO_FRONTEND_URL:-http://127.0.0.1:5173}"
+ADMIN_TOKEN="${AI_REPO_OPS_ADMIN_TOKEN:-local-ops-token}"
+OPERATOR_ID="${AI_REPO_SMOKE_OPERATOR_ID:-local-smoke-operator}"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+check_contains() {
+  local value="$1"
+  local expected="$2"
+  local label="$3"
+
+  if [[ "$value" != *"$expected"* ]]; then
+    fail "$label did not contain '$expected'"
+  fi
+}
+
+echo "MVP local smoke"
+echo "- backend:  ${BACKEND_URL}"
+echo "- frontend: ${FRONTEND_URL}"
+
+wallet_response="$(curl -fsS "${BACKEND_URL}/api/v1/wallets/wallet-001/balance")" \
+  || fail "backend wallet balance API is not reachable"
+check_contains "$wallet_response" '"walletId":"wallet-001"' "wallet balance response"
+
+manual_review_response="$(
+  curl -fsS \
+    -H "X-Admin-Token: ${ADMIN_TOKEN}" \
+    -H "X-Operator-Id: ${OPERATOR_ID}" \
+    "${BACKEND_URL}/api/v1/outbox-events/manual-review?limit=20"
+)" || fail "operator manual review API is not reachable with local admin headers"
+check_contains "$manual_review_response" '[' "manual review response"
+
+auth_error_response="$(
+  curl -sS \
+    -H "X-Admin-Token: wrong-token" \
+    -H "X-Operator-Id: ${OPERATOR_ID}" \
+    "${BACKEND_URL}/api/v1/outbox-events/manual-review?limit=20"
+)" || true
+check_contains "$auth_error_response" 'ADMIN_AUTHENTICATION_REQUIRED' "operator auth error response"
+
+frontend_response="$(curl -fsS "${FRONTEND_URL}/")" \
+  || fail "frontend is not reachable"
+check_contains "$frontend_response" 'AI Repo Fintech Lab' "frontend HTML"
+
+echo "PASS: MVP local smoke completed"


### PR DESCRIPTION
Closes #85

## Summary
- Add `scripts/mvp-local-smoke.sh` for already-running local backend/frontend demo checks.
- Verify wallet API, operator manual review API with local admin headers, invalid token auth error, and frontend HTML response.
- Document the smoke command in the local test guide and unreleased release candidate notes.

## Validation
- scripts/mvp-local-smoke.sh
- git diff --check

## Notes
- The script intentionally does not start or stop servers. It is a release demo smoke check for an already-running local environment.
