### PR TITLE
docs: add mvp release checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Proposed | Accepted | Deprecated | Superseded
 
 - [v0.6.0 Release Notes](docs/releases/v0.6.0.md)
 - [Unreleased Release Candidate Notes](docs/releases/unreleased.md)
+- [MVP Release Checklist](docs/releases/mvp-release-checklist.md)
 
 릴리스 노트에는 반드시 다음을 포함합니다.
 

--- a/docs/progress/0043-mvp-release-checklist.md
+++ b/docs/progress/0043-mvp-release-checklist.md
@@ -1,0 +1,32 @@
+# 0043. MVP Release Checklist
+
+## 스펙 목표
+
+- `unreleased` 후보를 실제 1차 MVP release로 승격하기 위한 tag/version 기준을 고정한다.
+- Release PR 전에 실행해야 하는 명령과 산출물을 체크리스트로 연결한다.
+- `v0.7.0`을 다음 MVP release tag 후보로 명시한다.
+
+## 완료 결과
+
+- `docs/releases/mvp-release-checklist.md`를 추가했다.
+- 다음 release note 후보를 `docs/releases/v0.7.0.md`로 정의했다.
+- 다음 Git tag 후보를 `v0.7.0`으로 정의했다.
+- Gradle version bump 기준을 `0.7.0`으로 정의했다.
+- Release PR 필수 검증 명령, Wiki sync, GitHub Release 발행 순서를 문서화했다.
+- README와 `unreleased` release candidate notes에서 체크리스트를 연결했다.
+
+## 검증
+
+- `rg -n "v0.7.0|MVP Release Checklist|mvp-release-checklist" README.md docs issue-drafts`
+- `git diff --check`
+
+## 남은 일
+
+- 실제 release PR에서 `docs/releases/v0.7.0.md`를 생성하고 `build.gradle` version을 `0.7.0`으로 bump한다.
+- Release PR merge 후 tag와 GitHub Release를 발행한다.
+
+## 관련 문서
+
+- `docs/releases/mvp-release-checklist.md`
+- `docs/releases/unreleased.md`
+- `issue-drafts/0043-mvp-release-checklist.md`

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -58,10 +58,11 @@ ADR은 “왜 그렇게 결정했는가”를 기록하고, 이 폴더는 “각
 | 0040 | [MVP Local Smoke Script](0040-mvp-local-smoke-script.md) | 완료 |
 | 0041 | [GitHub Wiki Sync Workflow](0041-github-wiki-sync-workflow.md) | 완료 |
 | 0042 | [Actuator Health Smoke Endpoint](0042-actuator-health-smoke-endpoint.md) | 완료 |
+| 0043 | [MVP Release Checklist](0043-mvp-release-checklist.md) | 완료 |
 
 ## 현재 기준선
 
 - 최신 병합 기준: `main`
-- 최신 완료 기능: Actuator Health Smoke Endpoint
+- 최신 완료 기능: MVP Release Checklist
 - 현재 릴리스 후보: `unreleased`
 - 아직 미완료: 운영자 relay health/pruning 화면, Kafka/RabbitMQ/SQS adapter, consumer idempotency, operator/admin token 분리, pruning 실행 이력, external alert channel, 승인 워크플로우, GitHub Wiki 실제 push, broker-specific Testcontainers 정책, manual review requeue full E2E fixture

--- a/docs/releases/mvp-release-checklist.md
+++ b/docs/releases/mvp-release-checklist.md
@@ -1,0 +1,72 @@
+# MVP Release Checklist
+
+이 문서는 `unreleased` 후보를 실제 1차 MVP release로 승격하기 직전 확인할 체크리스트다.
+
+## 버전 정책
+
+| 항목 | 기준 |
+| --- | --- |
+| 후보 문서 | `docs/releases/unreleased.md` |
+| 다음 release note | `docs/releases/v0.7.0.md` |
+| 다음 Git tag | `v0.7.0` |
+| Gradle version | release PR에서 `0.7.0`으로 bump |
+| Release 성격 | 1차 MVP 시연 가능 기준선 |
+
+`v0.6.0`은 outbox/manual review 기준선이고, `v0.7.0`은 React 사용자 화면, 운영자 콘솔, 보안/관측, PostgreSQL scenario CI, local smoke까지 포함한 1차 MVP 기준선으로 둔다.
+
+## Release PR 전 체크
+
+- [ ] `docs/releases/unreleased.md`를 `docs/releases/v0.7.0.md`로 복사하고 실제 포함 범위를 확정한다.
+- [ ] `build.gradle`의 `version`을 `0.7.0`으로 변경한다.
+- [ ] README의 현재 릴리스 노트 링크에 `v0.7.0`을 추가한다.
+- [ ] `docs/progress/README.md`의 현재 릴리스 후보를 `v0.7.0`으로 갱신한다.
+- [ ] `wiki-drafts/Release-Notes.md`의 현재 후보를 `v0.7.0` 기준으로 갱신한다.
+
+## 필수 검증 명령
+
+Release PR에는 다음 명령 결과를 첨부한다.
+
+```bash
+./gradlew check
+./gradlew scenarioTest
+./gradlew postgresScenarioTest
+npm --prefix frontend run test
+npm --prefix frontend run build
+npm --prefix frontend run e2e
+scripts/mvp-local-smoke.sh
+scripts/sync-wiki-drafts.sh wiki-drafts <wiki-checkout>
+docker compose config
+git diff --check
+```
+
+## GitHub 상태 확인
+
+- [ ] Release PR CI가 모두 통과한다.
+- [ ] `scripts/sync-wiki-drafts.sh` 결과를 GitHub Wiki checkout에 commit/push한다.
+- [ ] Wiki `Home`, `Release-Notes`, `QA-Scenarios`, `Architecture-Decisions`가 GitHub에서 열리는지 확인한다.
+- [ ] GitHub Release body에는 포함 기능, 검증 결과, 알려진 제약, 다음 후보를 기록한다.
+
+## 알려진 제약 명시
+
+Release note에는 다음 제약을 숨기지 않고 기록한다.
+
+- 운영자 relay health/pruning 화면은 아직 없다.
+- Kafka/RabbitMQ/SQS adapter는 아직 없다.
+- consumer idempotency는 아직 없다.
+- operator/admin token 분리와 실제 로그인 연동은 아직 없다.
+- external alert channel과 승인 워크플로우는 아직 없다.
+- manual review requeue full E2E fixture는 아직 없다.
+
+## Tag 발행 순서
+
+1. Release PR을 merge한다.
+2. 로컬 `main`을 `origin/main`에 fast-forward 한다.
+3. `git tag -a v0.7.0 -m "v0.7.0"`을 생성한다.
+4. `git push origin v0.7.0`을 실행한다.
+5. `gh release create v0.7.0 --title "v0.7.0" --notes-file docs/releases/v0.7.0.md`로 GitHub Release를 생성한다.
+
+## Rollback 기준
+
+- Release PR CI가 실패하면 tag를 만들지 않는다.
+- local smoke가 실패하면 tag를 만들지 않는다.
+- Wiki push가 실패하면 GitHub Release note에 Wiki 미반영 상태를 명시하거나 release를 보류한다.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -76,8 +76,8 @@ GitHub Actions에서는 다음 job이 통과해야 한다.
 
 ## 출시 전 blocker
 
-- 릴리스 tag 이름과 version bump 기준을 결정한다.
-- `unreleased` 내용을 실제 버전 릴리스 노트로 승격한다.
+- `docs/releases/mvp-release-checklist.md`에 따라 `v0.7.0` release PR을 준비한다.
+- `unreleased` 내용을 `docs/releases/v0.7.0.md`로 승격한다.
 - `scripts/mvp-local-smoke.sh` 실행 결과를 릴리스 PR에 첨부한다.
 - `scripts/sync-wiki-drafts.sh`로 Wiki 초안을 GitHub Wiki checkout에 반영한다.
 

--- a/docs/releases/v0.6.0.md
+++ b/docs/releases/v0.6.0.md
@@ -65,6 +65,6 @@ GitHub Actions의 `Gradle Check`가 통과한 뒤 `v0.6.0` tag와 GitHub Release
 
 ## 다음 릴리스 후보
 
-- `v0.7.0`: 실제 broker 발행 또는 broker adapter 추상화
-- `v0.8.0`: 관리자 인증/인가와 requeue 승인 워크플로우
-- `v0.9.0`: 운영 모니터링, 알림, release health check
+- `v0.7.0`: 1차 MVP 시연 기준선
+- `v0.8.0`: broker-specific adapter와 consumer idempotency
+- `v0.9.0`: 운영자 승인 워크플로우, 알림, 운영자 확장 화면

--- a/issue-drafts/0043-mvp-release-checklist.md
+++ b/issue-drafts/0043-mvp-release-checklist.md
@@ -1,0 +1,45 @@
+# [Docs] MVP release checklist 추가
+
+## 배경
+
+`docs/releases/unreleased.md`는 tag 이름과 version bump 기준 결정, 실제 버전 릴리스 노트 승격을 출시 전 blocker로 남겨두고 있다.
+
+1차 MVP 출시를 진행하려면 tag/version 정책, 필수 검증 명령, Wiki sync, GitHub Release 생성 순서를 release PR 전에 고정해야 한다.
+
+## 목표
+
+- MVP release checklist를 추가한다.
+- 다음 release 후보를 `v0.7.0`으로 명시한다.
+- Release PR에서 수행할 version bump와 release note 승격 기준을 문서화한다.
+- 필수 검증 명령과 GitHub 상태 확인 항목을 체크리스트로 남긴다.
+
+## 범위
+
+- `docs/releases/mvp-release-checklist.md` 추가
+- `docs/releases/unreleased.md` 갱신
+- README release note 링크 갱신
+- progress/issue draft 흔적 추가
+
+## 범위 제외
+
+- 실제 `build.gradle` version bump
+- `docs/releases/v0.7.0.md` 생성
+- Git tag 생성
+- GitHub Release 생성
+
+## 인수 조건
+
+- [x] 다음 tag 후보가 `v0.7.0`으로 명시된다.
+- [x] Gradle version bump 기준이 `0.7.0`으로 명시된다.
+- [x] release PR 필수 검증 명령이 문서화된다.
+- [x] Wiki sync와 GitHub Release 발행 순서가 문서화된다.
+
+## 검증
+
+- `rg -n "v0.7.0|MVP Release Checklist|mvp-release-checklist" README.md docs issue-drafts`
+- `git diff --check`
+
+## 리스크와 트레이드오프
+
+- 이번 작업은 release를 발행하지 않는다.
+- 실제 release PR에서 포함 범위와 known limitations를 다시 확인해야 한다.

--- a/issue-drafts/README.md
+++ b/issue-drafts/README.md
@@ -90,6 +90,8 @@
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/87
 - `0042-actuator-health-smoke-endpoint.md`: Actuator health smoke endpoint 작업 초안
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/90
+- `0043-mvp-release-checklist.md`: MVP release checklist 작업 초안
+  - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/92
 
 ## GitHub CLI로 생성
 


### PR DESCRIPTION
Closes #92

## Summary
- Adds MVP release checklist for the v0.7.0 release candidate
- Documents version/tag policy, release PR gates, Wiki sync, and GitHub Release order
- Updates README, unreleased notes, progress log, and issue draft index

## Validation
- `rg -n "v0.7.0|MVP Release Checklist|mvp-release-checklist|0.7.0|Release PR|출시 전 blocker" README.md docs issue-drafts --glob "!frontend/node_modules/**" --glob "!frontend/dist/**"`
- `git diff --check`

## Notes
- This PR does not create the v0.7.0 tag, bump build.gradle, or publish a GitHub Release. Those remain release PR tasks.