### PR TITLE
ci: enforce dev rules check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,21 @@ permissions:
   contents: read
 
 jobs:
+  dev-rules-check:
+    name: Dev Rules Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run dev rules check
+        env:
+          AI_REPO_DEV_RULES_BASE: ${{ github.event_name == 'push' && github.event.before || '' }}
+        run: scripts/check-dev-rules.sh
+
   gradle-check:
     name: Gradle Check
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -118,12 +118,13 @@ GitHub 작업 템플릿:
 ./gradlew scenarioTest
 ./gradlew postgresScenarioTest
 ./gradlew check
+scripts/check-dev-rules.sh
 cd frontend && npm run test
 cd frontend && npm run build
 cd frontend && npm run e2e
 ```
 
-현재 브랜치에는 Gradle Wrapper와 React/Vite 프론트가 포함되어 있으므로 위 명령을 표준 품질 게이트로 사용합니다. `test`는 단위/API/저장소 중심의 빠른 회귀 게이트이고, `scenarioTest`는 대표 사용자/운영 흐름을 검증하는 시나리오 게이트입니다. `postgresScenarioTest`는 Docker/Testcontainers 기반 실제 PostgreSQL profile 대표 흐름을 검증합니다. `frontend` unit test는 React 상태와 API payload 회귀를 빠르게 검증하고, `frontend` build는 TypeScript/Vite smoke gate이며, `frontend` E2E는 브라우저에서 Vite proxy와 Spring Boot API 연결을 검증합니다.
+현재 브랜치에는 Gradle Wrapper와 React/Vite 프론트가 포함되어 있으므로 위 명령을 표준 품질 게이트로 사용합니다. `test`는 단위/API/저장소 중심의 빠른 회귀 게이트이고, `scenarioTest`는 대표 사용자/운영 흐름을 검증하는 시나리오 게이트입니다. `postgresScenarioTest`는 Docker/Testcontainers 기반 실제 PostgreSQL profile 대표 흐름을 검증합니다. `scripts/check-dev-rules.sh`는 코드, DB, 프론트, CI/script 변경이 문서와 테스트 갱신 없이 들어오는지 사전에 확인합니다. `frontend` unit test는 React 상태와 API payload 회귀를 빠르게 검증하고, `frontend` build는 TypeScript/Vite smoke gate이며, `frontend` E2E는 브라우저에서 Vite proxy와 Spring Boot API 연결을 검증합니다.
 
 로컬 테스트 실행 순서와 실패 대응은 [Local Test Guide](docs/testing/local-test-guide.md)를 따릅니다.
 시나리오 테스트 추가 기준은 [Scenario Test Strategy](docs/testing/scenario-test-strategy.md)를 따릅니다.

--- a/docs/progress/0046-dev-rules-check-admin-auth-guard-test.md
+++ b/docs/progress/0046-dev-rules-check-admin-auth-guard-test.md
@@ -1,0 +1,34 @@
+# Dev Rules Check and Admin Auth Guard Test
+
+## 스펙 목표
+
+- 코드, DB, 프론트, CI/script 변경이 문서와 테스트 갱신 없이 들어오는 상황을 CI에서 조기에 탐지한다.
+- 운영 API 인증의 핵심 정책인 admin token과 operator id 검증을 controller slice보다 작은 단위 테스트로 고정한다.
+
+## 완료 결과
+
+- `scripts/check-dev-rules.sh`를 추가했다.
+  - 변경 파일 기준으로 backend, DB migration, frontend, CI/script 변경의 문서 동반 여부를 확인한다.
+  - unstaged/staged diff와 untracked file을 함께 스캔한다.
+  - macOS 기본 Bash 3.x와 호환되도록 `mapfile`에 의존하지 않는다.
+  - backend production 변경에는 `src/test/java` 테스트 동반을 요구한다.
+  - frontend source 변경에는 component test 또는 E2E 동반을 요구한다.
+  - DB migration 변경에는 ADR 동반을 요구한다.
+- GitHub Actions에 `Dev Rules Check` job을 추가했다.
+  - push event에서는 `github.event.before`를 base ref로 넘겨 main push에서도 no-op이 되지 않게 했다.
+- `AdminAuthorizationGuardTest`를 추가해 다음 정책을 검증했다.
+  - 유효한 admin token은 operator id를 trim해서 인증한다.
+  - 누락/오류 admin token은 `AdminAuthenticationException`으로 거부한다.
+  - token 검증 후 operator id 누락은 `AdminAuthorizationException`으로 거부한다.
+- README, local test guide, unreleased release candidate note를 최신화했다.
+
+## 검증
+
+- `scripts/check-dev-rules.sh`
+- `./gradlew test --no-daemon`
+- `git diff --check`
+
+## 남은 일
+
+- dev rules가 실제 팀 운영에서 너무 엄격하거나 느슨한지 다음 PR들에서 관찰한다.
+- 변경 성격이 더 세분화되면 `.dev/rules` 같은 선언형 rule 파일로 분리할지 검토한다.

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -61,6 +61,7 @@ ADR은 “왜 그렇게 결정했는가”를 기록하고, 이 폴더는 “각
 | 0043 | [MVP Release Checklist](0043-mvp-release-checklist.md) | 완료 |
 | 0044 | [v0.7.0 Release Baseline](0044-v0.7.0-release-baseline.md) | 완료 |
 | 0045 | [v0.7.0 Wiki Publication](0045-v0.7.0-wiki-publication.md) | 완료 |
+| 0046 | [Dev Rules Check and Admin Auth Guard Test](0046-dev-rules-check-admin-auth-guard-test.md) | 완료 |
 
 ## 현재 기준선
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -8,7 +8,9 @@
 
 ## 후보 범위
 
-- 아직 없음
+- CI에 `Dev Rules Check` job을 추가해 코드/DB/프론트/CI 변경 시 문서와 테스트 동기화 누락을 빠르게 탐지한다.
+- macOS 기본 Bash에서도 `scripts/check-dev-rules.sh`가 동작하도록 배열 입력 처리를 POSIX 친화적인 루프로 구성한다.
+- `AdminAuthorizationGuard` 단위 테스트를 추가해 admin token과 operator id 검증 정책을 controller test보다 작은 범위에서 고정한다.
 
 ## MVP 출시 판단 기준
 
@@ -31,6 +33,7 @@
 ./gradlew check
 ./gradlew scenarioTest
 ./gradlew postgresScenarioTest
+scripts/check-dev-rules.sh
 npm --prefix frontend run test
 npm --prefix frontend run build
 npm --prefix frontend run e2e
@@ -41,6 +44,7 @@ git diff --check
 
 GitHub Actions에서는 다음 job이 통과해야 한다.
 
+- `Dev Rules Check`
 - `Gradle Check`
 - `Scenario Test`
 - `PostgreSQL Scenario Test`

--- a/docs/reviews/2026-05-23-dev-rules-admin-auth-guard-codex-review.md
+++ b/docs/reviews/2026-05-23-dev-rules-admin-auth-guard-codex-review.md
@@ -1,0 +1,37 @@
+# Codex Review: Dev Rules Check and Admin Auth Guard Test
+
+## Review scope
+
+- Reviewer: Codex review agent
+- Perspective: DevOps, backend, QA/test
+- Target: uncommitted changes for `agent/daily-improvements-20260523`
+
+## Findings
+
+### P2: Include untracked files in local rule scan
+
+- File: `scripts/check-dev-rules.sh`
+- Summary: The script originally scanned merge-base diff, unstaged diff, and staged diff, but not untracked files. Running the gate before staging could miss newly created production/test/doc files.
+- Classification: 수용
+- Applied change: Added `git ls-files --others --exclude-standard` to the changed-file collection.
+
+### P2: Pass push base ref to dev-rules check
+
+- File: `.github/workflows/ci.yml`
+- Summary: On push runs, defaulting to `origin/main` can resolve to the pushed commit and make the check a no-op in a clean CI workspace.
+- Classification: 수용
+- Applied change: Passed `github.event.before` through `AI_REPO_DEV_RULES_BASE` for push events.
+
+## 반박
+
+- 없음
+
+## 후속 과제
+
+- 실제 PR과 main push CI에서 rule strictness를 관찰하고, 필요하면 rule definitions를 `.dev/rules` 같은 선언형 파일로 분리한다.
+
+## Re-verification plan
+
+- `scripts/check-dev-rules.sh`
+- `./gradlew test --no-daemon`
+- `git diff --check`

--- a/docs/testing/local-test-guide.md
+++ b/docs/testing/local-test-guide.md
@@ -12,6 +12,7 @@
 | 대표 업무 흐름 | `./gradlew scenarioTest` | 충전/송금/원장/감사/outbox 시나리오 |
 | PostgreSQL 대표 흐름 | `./gradlew postgresScenarioTest` | Testcontainers PostgreSQL, Flyway, postgres profile 시나리오 |
 | 백엔드 전체 게이트 | `./gradlew check` | Gradle 표준 검증 |
+| 개발 규칙 검증 | `scripts/check-dev-rules.sh` | 변경 파일 기준 문서/테스트 동기화 누락 |
 | 프론트 컴포넌트 테스트 | `cd frontend && npm run test` | React 상태, API payload, 오류 메시지 |
 | 프론트 타입/번들 검증 | `cd frontend && npm run build` | TypeScript, Vite build |
 | 브라우저 E2E | `cd frontend && npm run e2e` | Spring Boot API, Vite proxy, React 화면 흐름 |
@@ -25,6 +26,7 @@
 ./gradlew scenarioTest
 ./gradlew postgresScenarioTest
 ./gradlew check
+scripts/check-dev-rules.sh
 cd frontend
 npm run test
 npm run build
@@ -96,6 +98,21 @@ npm run e2e
 ### `./gradlew check`
 
 Gradle 표준 검증 게이트다. 현재는 `test`를 포함하며, CI의 `Gradle Check` job과 대응된다.
+
+## 개발 규칙 검증
+
+### `scripts/check-dev-rules.sh`
+
+변경 파일 목록을 기준으로 구현, DB migration, 프론트, CI/script 변경이 문서와 테스트 갱신 없이 들어오는지 확인한다.
+
+검증 대상:
+
+- backend production 변경 시 `src/test/java` 테스트 동반 여부
+- frontend source 변경 시 component test 또는 E2E 동반 여부
+- DB migration 변경 시 ADR 동반 여부
+- 코드, DB, 프론트, CI/script 변경 시 README, ADR, progress, release note, testing guide, frontend doc, wiki draft, issue draft 중 하나 이상 갱신 여부
+
+CI의 `Dev Rules Check` job과 대응된다.
 
 ## 프론트 테스트
 
@@ -207,6 +224,7 @@ scripts/mvp-local-smoke.sh
 
 | CI job | 로컬 명령 |
 | --- | --- |
+| `Dev Rules Check` | `scripts/check-dev-rules.sh` |
 | `Gradle Check` | `./gradlew check` |
 | `Scenario Test` | `./gradlew scenarioTest` |
 | `PostgreSQL Scenario Test` | `./gradlew postgresScenarioTest` |

--- a/scripts/check-dev-rules.sh
+++ b/scripts/check-dev-rules.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+info() {
+  echo "- $1"
+}
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  fail "scripts/check-dev-rules.sh must run inside a git worktree"
+fi
+
+BASE_REF="${AI_REPO_DEV_RULES_BASE:-}"
+if [[ -z "$BASE_REF" ]]; then
+  if git rev-parse --verify origin/main >/dev/null 2>&1; then
+    BASE_REF="$(git merge-base HEAD origin/main)"
+  elif git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+    BASE_REF="HEAD~1"
+  else
+    BASE_REF="HEAD"
+  fi
+fi
+
+changed_files=()
+while IFS= read -r changed_file; do
+  [[ -n "$changed_file" ]] && changed_files+=("$changed_file")
+done < <(
+  {
+    git diff --name-only "$BASE_REF"...HEAD 2>/dev/null || git diff --name-only "$BASE_REF" HEAD
+    git diff --name-only
+    git diff --cached --name-only
+    git ls-files --others --exclude-standard
+  } | sort -u
+)
+
+if [[ ${#changed_files[@]} -eq 0 ]]; then
+  info "no changed files detected"
+  exit 0
+fi
+
+matches_any() {
+  local pattern
+  for pattern in "$@"; do
+    printf '%s\n' "${changed_files[@]}" | grep -Eq "$pattern" && return 0
+  done
+  return 1
+}
+
+require_docs_for() {
+  local label="$1"
+  shift
+  local doc_patterns=(
+    '^README\.md$'
+    '^docs/adr/'
+    '^docs/progress/'
+    '^docs/releases/'
+    '^docs/testing/'
+    '^docs/frontend/'
+    '^wiki-drafts/'
+    '^issue-drafts/'
+  )
+
+  if matches_any "$@" && ! matches_any "${doc_patterns[@]}"; then
+    fail "$label changes require a README/docs/progress/release/wiki/issue update"
+  fi
+}
+
+require_docs_for "backend" '^src/main/java/' '^src/test/java/' '^build\.gradle$' '^settings\.gradle$'
+require_docs_for "database" '^src/main/resources/db/migration/' '^src/main/resources/db/postgresql/'
+require_docs_for "frontend" '^frontend/src/' '^frontend/e2e/' '^frontend/package(-lock)?\.json$' '^frontend/playwright\.config\.'
+require_docs_for "CI or script" '^\.github/workflows/' '^scripts/'
+
+if matches_any '^src/main/java/' && ! matches_any '^src/test/java/'; then
+  fail "backend production changes require a matching src/test/java update"
+fi
+
+if matches_any '^frontend/src/' && ! matches_any '^frontend/src/.*\.test\.(ts|tsx)$' '^frontend/e2e/'; then
+  fail "frontend source changes require a component or E2E test update"
+fi
+
+if matches_any '^src/main/resources/db/migration/' && ! matches_any '^docs/adr/'; then
+  fail "database migration changes require an ADR update"
+fi
+
+info "dev rules check passed for ${#changed_files[@]} changed file(s)"

--- a/src/test/java/com/imwoo/airepo/wallet/api/AdminAuthorizationGuardTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/api/AdminAuthorizationGuardTest.java
@@ -1,0 +1,41 @@
+package com.imwoo.airepo.wallet.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class AdminAuthorizationGuardTest {
+
+    private final AdminAuthorizationGuard guard = new AdminAuthorizationGuard(
+            new AdminAuthorizationProperties("local-ops-token")
+    );
+
+    @Test
+    void authenticatesValidAdminTokenAndTrimsOperatorId() {
+        AdminOperator operator = guard.authenticate("local-ops-token", " ops-user ");
+
+        assertThat(operator.operatorId()).isEqualTo("ops-user");
+    }
+
+    @Test
+    void rejectsMissingAdminTokenBeforeOperatorValidation() {
+        assertThatThrownBy(() -> guard.authenticate(" ", "ops-user"))
+                .isInstanceOf(AdminAuthenticationException.class)
+                .hasMessage("admin token is required");
+    }
+
+    @Test
+    void rejectsInvalidAdminToken() {
+        assertThatThrownBy(() -> guard.authenticate("wrong-token", "ops-user"))
+                .isInstanceOf(AdminAuthenticationException.class)
+                .hasMessage("admin token is invalid");
+    }
+
+    @Test
+    void rejectsMissingOperatorIdAfterSuccessfulTokenValidation() {
+        assertThatThrownBy(() -> guard.authenticate("local-ops-token", " "))
+                .isInstanceOf(AdminAuthorizationException.class)
+                .hasMessage("operator id is required");
+    }
+}


### PR DESCRIPTION
## Summary
- add Dev Rules Check CI job and local script for docs/test synchronization
- add AdminAuthorizationGuard unit tests for admin token/operator id policy
- update README, local test guide, progress, release notes, and Codex review record

## Selected improvements
1. CI/dev rules gate for documentation and test synchronization
2. Focused AdminAuthorizationGuard unit coverage

## Verification
- scripts/check-dev-rules.sh
- ./gradlew test --no-daemon
- git diff --check

## Review
- Codex review recorded in docs/reviews/2026-05-23-dev-rules-admin-auth-guard-codex-review.md
- Accepted P2 findings: include untracked files in dev-rule scan and pass push base ref in CI
