### PR TITLE
test: cover health policy configuration guard rails

### DIFF
--- a/docs/progress/0066-health-policy-configuration-tests.md
+++ b/docs/progress/0066-health-policy-configuration-tests.md
@@ -1,0 +1,23 @@
+# 0066 Health Policy Configuration Tests
+
+## 스펙 목표
+
+- Outbox relay health policy의 설정값 변환과 guard rail을 단위 테스트로 고정한다.
+- Outbox consumer duplicate health policy의 설정값 변환과 guard rail을 단위 테스트로 고정한다.
+- 운영 alert/health threshold 변경 시 잘못된 설정이 조기에 실패하도록 회귀 기준을 보강한다.
+
+## 완료 결과
+
+- `OutboxRelayHealthPolicyTest`를 추가해 sample size, 연속 실패 임계값, failure rate percent, last success age minute 설정을 검증했다.
+- `OperationOutboxConsumerHealthPolicyTest`를 추가해 duplicate count, warning/critical duplicate rate percent, window minute 설정을 검증했다.
+- 음수/0/상한 초과/임계값 역전 설정이 명확한 예외 메시지로 거부되는지 확인했다.
+
+## 검증
+
+- `./gradlew test --tests '*HealthPolicyTest'`
+- `./gradlew test`
+- `scripts/check-dev-rules.sh`
+
+## 남은 일
+
+- 실제 운영 환경별 threshold 튜닝값은 관측 데이터가 쌓인 뒤 별도 ADR 또는 운영 가이드에서 조정한다.

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -81,10 +81,11 @@ ADR은 “왜 그렇게 결정했는가”를 기록하고, 이 폴더는 “각
 | 0063 | [Operational Alert Suppression and Pruning](0063-operational-alert-suppression-pruning.md) | 완료 |
 | 0064 | [Slack Webhook Operational Alert Publisher](0064-slack-webhook-operational-alert-publisher.md) | 완료 |
 | 0065 | [Admin API Path Matching Hardening](0065-admin-api-path-matching-hardening.md) | 완료 |
+| 0066 | [Health Policy Configuration Tests](0066-health-policy-configuration-tests.md) | 완료 |
 
 ## 현재 기준선
 
 - 최신 병합 기준: `main`
-- 최신 완료 기능: Admin API Path Matching Hardening
+- 최신 완료 기능: Health Policy Configuration Tests
 - 현재 릴리스 후보: `v0.7.0`
 - 아직 미완료: Kafka/RabbitMQ/SQS adapter, pruning 실행 이력, Slack 발행 실패 record와 재시도 정책, broker-specific Testcontainers 정책, broker replay window별 retention 권장값, 실제 identity/role scope 연동, 운영 alert 화면 연결

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -29,6 +29,7 @@
 - Operational alert suppression and pruning
 - Slack webhook operational alert publisher
 - `.dev/rules` 자동 문서/테스트 동기화 체크
+- Outbox relay/consumer health policy 설정 guard rail 단위 테스트
 
 ## MVP 출시 판단 기준
 

--- a/docs/reviews/2026-05-26-health-policy-configuration-tests-codex-review.md
+++ b/docs/reviews/2026-05-26-health-policy-configuration-tests-codex-review.md
@@ -1,0 +1,36 @@
+# Codex Review: Health Policy Configuration Tests
+
+**Date**: 2026-05-26
+**Branch**: `agent/daily-improvements-20260526`
+**Reviewer**: Codex review agent
+**Scope**: QA/test-focused review for relay/consumer health policy tests and documentation sync.
+
+## Summary
+
+Codex reviewed the uncommitted changes, including the new `OutboxRelayHealthPolicyTest`, `OperationOutboxConsumerHealthPolicyTest`, and documentation updates.
+
+## Findings
+
+No findings.
+
+Codex summary:
+
+> The changes add focused unit tests for the health policy configuration guard rails and update related documentation. The new tests compile and pass with `./gradlew test --tests '*HealthPolicyTest'`, and I did not identify any introduced correctness issues.
+
+## 반영 분류
+
+### 수용
+
+- 없음.
+
+### 반박
+
+- 없음.
+
+### 후속 과제
+
+- 없음.
+
+## Verification During Review
+
+- `./gradlew test --tests '*HealthPolicyTest'` passed during the review run.

--- a/docs/testing/local-test-guide.md
+++ b/docs/testing/local-test-guide.md
@@ -67,6 +67,7 @@ npm run e2e
 - HTTP consumer adapter duplicate no-op과 receipt side effect
 - HTTP publisher에서 consumer endpoint로 이어지는 publish→consume loop
 - consumer monitoring admin API의 processed, duplicate, receipt count
+- relay/consumer health threshold 설정값 변환과 guard rail
 
 ### `./gradlew scenarioTest`
 

--- a/src/test/java/com/imwoo/airepo/wallet/application/OperationOutboxConsumerHealthPolicyTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/application/OperationOutboxConsumerHealthPolicyTest.java
@@ -1,0 +1,44 @@
+package com.imwoo.airepo.wallet.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class OperationOutboxConsumerHealthPolicyTest {
+
+    @Test
+    void convertsConfiguredPercentToRuntimeDuplicateRates() {
+        OperationOutboxConsumerHealthPolicy policy = new OperationOutboxConsumerHealthPolicy(3, 15, 65, 10);
+
+        assertThat(policy.minDuplicateEventCount()).isEqualTo(3);
+        assertThat(policy.warningDuplicateRate()).isEqualTo(0.15);
+        assertThat(policy.criticalDuplicateRate()).isEqualTo(0.65);
+        assertThat(policy.windowMinutes()).isEqualTo(10);
+    }
+
+    @Test
+    void rejectsInvalidDuplicateHealthConfiguration() {
+        assertThatThrownBy(() -> new OperationOutboxConsumerHealthPolicy(0, 20, 50, 5))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("outbox consumer health min-duplicate-event-count must be positive");
+        assertThatThrownBy(() -> new OperationOutboxConsumerHealthPolicy(3, 20, 50, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("outbox consumer health window-minutes must be 1..1440");
+        assertThatThrownBy(() -> new OperationOutboxConsumerHealthPolicy(3, 20, 50, 1441))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("outbox consumer health window-minutes must be 1..1440");
+        assertThatThrownBy(() -> new OperationOutboxConsumerHealthPolicy(3, 0, 50, 5))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("outbox consumer health warning-duplicate-rate-percent must be 1..100");
+        assertThatThrownBy(() -> new OperationOutboxConsumerHealthPolicy(3, 101, 101, 5))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("outbox consumer health warning-duplicate-rate-percent must be 1..100");
+        assertThatThrownBy(() -> new OperationOutboxConsumerHealthPolicy(3, 20, 19, 5))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("outbox consumer health critical-duplicate-rate-percent must be warning..100");
+        assertThatThrownBy(() -> new OperationOutboxConsumerHealthPolicy(3, 20, 101, 5))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("outbox consumer health critical-duplicate-rate-percent must be warning..100");
+    }
+}

--- a/src/test/java/com/imwoo/airepo/wallet/application/OutboxRelayHealthPolicyTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/application/OutboxRelayHealthPolicyTest.java
@@ -1,0 +1,43 @@
+package com.imwoo.airepo.wallet.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class OutboxRelayHealthPolicyTest {
+
+    @Test
+    void convertsConfiguredPercentAndMinutesToRuntimeThresholds() {
+        OutboxRelayHealthPolicy policy = new OutboxRelayHealthPolicy(7, 2, 4, 25, 30);
+
+        assertThat(policy.sampleSize()).isEqualTo(7);
+        assertThat(policy.warningConsecutiveFailures()).isEqualTo(2);
+        assertThat(policy.criticalConsecutiveFailures()).isEqualTo(4);
+        assertThat(policy.warningFailureRate()).isEqualTo(0.25);
+        assertThat(policy.criticalLastSuccessAge()).isEqualTo(Duration.ofMinutes(30));
+    }
+
+    @Test
+    void rejectsInvalidThresholdConfiguration() {
+        assertThatThrownBy(() -> new OutboxRelayHealthPolicy(0, 2, 4, 25, 30))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("outbox relay health sample-size must be positive");
+        assertThatThrownBy(() -> new OutboxRelayHealthPolicy(7, 0, 4, 25, 30))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("outbox relay health warning-consecutive-failures must be positive");
+        assertThatThrownBy(() -> new OutboxRelayHealthPolicy(7, 3, 2, 25, 30))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("outbox relay health critical-consecutive-failures must be greater than or equal to warning threshold");
+        assertThatThrownBy(() -> new OutboxRelayHealthPolicy(7, 2, 4, 0, 30))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("outbox relay health warning-failure-rate-percent must be 1..100");
+        assertThatThrownBy(() -> new OutboxRelayHealthPolicy(7, 2, 4, 101, 30))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("outbox relay health warning-failure-rate-percent must be 1..100");
+        assertThatThrownBy(() -> new OutboxRelayHealthPolicy(7, 2, 4, 25, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("outbox relay health critical-last-success-age-minutes must be positive");
+    }
+}

--- a/wiki-drafts/Architecture-Decisions.md
+++ b/wiki-drafts/Architecture-Decisions.md
@@ -104,6 +104,7 @@
 | Operational alert suppression/pruning | 같은 alert의 짧은 시간 중복 저장을 막고 보존 기간 기준으로 삭제 | suppression 기준이 reason 문자열에 의존 |
 | Slack webhook operational alert publisher | Incoming Webhook 호환 text payload로 push channel 계약 고정 | 발행 실패 record와 재시도 정책은 후속 과제 |
 | Admin API path matching hardening | 인증·감사 필터가 공통 segment-aware matcher로 root/sub-path만 운영 API로 분류 | Spring Security matcher 목록과 완전한 단일 source of truth는 후속 과제 |
+| Health policy configuration tests | relay/consumer health threshold 설정의 percent/minute 변환과 guard rail을 단위 테스트로 고정 | 실제 운영 threshold 튜닝은 관측 데이터 기반 후속 과제 |
 | Wiki는 요약, ADR은 결정 | 포트폴리오 설명성과 PR 검증성 모두 확보 | Wiki 하나에 모든 결정을 몰아넣는 단순성 |
 
 ## 다음 구조 후보


### PR DESCRIPTION
## Summary
- add unit tests for outbox relay health policy threshold conversion and invalid configuration guard rails
- add unit tests for outbox consumer duplicate health policy threshold conversion and invalid configuration guard rails
- update progress, release candidate notes, local test guide, wiki draft, and Codex review record

## Validation
- ./gradlew test --tests '*HealthPolicyTest'
- ./gradlew test
- scripts/check-dev-rules.sh
- git diff --check

## Domain rule changes
- None. Test/documentation hardening only.

## Review
- Codex review completed: docs/reviews/2026-05-26-health-policy-configuration-tests-codex-review.md
