### PR TITLE
chore: prepare v0.7.0 release baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,10 +257,12 @@ Proposed | Accepted | Deprecated | Superseded
 - `v0.4.0`: 원장 모델, 감사 로그
 - `v0.5.0`: PostgreSQL 스키마 migration, 정산 배치 후보
 - `v0.6.0`: outbox 재처리, manual review, requeue 감사 이력, 첫 GitHub Release 기준선
-- `unreleased`: 1차 MVP 출시 후보 검증 기준선
+- `v0.7.0`: 1차 MVP 시연 기준선
+- `unreleased`: `v0.7.0` 이후 변경 후보
 
 현재 릴리스 노트:
 
+- [v0.7.0 Release Notes](docs/releases/v0.7.0.md)
 - [v0.6.0 Release Notes](docs/releases/v0.6.0.md)
 - [Unreleased Release Candidate Notes](docs/releases/unreleased.md)
 - [MVP Release Checklist](docs/releases/mvp-release-checklist.md)

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.imwoo'
-version = '0.6.0'
+version = '0.7.0'
 description = 'Fintech harness engineering lab'
 
 java {

--- a/docs/adr/0021-release-version-baseline.md
+++ b/docs/adr/0021-release-version-baseline.md
@@ -80,6 +80,6 @@ Accepted
 
 후속 작업:
 
-- `v0.7.0` 후보로 실제 broker 발행 또는 인증/인가 정책을 설계한다.
+- `v0.8.0` 이후 후보로 broker-specific adapter와 consumer idempotency를 설계한다.
 - GitHub Wiki 동기화 절차를 릴리스 체크리스트에 연결한다.
 - 필요하면 컨테이너 이미지 빌드/검증 단계를 추가한다.

--- a/docs/adr/0023-validation-summary-hardening.md
+++ b/docs/adr/0023-validation-summary-hardening.md
@@ -71,7 +71,7 @@ Accepted
 
 - `미존재 operation은 빈 목록으로 둘 수 있다`는 반박은 채택하지 않는다. 현재 성공 operation은 step log와 outbox event를 남기는 정책이므로 빈 목록은 식별자 오류를 숨길 가능성이 더 크다.
 - `fixtures-schema drift probe`는 이번 PR에서 보류한다. Flyway V2 seed migration이 이미 기준 경로이고, H2 fixture는 빠른 테스트 보조 경로라 rollback 회귀 보호보다 우선순위가 낮다.
-- `CI Testcontainers SKIP 위험`은 별도 ADR이 필요하다. Docker availability를 강제하면 CI 비용과 실패 모드가 바뀌므로 v0.7.0 인프라 정책에서 결정한다.
+- `CI Testcontainers SKIP 위험`은 별도 ADR이 필요하다. Docker availability를 강제하면 CI 비용과 실패 모드가 바뀌므로 post-MVP 인프라 정책에서 계속 점검한다.
 
 ## 결과
 
@@ -89,5 +89,5 @@ Accepted
 후속 작업:
 
 - Wiki 동기화 부채를 별도 작업으로 처리한다.
-- Testcontainers 강제 실행 정책을 v0.7.0 CI ADR에서 결정한다.
+- Testcontainers 강제 실행 정책을 post-MVP CI ADR에서 계속 점검한다.
 - broker adapter 도입 시 operation/outbox 조회 정책을 다시 검토한다.

--- a/docs/progress/0044-v0.7.0-release-baseline.md
+++ b/docs/progress/0044-v0.7.0-release-baseline.md
@@ -1,0 +1,40 @@
+# 0044. v0.7.0 Release Baseline
+
+## 스펙 목표
+
+- `unreleased` 1차 MVP 후보를 실제 `v0.7.0` release 기준선으로 승격한다.
+- Gradle artifact version과 README/Wiki release 문서를 같은 버전으로 정렬한다.
+- Release PR 이후 tag와 GitHub Release를 발행할 수 있는 상태로 만든다.
+
+## 완료 결과
+
+- `docs/releases/v0.7.0.md`를 생성했다.
+- `build.gradle` version을 `0.7.0`으로 bump했다.
+- README release history와 release note 링크에 `v0.7.0`을 추가했다.
+- `docs/releases/unreleased.md`를 `v0.7.0` 이후 변경 후보 staging 문서로 리셋했다.
+- Wiki draft의 현재 후보와 기준 문서를 `v0.7.0`으로 갱신했다.
+
+## 검증
+
+- `rg -n "v0.7.0|0.7.0|Release Baseline|docs/releases/v0.7.0.md" README.md build.gradle docs wiki-drafts issue-drafts`
+- `./gradlew check`
+- `./gradlew scenarioTest`
+- `./gradlew postgresScenarioTest`
+- `npm --prefix frontend run test`
+- `npm --prefix frontend run build`
+- `npm --prefix frontend run e2e`
+- `scripts/mvp-local-smoke.sh`
+- `docker compose config`
+- `git diff --check`
+
+## 남은 일
+
+- Release PR CI가 통과하면 tag `v0.7.0`과 GitHub Release를 발행한다.
+- GitHub Wiki 원격 저장소가 초기화되면 Wiki draft를 push한다.
+
+## 관련 문서
+
+- `docs/releases/v0.7.0.md`
+- `docs/releases/mvp-release-checklist.md`
+- `wiki-drafts/Release-Notes.md`
+- `issue-drafts/0044-v0.7.0-release-baseline.md`

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -59,10 +59,11 @@ ADR은 “왜 그렇게 결정했는가”를 기록하고, 이 폴더는 “각
 | 0041 | [GitHub Wiki Sync Workflow](0041-github-wiki-sync-workflow.md) | 완료 |
 | 0042 | [Actuator Health Smoke Endpoint](0042-actuator-health-smoke-endpoint.md) | 완료 |
 | 0043 | [MVP Release Checklist](0043-mvp-release-checklist.md) | 완료 |
+| 0044 | [v0.7.0 Release Baseline](0044-v0.7.0-release-baseline.md) | 완료 |
 
 ## 현재 기준선
 
 - 최신 병합 기준: `main`
-- 최신 완료 기능: MVP Release Checklist
-- 현재 릴리스 후보: `unreleased`
+- 최신 완료 기능: v0.7.0 Release Baseline
+- 현재 릴리스 후보: `v0.7.0`
 - 아직 미완료: 운영자 relay health/pruning 화면, Kafka/RabbitMQ/SQS adapter, consumer idempotency, operator/admin token 분리, pruning 실행 이력, external alert channel, 승인 워크플로우, GitHub Wiki 실제 push, broker-specific Testcontainers 정책, manual review requeue full E2E fixture

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -1,18 +1,35 @@
-# Unreleased Release Candidate Notes
+# v0.7.0 Release Notes
 
 ## 릴리스 성격
 
-`unreleased`는 `v0.7.0` 이후 `main`에 누적될 변경 후보를 추적한다.
+`v0.7.0`은 `v0.6.0` 이후 `main`에 누적된 1차 MVP 출시 후보 변경분을 확정한 release 기준선이다.
 
-이 문서는 GitHub Release가 아니라, 다음 실제 tag를 만들기 전 현재 개발분을 정리하는 staging 문서다.
+이 문서는 GitHub Release body의 source 문서로 사용한다.
 
-## 후보 범위
+## 포함 범위
 
-- 아직 없음
+- 시나리오 기반 테스트 파이프라인 분리
+- 검증 요약 기반 코드 하드닝
+- React 사용자 화면 MVP
+- Playwright 기반 Frontend E2E gate
+- 백엔드/프론트 로컬 테스트 가이드
+- 충전/송금 성공·실패 E2E 시나리오
+- Vitest와 Testing Library 기반 프론트 컴포넌트 테스트
+- Outbox publisher port
+- 운영 API 인증/인가와 Spring Security role model
+- Outbox relay scheduler
+- Outbox relay 실행 기록, health summary, alert 판정
+- 운영 API 접근 감사 로그
+- 운영 로그 pruning
+- HTTP outbox broker adapter와 contract test
+- PostgreSQL scenario Testcontainers CI gate
+- 운영자 manual review console UI
+- 운영자 console E2E smoke
+- Actuator health endpoint 기반 release smoke
 
 ## MVP 출시 판단 기준
 
-다음 release 후보는 다음 조건을 만족해야 한다.
+1차 MVP release는 다음 조건을 만족해야 한다.
 
 - 핵심 사용자 흐름인 잔액 조회, 충전, 송금, 거래내역 확인이 화면과 API에서 동작한다.
 - 돈 이동 결과가 원장, 감사 로그, operation step log, outbox event로 추적된다.
@@ -25,7 +42,7 @@
 
 ## 검증 게이트
 
-릴리스 후보 PR 또는 tag 전에는 다음 명령을 통과해야 한다.
+Release PR 또는 tag 전에는 다음 명령을 통과해야 한다.
 
 ```bash
 ./gradlew check
@@ -57,11 +74,12 @@ GitHub Actions에서는 다음 job이 통과해야 한다.
 - Kafka/RabbitMQ/SQS 같은 broker-specific adapter는 아직 없다.
 - GitHub Wiki 동기화는 아직 수동 후보 문서 수준이다.
 
-## 출시 전 blocker
+## Release operation
 
-- 다음 release 범위가 확정되면 버전 번호와 tag 정책을 결정한다.
-- `unreleased` 내용을 실제 버전 릴리스 노트로 승격한다.
-- `scripts/mvp-local-smoke.sh` 실행 결과를 릴리스 PR에 첨부한다.
+- Release PR CI가 모두 통과한 뒤 tag를 발행한다.
+- `scripts/mvp-local-smoke.sh` 결과를 Release PR 또는 GitHub Release body에 첨부한다.
+- GitHub Wiki 원격 repository가 초기화되어 있으면 `scripts/sync-wiki-drafts.sh` 결과를 push한다.
+- GitHub Wiki push가 실패하면 GitHub Release body에 Wiki 미반영 상태를 명시한다.
 
 ## 후속 후보
 

--- a/issue-drafts/0044-v0.7.0-release-baseline.md
+++ b/issue-drafts/0044-v0.7.0-release-baseline.md
@@ -1,0 +1,50 @@
+# [Release] v0.7.0 MVP baseline
+
+## 배경
+
+`docs/releases/mvp-release-checklist.md`에 따라 1차 MVP 후보를 실제 release 기준선으로 승격해야 한다.
+
+## 목표
+
+- `docs/releases/v0.7.0.md`를 생성한다.
+- `build.gradle` version을 `0.7.0`으로 bump한다.
+- README, progress, Wiki draft의 현재 release 기준을 `v0.7.0`으로 갱신한다.
+- `unreleased` 문서를 다음 release 후보 staging 문서로 되돌린다.
+
+## 범위
+
+- Release note 문서화
+- Gradle version bump
+- README/progress/Wiki draft 정렬
+- 검증 명령 결과 수집
+
+## 범위 제외
+
+- Git tag 생성
+- GitHub Release 발행
+- GitHub Wiki 원격 push
+
+## 인수 조건
+
+- [x] `docs/releases/v0.7.0.md`가 존재한다.
+- [x] `build.gradle` version이 `0.7.0`이다.
+- [x] README와 Wiki draft가 `v0.7.0` 기준을 가리킨다.
+- [x] `unreleased`가 `v0.7.0` 이후 후보 문서로 정리된다.
+
+## 검증
+
+- `rg -n "v0.7.0|0.7.0|Release Baseline|docs/releases/v0.7.0.md" README.md build.gradle docs wiki-drafts issue-drafts`
+- `./gradlew check`
+- `./gradlew scenarioTest`
+- `./gradlew postgresScenarioTest`
+- `npm --prefix frontend run test`
+- `npm --prefix frontend run build`
+- `npm --prefix frontend run e2e`
+- `scripts/mvp-local-smoke.sh`
+- `docker compose config`
+- `git diff --check`
+
+## 리스크와 트레이드오프
+
+- 이번 PR은 release 준비 PR이며 tag와 GitHub Release 생성은 merge 이후 수행한다.
+- GitHub Wiki push는 현재 원격 Wiki repository 초기화 상태에 의존한다.

--- a/issue-drafts/README.md
+++ b/issue-drafts/README.md
@@ -92,6 +92,8 @@
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/90
 - `0043-mvp-release-checklist.md`: MVP release checklist 작업 초안
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/92
+- `0044-v0.7.0-release-baseline.md`: v0.7.0 release baseline 작업 초안
+  - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/94
 
 ## GitHub CLI로 생성
 

--- a/wiki-drafts/Domain-Rules.md
+++ b/wiki-drafts/Domain-Rules.md
@@ -15,7 +15,7 @@
 - outbox event는 relay 상태와 retry 정책을 가지며, 반복 실패 시 `MANUAL_REVIEW`로 격리된다.
 - 운영자는 manual review outbox를 조회하고 requeue하며, requeue audit trail을 확인한다.
 - 운영 API는 local admin token과 operator id header로 보호된다.
-- 현재 릴리스 후보 기준은 `docs/releases/unreleased.md`를 따른다.
+- 현재 릴리스 후보 기준은 `docs/releases/v0.7.0.md`를 따른다.
 
 ## 현재 도메인 진행 순서
 

--- a/wiki-drafts/Home.md
+++ b/wiki-drafts/Home.md
@@ -6,8 +6,8 @@
 
 ## 현재 릴리스 상태
 
-- 현재 릴리스 후보: `unreleased`
-- 기준 문서: `docs/releases/unreleased.md`
+- 현재 릴리스 후보: `v0.7.0`
+- 기준 문서: `docs/releases/v0.7.0.md`
 - 로컬 smoke 명령: `scripts/mvp-local-smoke.sh`
 - 핵심 실행 화면: React 사용자 화면과 운영자 manual review 콘솔
 
@@ -43,6 +43,6 @@
 
 - GitHub Actions 전체 gate 통과
 - `scripts/mvp-local-smoke.sh` 통과
-- `docs/releases/unreleased.md`를 버전 릴리스 노트로 승격
+- `docs/releases/v0.7.0.md` release note 확정
 - Wiki draft를 GitHub Wiki checkout에 동기화
 - 릴리스 PR에 smoke 결과와 알려진 제약을 첨부

--- a/wiki-drafts/Release-Notes.md
+++ b/wiki-drafts/Release-Notes.md
@@ -2,11 +2,11 @@
 
 이 문서는 GitHub Wiki에 게시할 릴리스 요약 초안이다.
 
-상세한 release candidate source는 `docs/releases/unreleased.md`이고, 실제 tag 발행 시 버전별 릴리스 노트로 승격한다.
+상세한 release note source는 `docs/releases/v0.7.0.md`이고, 이후 변경 후보는 `docs/releases/unreleased.md`에서 추적한다.
 
-## 현재 후보: unreleased
+## 현재 후보: v0.7.0
 
-`unreleased`는 `v0.6.0` 이후 `main`에 누적된 1차 MVP 출시 후보 변경분을 추적한다.
+`v0.7.0`은 `v0.6.0` 이후 `main`에 누적된 1차 MVP 출시 후보 변경분을 확정한 기준선이다.
 
 ## 포함된 큰 흐름
 
@@ -48,7 +48,6 @@
 ## 다음 후보
 
 - manual review requeue full E2E fixture
-- actuator 기반 health check
 - relay health/pruning operator UI
 - broker-specific Testcontainers contract
 - consumer idempotency


### PR DESCRIPTION
Closes #94

## Summary
- Promotes the MVP candidate into `docs/releases/v0.7.0.md`
- Bumps Gradle project version to `0.7.0`
- Updates README, progress, ADR references, and Wiki drafts to point at the v0.7.0 baseline
- Resets `docs/releases/unreleased.md` for post-v0.7.0 changes

## Validation
- `./gradlew check`
- `./gradlew scenarioTest`
- `./gradlew postgresScenarioTest`
- `npm --prefix frontend run test`
- `npm --prefix frontend run build`
- `npm --prefix frontend run e2e`
- `scripts/mvp-local-smoke.sh`
- `scripts/sync-wiki-drafts.sh wiki-drafts /private/tmp/ai-repo-wiki-release-check`
- `docker compose config`
- `git diff --check`

## Release Notes
- This PR prepares the release baseline only.
- Tag creation and `gh release create v0.7.0 --title "v0.7.0" --notes-file docs/releases/v0.7.0.md` should run after merge.
- GitHub Wiki push is still dependent on the remote Wiki repository being initialized.