### PR TITLE
docs: record v0.7.0 wiki publication

### DIFF
--- a/docs/progress/0045-v0.7.0-wiki-publication.md
+++ b/docs/progress/0045-v0.7.0-wiki-publication.md
@@ -1,0 +1,32 @@
+# 0045. v0.7.0 Wiki Publication
+
+## 스펙 목표
+
+- `wiki-drafts`에 정리된 MVP 문서를 실제 GitHub Wiki에 publish한다.
+- `v0.7.0` release note와 progress 문서의 Wiki 상태를 실제 상태와 맞춘다.
+
+## 완료 결과
+
+- GitHub Wiki 원격 저장소 `IMWoo94/ai-repo.wiki.git`이 초기화되어 있음을 확인했다.
+- `scripts/sync-wiki-drafts.sh wiki-drafts <wiki-checkout>`로 8개 Wiki 문서를 동기화했다.
+- GitHub Wiki 원격 `master`에 `docs: publish v0.7.0 wiki drafts` commit을 push했다.
+- `docs/releases/v0.7.0.md`, `wiki-drafts/Home.md`, `wiki-drafts/Release-Notes.md`의 Wiki 상태를 publish 완료로 갱신했다.
+
+## 검증
+
+- `git ls-remote https://github.com/IMWoo94/ai-repo.wiki.git HEAD`
+- `scripts/sync-wiki-drafts.sh wiki-drafts <wiki-checkout>`
+- `git -C <wiki-checkout> push origin HEAD`
+- `rg -n "GitHub Wiki|Wiki publish|v0.7.0" docs/releases/v0.7.0.md docs/progress/README.md wiki-drafts issue-drafts`
+- `git diff --check`
+
+## 남은 일
+
+- GitHub Wiki 화면에서 `Home`, `Release-Notes`, `QA-Scenarios`, `Architecture-Decisions` 렌더링을 사람이 최종 확인한다.
+
+## 관련 문서
+
+- `docs/releases/v0.7.0.md`
+- `wiki-drafts/Home.md`
+- `wiki-drafts/Release-Notes.md`
+- `issue-drafts/0045-v0.7.0-wiki-publication.md`

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -60,10 +60,11 @@ ADR은 “왜 그렇게 결정했는가”를 기록하고, 이 폴더는 “각
 | 0042 | [Actuator Health Smoke Endpoint](0042-actuator-health-smoke-endpoint.md) | 완료 |
 | 0043 | [MVP Release Checklist](0043-mvp-release-checklist.md) | 완료 |
 | 0044 | [v0.7.0 Release Baseline](0044-v0.7.0-release-baseline.md) | 완료 |
+| 0045 | [v0.7.0 Wiki Publication](0045-v0.7.0-wiki-publication.md) | 완료 |
 
 ## 현재 기준선
 
 - 최신 병합 기준: `main`
-- 최신 완료 기능: v0.7.0 Release Baseline
+- 최신 완료 기능: v0.7.0 Wiki Publication
 - 현재 릴리스 후보: `v0.7.0`
-- 아직 미완료: 운영자 relay health/pruning 화면, Kafka/RabbitMQ/SQS adapter, consumer idempotency, operator/admin token 분리, pruning 실행 이력, external alert channel, 승인 워크플로우, GitHub Wiki 실제 push, broker-specific Testcontainers 정책, manual review requeue full E2E fixture
+- 아직 미완료: 운영자 relay health/pruning 화면, Kafka/RabbitMQ/SQS adapter, consumer idempotency, operator/admin token 분리, pruning 실행 이력, external alert channel, 승인 워크플로우, broker-specific Testcontainers 정책, manual review requeue full E2E fixture

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -72,14 +72,13 @@ GitHub Actions에서는 다음 job이 통과해야 한다.
 - 운영자 승인 워크플로우와 external alert channel은 아직 없다.
 - admin token과 operator identity는 local header 기반이며 실제 로그인과 분리되어 있다.
 - Kafka/RabbitMQ/SQS 같은 broker-specific adapter는 아직 없다.
-- GitHub Wiki 동기화는 아직 수동 후보 문서 수준이다.
+- GitHub Wiki는 `wiki-drafts` 기준으로 publish 완료했다.
 
 ## Release operation
 
 - Release PR CI가 모두 통과한 뒤 tag를 발행한다.
 - `scripts/mvp-local-smoke.sh` 결과를 Release PR 또는 GitHub Release body에 첨부한다.
-- GitHub Wiki 원격 repository가 초기화되어 있으면 `scripts/sync-wiki-drafts.sh` 결과를 push한다.
-- GitHub Wiki push가 실패하면 GitHub Release body에 Wiki 미반영 상태를 명시한다.
+- `scripts/sync-wiki-drafts.sh` 결과를 GitHub Wiki 원격 저장소에 push했다.
 
 ## 후속 후보
 

--- a/issue-drafts/0045-v0.7.0-wiki-publication.md
+++ b/issue-drafts/0045-v0.7.0-wiki-publication.md
@@ -1,0 +1,37 @@
+# [Docs] v0.7.0 Wiki publication 기록
+
+## 배경
+
+`v0.7.0` GitHub Release 이후 GitHub Wiki 원격 저장소가 초기화되어 `wiki-drafts`를 실제 Wiki에 push할 수 있게 되었다.
+
+## 목표
+
+- Wiki publish 완료 상태를 release note와 Wiki draft에 반영한다.
+- progress 문서에서 GitHub Wiki 실제 push를 미완료 목록에서 제거한다.
+- Wiki publish 작업 흔적을 남긴다.
+
+## 범위
+
+- `docs/releases/v0.7.0.md` Wiki 상태 갱신
+- `wiki-drafts/Home.md`, `wiki-drafts/Release-Notes.md` 갱신
+- progress/issue draft 흔적 추가
+
+## 범위 제외
+
+- 기능 코드 변경
+- GitHub Wiki 화면 렌더링 수동 검수
+
+## 인수 조건
+
+- [x] `docs/releases/v0.7.0.md`가 Wiki publish 완료 상태를 기록한다.
+- [x] `docs/progress/README.md` 미완료 목록에서 GitHub Wiki 실제 push가 제거된다.
+- [x] Wiki draft release note가 publish 완료 상태를 기록한다.
+
+## 검증
+
+- `rg -n "GitHub Wiki|Wiki publish|v0.7.0" docs/releases/v0.7.0.md docs/progress/README.md wiki-drafts issue-drafts`
+- `git diff --check`
+
+## 리스크와 트레이드오프
+
+- Wiki 원격 push는 완료됐지만, 브라우저 렌더링 최종 확인은 사람이 수행해야 한다.

--- a/issue-drafts/README.md
+++ b/issue-drafts/README.md
@@ -94,6 +94,8 @@
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/92
 - `0044-v0.7.0-release-baseline.md`: v0.7.0 release baseline 작업 초안
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/94
+- `0045-v0.7.0-wiki-publication.md`: v0.7.0 Wiki publication 작업 초안
+  - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/96
 
 ## GitHub CLI로 생성
 

--- a/wiki-drafts/Home.md
+++ b/wiki-drafts/Home.md
@@ -8,6 +8,7 @@
 
 - 현재 릴리스 후보: `v0.7.0`
 - 기준 문서: `docs/releases/v0.7.0.md`
+- Wiki publish 상태: `v0.7.0` 기준 publish 완료
 - 로컬 smoke 명령: `scripts/mvp-local-smoke.sh`
 - 핵심 실행 화면: React 사용자 화면과 운영자 manual review 콘솔
 

--- a/wiki-drafts/Release-Notes.md
+++ b/wiki-drafts/Release-Notes.md
@@ -43,7 +43,7 @@
 - 운영자 승인 워크플로우와 external alert channel은 아직 없다.
 - admin token과 operator identity는 local header 기반이다.
 - Kafka/RabbitMQ/SQS 같은 broker-specific adapter는 아직 없다.
-- GitHub Wiki actual publication은 release operation으로 수행한다.
+- GitHub Wiki actual publication은 `v0.7.0` 기준으로 완료했다.
 
 ## 다음 후보
 


### PR DESCRIPTION
Closes #96

## Summary
- Records that v0.7.0 wiki drafts were published to the GitHub Wiki remote
- Updates v0.7.0 release notes and Wiki drafts to remove stale Wiki-not-published wording
- Removes GitHub Wiki actual push from the current incomplete list

## Validation
- `rg -n "GitHub Wiki|Wiki publish|v0.7.0|실제 push" docs/releases/v0.7.0.md docs/progress/README.md docs/progress/0045-v0.7.0-wiki-publication.md wiki-drafts issue-drafts`
- `git diff --check`

## Wiki Evidence
- `git ls-remote https://github.com/IMWoo94/ai-repo.wiki.git HEAD`
- `scripts/sync-wiki-drafts.sh wiki-drafts <wiki-checkout>`
- `git -C <wiki-checkout> push origin HEAD`