### PR TITLE
feat: add actuator health smoke

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-database-postgresql'
     implementation 'org.springframework.boot:spring-boot-flyway'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'

--- a/docs/progress/0040-mvp-local-smoke-script.md
+++ b/docs/progress/0040-mvp-local-smoke-script.md
@@ -22,7 +22,7 @@
 
 ## 남은 일
 
-- actuator 기반 health check를 추가할지 별도 ADR에서 결정한다.
+- Actuator health check는 후속 단계에서 MVP local smoke에 포함했다.
 - smoke script가 서버를 직접 기동/중지하는 방식은 필요해질 때 별도 작업으로 분리한다.
 
 ## 관련 문서

--- a/docs/progress/0042-actuator-health-smoke-endpoint.md
+++ b/docs/progress/0042-actuator-health-smoke-endpoint.md
@@ -1,0 +1,34 @@
+# 0042. Actuator Health Smoke Endpoint
+
+## 스펙 목표
+
+- 릴리스 시연과 smoke 검증에서 사용할 표준 health endpoint를 추가한다.
+- `/actuator/health`는 운영 admin header 없이도 로컬 smoke에서 확인 가능해야 한다.
+- MVP local smoke script가 domain API뿐 아니라 application health도 확인하게 한다.
+
+## 완료 결과
+
+- `spring-boot-starter-actuator` 의존성을 추가했다.
+- `management.endpoints.web.exposure.include=health` 설정을 추가했다.
+- `/actuator/health`가 `UP`을 반환하는 backend test를 추가했다.
+- `scripts/mvp-local-smoke.sh`가 Actuator health 응답을 검증하게 했다.
+- local test guide와 unreleased release candidate notes를 갱신했다.
+
+## 검증
+
+- `./gradlew test --tests '*ActuatorHealthEndpointTest'`
+- `scripts/mvp-local-smoke.sh`
+- `git diff --check`
+
+## 남은 일
+
+- readiness/liveness probe를 실제 배포 환경과 연결할지는 배포 방식이 정해진 뒤 결정한다.
+- 운영자 relay health/pruning 화면은 별도 UI 작업으로 남긴다.
+
+## 관련 문서
+
+- `build.gradle`
+- `src/main/resources/application.yml`
+- `scripts/mvp-local-smoke.sh`
+- `docs/testing/local-test-guide.md`
+- `issue-drafts/0042-actuator-health-smoke-endpoint.md`

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -57,10 +57,11 @@ ADR은 “왜 그렇게 결정했는가”를 기록하고, 이 폴더는 “각
 | 0039 | [Refresh MVP Wiki Drafts](0039-refresh-mvp-wiki-drafts.md) | 완료 |
 | 0040 | [MVP Local Smoke Script](0040-mvp-local-smoke-script.md) | 완료 |
 | 0041 | [GitHub Wiki Sync Workflow](0041-github-wiki-sync-workflow.md) | 완료 |
+| 0042 | [Actuator Health Smoke Endpoint](0042-actuator-health-smoke-endpoint.md) | 완료 |
 
 ## 현재 기준선
 
 - 최신 병합 기준: `main`
-- 최신 완료 기능: GitHub Wiki Sync Workflow
+- 최신 완료 기능: Actuator Health Smoke Endpoint
 - 현재 릴리스 후보: `unreleased`
-- 아직 미완료: 운영자 relay health/pruning 화면, Kafka/RabbitMQ/SQS adapter, consumer idempotency, operator/admin token 분리, pruning 실행 이력, external alert channel, 승인 워크플로우, GitHub Wiki 실제 push, broker-specific Testcontainers 정책, manual review requeue full E2E fixture, actuator health check
+- 아직 미완료: 운영자 relay health/pruning 화면, Kafka/RabbitMQ/SQS adapter, consumer idempotency, operator/admin token 분리, pruning 실행 이력, external alert channel, 승인 워크플로우, GitHub Wiki 실제 push, broker-specific Testcontainers 정책, manual review requeue full E2E fixture

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -25,6 +25,7 @@
 - PostgreSQL scenario Testcontainers CI gate
 - 운영자 manual review console UI
 - 운영자 console E2E smoke
+- Actuator health endpoint 기반 release smoke
 
 ## MVP 출시 판단 기준
 
@@ -83,7 +84,6 @@ GitHub Actions에서는 다음 job이 통과해야 한다.
 ## 후속 후보
 
 - 운영자 requeue full E2E fixture
-- actuator 기반 health check
 - relay health/pruning operator UI
 - broker-specific Testcontainers contract
 - consumer idempotency

--- a/docs/reviews/current-development-baseline-review.md
+++ b/docs/reviews/current-development-baseline-review.md
@@ -21,13 +21,13 @@
 | P2 | 운영 API 인증/인가 부재 | manual review/requeue API는 운영 행위인데 현재 누구나 호출 가능한 형태다 | 관리자 인증/인가 ADR과 테스트를 추가한다 |
 | P2 | 실제 broker 미연동 | outbox는 상태와 retry는 있지만 외부 publish adapter가 없다 | broker port/interface와 fake adapter부터 도입한다 |
 | P3 | Wiki 동기화 수동 | `scripts/sync-wiki-drafts.sh`로 checkout 동기화 절차는 생겼고 실제 push는 release operation이다 | 릴리스 체크리스트에서 Wiki push를 확인한다 |
-| P3 | release health check 부재 | Release는 발행됐지만 로컬 앱 기동 smoke 검증은 별도 게이트가 아니다 | `bootRun` 또는 actuator 도입 후 smoke script를 추가한다 |
+| P3 | release health check 부재 | Actuator health endpoint와 MVP local smoke script로 후속 보강 완료 | 릴리스 PR에서 smoke 결과를 첨부한다 |
 
 ## 이번 작업에서 반영한 개선
 
 - P1 항목인 시나리오 기반 게이트 부족을 `scenarioTest` Gradle task와 GitHub Actions `Scenario Test` job으로 보완했다.
 - 돈 이동 증거 흐름과 outbox 운영 흐름을 첫 시나리오 테스트로 고정했다.
-- 남은 개선점은 실제 Wiki push, release health check, broker-specific 검증, 운영자 승인 workflow다.
+- 남은 개선점은 실제 Wiki push, broker-specific 검증, 운영자 승인 workflow다.
 
 ## 테스트 파이프라인 진단
 

--- a/docs/testing/local-test-guide.md
+++ b/docs/testing/local-test-guide.md
@@ -195,6 +195,7 @@ scripts/mvp-local-smoke.sh
 
 검증 대상:
 
+- Actuator health endpoint의 `UP` 응답
 - 백엔드 지갑 잔액 API 응답
 - 운영자 manual review API의 local admin header 성공 응답
 - 잘못된 admin token의 `ADMIN_AUTHENTICATION_REQUIRED` 응답

--- a/issue-drafts/0042-actuator-health-smoke-endpoint.md
+++ b/issue-drafts/0042-actuator-health-smoke-endpoint.md
@@ -1,0 +1,43 @@
+# [Feature] Actuator health smoke endpoint 추가
+
+## 배경
+
+MVP 출시 준비 항목에 actuator 기반 health check가 남아 있다. 기존 local smoke script는 지갑 API, 운영자 API, 프론트 HTML을 확인하지만 표준 애플리케이션 health endpoint는 확인하지 않는다.
+
+## 목표
+
+- Spring Boot Actuator health endpoint를 추가한다.
+- `/actuator/health`를 local smoke에서 확인한다.
+- admin header 없이 health endpoint가 `UP`을 반환하는지 테스트한다.
+
+## 범위
+
+- `spring-boot-starter-actuator` 의존성 추가
+- health endpoint 노출 설정 추가
+- health endpoint test 추가
+- `scripts/mvp-local-smoke.sh` 갱신
+- local test guide, release candidate notes, progress 갱신
+
+## 범위 제외
+
+- actuator 전체 endpoint 공개
+- 배포 환경 readiness/liveness 설정
+- 운영자 relay health/pruning UI
+
+## 인수 조건
+
+- [x] `GET /actuator/health`가 200과 `UP`을 반환한다.
+- [x] health endpoint는 admin header 없이 조회 가능하다.
+- [x] MVP local smoke script가 actuator health를 검증한다.
+- [x] 운영 API admin auth contract는 변경하지 않는다.
+
+## 검증
+
+- `./gradlew test --tests '*ActuatorHealthEndpointTest'`
+- `scripts/mvp-local-smoke.sh`
+- `git diff --check`
+
+## 리스크와 트레이드오프
+
+- health endpoint만 노출한다. metrics, env, beans 같은 endpoint는 MVP smoke 범위 밖이다.
+- 실제 배포 probe 설정은 배포 환경이 정해진 뒤 별도 결정한다.

--- a/issue-drafts/README.md
+++ b/issue-drafts/README.md
@@ -88,6 +88,8 @@
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/85
 - `0041-github-wiki-sync-workflow.md`: GitHub Wiki sync workflow 작업 초안
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/87
+- `0042-actuator-health-smoke-endpoint.md`: Actuator health smoke endpoint 작업 초안
+  - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/90
 
 ## GitHub CLI로 생성
 

--- a/scripts/mvp-local-smoke.sh
+++ b/scripts/mvp-local-smoke.sh
@@ -25,6 +25,10 @@ echo "MVP local smoke"
 echo "- backend:  ${BACKEND_URL}"
 echo "- frontend: ${FRONTEND_URL}"
 
+health_response="$(curl -fsS "${BACKEND_URL}/actuator/health")" \
+  || fail "actuator health endpoint is not reachable"
+check_contains "$health_response" '"status":"UP"' "actuator health response"
+
 wallet_response="$(curl -fsS "${BACKEND_URL}/api/v1/wallets/wallet-001/balance")" \
   || fail "backend wallet balance API is not reachable"
 check_contains "$wallet_response" '"walletId":"wallet-001"' "wallet balance response"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,16 @@ spring:
 server:
   port: 8080
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      probes:
+        enabled: true
+
 ai-repo:
   ops:
     admin-token: ${AI_REPO_OPS_ADMIN_TOKEN:local-ops-token}

--- a/src/test/java/com/imwoo/airepo/wallet/api/ActuatorHealthEndpointTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/api/ActuatorHealthEndpointTest.java
@@ -1,0 +1,31 @@
+package com.imwoo.airepo.wallet.api;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.imwoo.airepo.AiRepoApplication;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(classes = AiRepoApplication.class)
+@AutoConfigureMockMvc
+class ActuatorHealthEndpointTest {
+
+    private final MockMvc mockMvc;
+
+    @Autowired
+    ActuatorHealthEndpointTest(MockMvc mockMvc) {
+        this.mockMvc = mockMvc;
+    }
+
+    @Test
+    void exposesPublicHealthEndpointForReleaseSmoke() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UP"));
+    }
+}


### PR DESCRIPTION
Closes #90

## Summary
- Add Spring Boot Actuator health endpoint exposure for release smoke.
- Verify `/actuator/health` returns `UP` without admin headers.
- Include actuator health in `scripts/mvp-local-smoke.sh` and update release/test/progress docs.

## Validation
- ./gradlew test --tests '*ActuatorHealthEndpointTest'
- scripts/mvp-local-smoke.sh
- git diff --check

## Notes
- Only the health endpoint is exposed. Other actuator endpoints remain outside MVP smoke scope.
