### PR TITLE
fix: recover idempotent result on duplicate-key race (#104)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ frontend/node_modules/
 frontend/dist/
 frontend/playwright-report/
 frontend/test-results/
+.claude/
+.understand-anything/

--- a/docs/adr/0057-idempotency-duplicate-key-recovery.md
+++ b/docs/adr/0057-idempotency-duplicate-key-recovery.md
@@ -1,0 +1,53 @@
+# ADR-0057: Idempotency Duplicate-Key Recovery
+
+## 상태
+
+Accepted
+
+## 배경
+
+charge/transfer는 멱등성을 위해 두 단계로 동작했다. 먼저 `InMemoryWalletCommandService`가 `findOperation`으로 기존 operation을 조회하고, 없으면 repository의 `applyCharge`/`applyTransfer`가 별도 트랜잭션에서 잔액 변경과 함께 `wallet_operations`에 idempotency key를 INSERT한다. `wallet_operations.idempotency_key`는 PRIMARY KEY이므로 중복 INSERT는 DB에서 거부된다.
+
+이 check-then-act는 단일 JVM에서는 service의 `synchronized`가 직렬화하여 안전하다. 그러나 멀티-JVM(혹은 멀티 인스턴스) 배포에서는 두 요청이 서로 다른 JVM에서 동시에 `findOperation`을 빈 결과로 보고 둘 다 apply 단계로 진입할 수 있다. 이때 늦게 INSERT하는 쪽(레이스 패자)은 `DuplicateKeyException`을 만나고, `executeWithLockTimeout`은 lock timeout만 변환하므로 이 예외는 그대로 전파되어 핸들러가 없는 `DuplicateKeyException` → HTTP 500이 된다.
+
+멱등성 API의 핵심 계약은 "같은 요청을 재시도하면 같은 결과를 안전하게 받는다"이다. 레이스 패자가 500을 받는 것은 이 계약을 위반하며, 클라이언트 재시도 안전성을 깨뜨린다.
+
+## 결정
+
+멱등성 INSERT 충돌을 예외가 아니라 **회복(recovery)** 으로 처리한다. apply 경로에서 `DuplicateKeyException`이 발생하면 같은 트랜잭션 밖에서 `findOperation`으로 이미 커밋된 operation을 재조회하여 그 결과를 반환한다.
+
+| 항목 | 결정 |
+| --- | --- |
+| 회복 위치 | repository apply 경로 (`JdbcWalletRepository.executeIdempotentOperation`) |
+| 충돌 처리 | `DuplicateKeyException` → `findOperation` 재조회 후 기존 record 반환 |
+| fingerprint 검증 | 회복된 record의 fingerprint가 다르면 `IdempotencyKeyConflictException` |
+| 반환 타입 | `applyCharge`/`applyTransfer`가 `WalletOperationOutcome(record, created)` 반환 |
+| created 의미 | 새로 적용하면 `created=true`, 회복하면 `created=false` |
+| service 반영 | `WalletCommandResult.created`가 outcome의 created를 그대로 전달 |
+| 구현 일관성 | `InMemoryWalletRepository`도 동일하게 회복/충돌 계약을 구현 |
+
+## 트레이드오프
+
+### 장점
+
+- 레이스 패자가 500 대신 멱등 결과(기존 operationId, 동일 잔액)를 받는다.
+- 부작용(잔액/거래/원장/감사/아웃박스)은 패자 트랜잭션 롤백으로 정확히 한 번만 발생한다.
+- `created` 플래그가 "새로 생성"과 "회복"을 정확히 구분하여 호출자가 의미를 신뢰할 수 있다.
+- 회복은 DB 트랜잭션 경계에서 강제되므로 service-level check 우회 여부와 무관하게 안전하다.
+
+### 비용
+
+- `applyCharge`/`applyTransfer` 반환 타입이 `WalletOperationRecord` → `WalletOperationOutcome`으로 바뀌어 두 repository 구현과 service가 함께 변경된다.
+- 회복 시 `findOperation` 재조회가 1회 추가되지만, 레이스 충돌이라는 드문 경로에서만 발생한다.
+
+## 검증 기준
+
+- 이미 적용된 idempotency key로 `applyCharge`/`applyTransfer`를 호출하면 예외 없이 기존 record를 `created=false`로 반환한다.
+- 같은 key에 다른 fingerprint면 회복하지 않고 `IdempotencyKeyConflictException`을 던진다.
+- 실제 PostgreSQL에서 같은 key로 동시 charge하면 정확히 하나는 `created=true`, 하나는 `created=false`이고 부작용은 한 번만 남는다.
+- 충돌 시 부분 상태(잔액/원장/감사)가 남지 않는다.
+
+## 후속 작업
+
+- 실제 사용자 인증/소유권(per-user wallet ownership) 도입 시 idempotency fingerprint에 userId를 포함한다.
+- 회복 경로 빈도를 관측할 수 있는 metric을 metrics 도입 작업과 함께 검토한다.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -71,3 +71,5 @@ ADR은 이 저장소에서 중요한 결정의 source of truth입니다. README�
 | ADR-0053 | Operational Alert Suppression and Pruning | Accepted |
 | ADR-0054 | Slack Webhook Operational Alert Publisher | Accepted |
 | ADR-0055 | Admin API Path Matching Hardening | Accepted |
+| ADR-0056 | Test Fixture Admin Boundary | Accepted |
+| ADR-0057 | Idempotency Duplicate-Key Recovery | Accepted |

--- a/docs/progress/0068-idempotency-duplicate-key-recovery.md
+++ b/docs/progress/0068-idempotency-duplicate-key-recovery.md
@@ -1,0 +1,28 @@
+# Idempotency Duplicate-Key Recovery
+
+## 스펙 목표
+
+멀티-JVM 레이스에서 멱등성 INSERT 충돌을 만난 패자가 HTTP 500이 아니라 기존 멱등 결과를 받도록, repository apply 경로에서 `DuplicateKeyException`을 회복으로 처리한다.
+
+## 완료 결과
+
+- `JdbcWalletRepository`에 `executeIdempotentOperation`/`recoverIdempotentRecord`를 추가하여 apply 중 `DuplicateKeyException`이 발생하면 `findOperation`으로 기존 operation을 재조회해 반환한다.
+- 회복된 record의 fingerprint가 요청과 다르면 `IdempotencyKeyConflictException`을 던지도록 했다.
+- `applyCharge`/`applyTransfer` 반환 타입을 `WalletOperationOutcome(record, created)`로 바꿔 "새로 적용"과 "회복"을 구분했다.
+- `InMemoryWalletRepository`도 동일한 회복/충돌 계약을 구현했다(기존에는 같은 key를 조용히 덮어썼다).
+- `InMemoryWalletCommandService`가 outcome의 `created`를 `WalletCommandResult`에 그대로 전달하여, 회복된 결과가 `created=false`로 보고되도록 했다.
+- `JdbcWalletRepositoryTest`에 이미 적용된 key의 회복, 다른 fingerprint 충돌 회귀 테스트를 추가했다.
+- `JdbcWalletRepositoryRollbackTest`의 충돌 시나리오 기대 예외를 `DuplicateKeyException`에서 `IdempotencyKeyConflictException`으로 갱신했다(롤백 검증 자체는 유지).
+- `PostgresContainerWalletRepositoryTest`에 실제 PostgreSQL 동시 charge 레이스 테스트를 추가하여 정확히 하나는 `created=true`, 하나는 `created=false`이고 부작용이 한 번만 남음을 검증했다.
+
+## 검증
+
+- `./gradlew test`
+- `./gradlew scenarioTest`
+- `./gradlew postgresScenarioTest`
+- `scripts/check-dev-rules.sh`
+
+## 남은 일
+
+- 실제 사용자 인증/소유권 도입 시 idempotency fingerprint에 userId를 포함한다.
+- 회복 경로 빈도를 관측할 수 있는 metric을 metrics 도입 작업과 함께 검토한다.

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -81,10 +81,11 @@ ADR은 “왜 그렇게 결정했는가”를 기록하고, 이 폴더는 “각
 | 0063 | [Operational Alert Suppression and Pruning](0063-operational-alert-suppression-pruning.md) | 완료 |
 | 0064 | [Slack Webhook Operational Alert Publisher](0064-slack-webhook-operational-alert-publisher.md) | 완료 |
 | 0065 | [Admin API Path Matching Hardening](0065-admin-api-path-matching-hardening.md) | 완료 |
+| 0068 | [Idempotency Duplicate-Key Recovery](0068-idempotency-duplicate-key-recovery.md) | 완료 |
 
 ## 현재 기준선
 
 - 최신 병합 기준: `main`
-- 최신 완료 기능: Admin API Path Matching Hardening
+- 최신 완료 기능: Idempotency Duplicate-Key Recovery
 - 현재 릴리스 후보: `v0.7.0`
 - 아직 미완료: Kafka/RabbitMQ/SQS adapter, pruning 실행 이력, Slack 발행 실패 record와 재시도 정책, broker-specific Testcontainers 정책, broker replay window별 retention 권장값, 실제 identity/role scope 연동, 운영 alert 화면 연결

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -28,6 +28,9 @@
 - Operational alert record channel
 - Operational alert suppression and pruning
 - Slack webhook operational alert publisher
+- Admin API path matching hardening
+- Test fixture admin boundary
+- Idempotency duplicate-key recovery
 - `.dev/rules` 자동 문서/테스트 동기화 체크
 
 ## MVP 출시 판단 기준

--- a/issue-drafts/0067-idempotency-duplicate-key-recovery.md
+++ b/issue-drafts/0067-idempotency-duplicate-key-recovery.md
@@ -1,0 +1,32 @@
+# Idempotency Duplicate-Key Recovery
+
+## 배경
+
+charge/transfer 멱등성은 service의 `findOperation` 체크와 repository의 idempotency key INSERT로 이루어진다. 단일 JVM에서는 service의 `synchronized`가 보호하지만, 멀티-JVM 배포에서는 두 요청이 동시에 `findOperation`을 빈 결과로 보고 apply 단계로 진입할 수 있다. 늦게 INSERT하는 레이스 패자는 `wallet_operations` PK 충돌로 `DuplicateKeyException`을 만나고, 이 예외는 핸들러가 없어 HTTP 500으로 노출된다. 멱등성 API가 재시도 클라이언트에게 500을 주는 것은 핵심 계약 위반이다.
+
+## 목표
+
+- 멱등성 INSERT 충돌을 예외가 아니라 회복으로 처리한다.
+- `applyCharge`/`applyTransfer`가 충돌 시 기존 operation을 재조회하여 반환한다.
+- 회복된 결과는 `created=false`, 새로 적용된 결과는 `created=true`로 구분한다.
+- 같은 key에 다른 fingerprint면 회복하지 않고 `IdempotencyKeyConflictException`을 던진다.
+- 두 repository 구현(`Jdbc`, `InMemory`)이 동일한 회복 계약을 따른다.
+- 실제 PostgreSQL 동시 charge 레이스로 회귀 테스트한다.
+
+## 완료 조건
+
+- [x] `applyCharge`/`applyTransfer`가 `WalletOperationOutcome(record, created)`를 반환한다.
+- [x] 이미 적용된 key로 apply하면 예외 없이 기존 record를 `created=false`로 반환한다.
+- [x] 같은 key에 다른 fingerprint면 `IdempotencyKeyConflictException`을 던진다.
+- [x] 충돌 시 잔액/거래/원장/감사/아웃박스 부작용이 한 번만 발생한다.
+- [x] 실제 PostgreSQL에서 동시 charge 시 정확히 하나만 `created=true`이고 결과 operationId가 동일하다.
+- [x] `WalletCommandResult.created`가 outcome의 created를 그대로 전달한다.
+- [x] ADR, progress, release, wiki draft가 갱신된다.
+
+## 검증 명령
+
+```bash
+./gradlew test --tests '*JdbcWalletRepositoryTest' --tests '*JdbcWalletRepositoryRollbackTest' --tests '*InMemoryWalletCommandServiceTest'
+./gradlew postgresScenarioTest --tests '*PostgresContainerWalletRepositoryTest'
+scripts/check-dev-rules.sh
+```

--- a/src/main/java/com/imwoo/airepo/wallet/application/InMemoryWalletCommandService.java
+++ b/src/main/java/com/imwoo/airepo/wallet/application/InMemoryWalletCommandService.java
@@ -30,17 +30,14 @@ public class InMemoryWalletCommandService implements WalletCommandService {
         WalletAccount walletAccount = findOperableWallet(walletId);
         String fingerprint = chargeFingerprint(walletAccount.walletId(), command);
         return resolveIdempotency(command.idempotencyKey(), fingerprint)
-                .orElseGet(() -> new WalletCommandResult(
-                        walletCommandRepository.applyCharge(
-                                command.idempotencyKey(),
-                                fingerprint,
-                                walletAccount.walletId(),
-                                command.money(),
-                                command.description(),
-                                Instant.now(clock)
-                        ).result(),
-                        true
-                ));
+                .orElseGet(() -> toCommandResult(walletCommandRepository.applyCharge(
+                        command.idempotencyKey(),
+                        fingerprint,
+                        walletAccount.walletId(),
+                        command.money(),
+                        command.description(),
+                        Instant.now(clock)
+                )));
     }
 
     @Override
@@ -63,18 +60,19 @@ public class InMemoryWalletCommandService implements WalletCommandService {
 
         String fingerprint = transferFingerprint(sourceWallet.walletId(), targetWallet.walletId(), command);
         return resolveIdempotency(command.idempotencyKey(), fingerprint)
-                .orElseGet(() -> new WalletCommandResult(
-                        walletCommandRepository.applyTransfer(
-                                command.idempotencyKey(),
-                                fingerprint,
-                                sourceWallet.walletId(),
-                                targetWallet.walletId(),
-                                command.money(),
-                                command.description(),
-                                Instant.now(clock)
-                        ).result(),
-                        true
-                ));
+                .orElseGet(() -> toCommandResult(walletCommandRepository.applyTransfer(
+                        command.idempotencyKey(),
+                        fingerprint,
+                        sourceWallet.walletId(),
+                        targetWallet.walletId(),
+                        command.money(),
+                        command.description(),
+                        Instant.now(clock)
+                )));
+    }
+
+    private WalletCommandResult toCommandResult(WalletOperationOutcome outcome) {
+        return new WalletCommandResult(outcome.record().result(), outcome.created());
     }
 
     private Optional<WalletCommandResult> resolveIdempotency(String idempotencyKey, String fingerprint) {

--- a/src/main/java/com/imwoo/airepo/wallet/application/WalletCommandRepository.java
+++ b/src/main/java/com/imwoo/airepo/wallet/application/WalletCommandRepository.java
@@ -8,7 +8,7 @@ public interface WalletCommandRepository extends WalletQueryRepository {
 
     Optional<WalletOperationRecord> findOperation(String idempotencyKey);
 
-    WalletOperationRecord applyCharge(
+    WalletOperationOutcome applyCharge(
             String idempotencyKey,
             String fingerprint,
             String walletId,
@@ -17,7 +17,7 @@ public interface WalletCommandRepository extends WalletQueryRepository {
             Instant occurredAt
     );
 
-    WalletOperationRecord applyTransfer(
+    WalletOperationOutcome applyTransfer(
             String idempotencyKey,
             String fingerprint,
             String sourceWalletId,

--- a/src/main/java/com/imwoo/airepo/wallet/application/WalletOperationOutcome.java
+++ b/src/main/java/com/imwoo/airepo/wallet/application/WalletOperationOutcome.java
@@ -1,0 +1,18 @@
+package com.imwoo.airepo.wallet.application;
+
+import java.util.Objects;
+
+public record WalletOperationOutcome(WalletOperationRecord record, boolean created) {
+
+    public WalletOperationOutcome {
+        Objects.requireNonNull(record, "record must not be null");
+    }
+
+    public static WalletOperationOutcome created(WalletOperationRecord record) {
+        return new WalletOperationOutcome(record, true);
+    }
+
+    public static WalletOperationOutcome recovered(WalletOperationRecord record) {
+        return new WalletOperationOutcome(record, false);
+    }
+}

--- a/src/main/java/com/imwoo/airepo/wallet/infra/InMemoryWalletRepository.java
+++ b/src/main/java/com/imwoo/airepo/wallet/infra/InMemoryWalletRepository.java
@@ -14,6 +14,8 @@ import com.imwoo.airepo.wallet.application.OperationalAlertRepository;
 import com.imwoo.airepo.wallet.application.InvalidWalletOperationException;
 import com.imwoo.airepo.wallet.application.WalletCommandRepository;
 import com.imwoo.airepo.wallet.application.WalletLedgerQueryRepository;
+import com.imwoo.airepo.wallet.application.IdempotencyKeyConflictException;
+import com.imwoo.airepo.wallet.application.WalletOperationOutcome;
 import com.imwoo.airepo.wallet.application.WalletOperationRecord;
 import com.imwoo.airepo.wallet.application.WalletOperationResult;
 import com.imwoo.airepo.wallet.domain.AdminApiAccessAudit;
@@ -780,7 +782,7 @@ public class InMemoryWalletRepository implements
     }
 
     @Override
-    public synchronized WalletOperationRecord applyCharge(
+    public synchronized WalletOperationOutcome applyCharge(
             String idempotencyKey,
             String fingerprint,
             String walletId,
@@ -788,6 +790,10 @@ public class InMemoryWalletRepository implements
             String description,
             Instant occurredAt
     ) {
+        WalletOperationRecord recovered = recoverExistingOperation(idempotencyKey, fingerprint);
+        if (recovered != null) {
+            return WalletOperationOutcome.recovered(recovered);
+        }
         WalletBalance currentBalance = balances.get(walletId);
         WalletBalance updatedBalance = new WalletBalance(walletId, currentBalance.money().add(money), occurredAt);
         balances.put(walletId, updatedBalance);
@@ -844,11 +850,11 @@ public class InMemoryWalletRepository implements
         operations.put(idempotencyKey, record);
         addStepLog(operationId, OperationStep.IDEMPOTENCY_RECORDED, occurredAt, "Idempotency record stored for operation " + operationId);
         addOutboxEvent(result);
-        return record;
+        return WalletOperationOutcome.created(record);
     }
 
     @Override
-    public synchronized WalletOperationRecord applyTransfer(
+    public synchronized WalletOperationOutcome applyTransfer(
             String idempotencyKey,
             String fingerprint,
             String sourceWalletId,
@@ -857,6 +863,10 @@ public class InMemoryWalletRepository implements
             String description,
             Instant occurredAt
     ) {
+        WalletOperationRecord recovered = recoverExistingOperation(idempotencyKey, fingerprint);
+        if (recovered != null) {
+            return WalletOperationOutcome.recovered(recovered);
+        }
         WalletBalance sourceBalance = balances.get(sourceWalletId);
         WalletBalance targetBalance = balances.get(targetWalletId);
         String operationId = nextOperationId();
@@ -944,7 +954,18 @@ public class InMemoryWalletRepository implements
         operations.put(idempotencyKey, record);
         addStepLog(operationId, OperationStep.IDEMPOTENCY_RECORDED, occurredAt, "Idempotency record stored for operation " + operationId);
         addOutboxEvent(result);
-        return record;
+        return WalletOperationOutcome.created(record);
+    }
+
+    private WalletOperationRecord recoverExistingOperation(String idempotencyKey, String fingerprint) {
+        WalletOperationRecord existing = operations.get(idempotencyKey);
+        if (existing == null) {
+            return null;
+        }
+        if (!existing.fingerprint().equals(fingerprint)) {
+            throw new IdempotencyKeyConflictException(idempotencyKey);
+        }
+        return existing;
     }
 
     private void addOutboxEvent(WalletOperationResult result) {

--- a/src/main/java/com/imwoo/airepo/wallet/infra/JdbcWalletRepository.java
+++ b/src/main/java/com/imwoo/airepo/wallet/infra/JdbcWalletRepository.java
@@ -1,6 +1,8 @@
 package com.imwoo.airepo.wallet.infra;
 
 import com.imwoo.airepo.wallet.application.AdminApiAccessAuditRepository;
+import com.imwoo.airepo.wallet.application.WalletOperationOutcome;
+import com.imwoo.airepo.wallet.application.IdempotencyKeyConflictException;
 import com.imwoo.airepo.wallet.application.InsufficientBalanceException;
 import com.imwoo.airepo.wallet.application.InvalidWalletOperationException;
 import com.imwoo.airepo.wallet.application.OperationOutboxConsumerDeliveryMetricRepository;
@@ -1132,7 +1134,7 @@ public class JdbcWalletRepository implements
     }
 
     @Override
-    public WalletOperationRecord applyCharge(
+    public WalletOperationOutcome applyCharge(
             String idempotencyKey,
             String fingerprint,
             String walletId,
@@ -1140,7 +1142,7 @@ public class JdbcWalletRepository implements
             String description,
             Instant occurredAt
     ) {
-        return executeWithLockTimeout(() -> {
+        return executeIdempotentOperation(idempotencyKey, fingerprint, () -> {
             WalletBalance currentBalance = findBalanceForUpdate(walletId);
             WalletBalance updatedBalance = new WalletBalance(walletId, currentBalance.money().add(money), occurredAt);
             String operationId = nextId("op", "operation_id_seq");
@@ -1233,7 +1235,7 @@ public class JdbcWalletRepository implements
     }
 
     @Override
-    public WalletOperationRecord applyTransfer(
+    public WalletOperationOutcome applyTransfer(
             String idempotencyKey,
             String fingerprint,
             String sourceWalletId,
@@ -1242,7 +1244,7 @@ public class JdbcWalletRepository implements
             String description,
             Instant occurredAt
     ) {
-        return executeWithLockTimeout(() -> {
+        return executeIdempotentOperation(idempotencyKey, fingerprint, () -> {
             List<WalletBalance> lockedBalances = findTransferBalancesForUpdate(sourceWalletId, targetWalletId);
             WalletBalance sourceBalance = findLockedBalance(lockedBalances, sourceWalletId);
             WalletBalance targetBalance = findLockedBalance(lockedBalances, targetWalletId);
@@ -1369,6 +1371,30 @@ public class JdbcWalletRepository implements
             insertOutboxEvent(result);
             return record;
         });
+    }
+
+    private WalletOperationOutcome executeIdempotentOperation(
+            String idempotencyKey,
+            String fingerprint,
+            Supplier<WalletOperationRecord> operation
+    ) {
+        try {
+            return WalletOperationOutcome.created(executeWithLockTimeout(operation));
+        } catch (DuplicateKeyException exception) {
+            return WalletOperationOutcome.recovered(recoverIdempotentRecord(idempotencyKey, fingerprint, exception));
+        }
+    }
+
+    private WalletOperationRecord recoverIdempotentRecord(
+            String idempotencyKey,
+            String fingerprint,
+            DuplicateKeyException exception
+    ) {
+        WalletOperationRecord existing = findOperation(idempotencyKey).orElseThrow(() -> exception);
+        if (!existing.fingerprint().equals(fingerprint)) {
+            throw new IdempotencyKeyConflictException(idempotencyKey);
+        }
+        return existing;
     }
 
     private WalletOperationRecord executeWithLockTimeout(Supplier<WalletOperationRecord> operation) {

--- a/src/test/java/com/imwoo/airepo/wallet/application/InMemoryWalletCommandServiceTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/application/InMemoryWalletCommandServiceTest.java
@@ -51,6 +51,19 @@ class InMemoryWalletCommandServiceTest {
     }
 
     @Test
+    void applyChargeReportsRecoveredOutcomeWhenIdempotencyKeyAlreadyApplied() {
+        WalletOperationOutcome first = repository.applyCharge(
+                "charge-001", "fp-charge-001", "wallet-001", money("5000"), "테스트 충전", instant());
+        WalletOperationOutcome second = repository.applyCharge(
+                "charge-001", "fp-charge-001", "wallet-001", money("5000"), "테스트 충전", instant());
+
+        assertThat(first.created()).isTrue();
+        assertThat(second.created()).isFalse();
+        assertThat(second.record().result().operationId()).isEqualTo(first.record().result().operationId());
+        assertThat(repository.findBalance("wallet-001").orElseThrow().money()).isEqualTo(money("130000"));
+    }
+
+    @Test
     void sameIdempotencyKeyWithDifferentChargeRequestFails() {
         service.charge("wallet-001", new WalletChargeCommand(money("5000"), "charge-001", "테스트 충전"));
 
@@ -123,5 +136,9 @@ class InMemoryWalletCommandServiceTest {
 
     private Money money(String amount) {
         return new Money(new BigDecimal(amount), "KRW");
+    }
+
+    private Instant instant() {
+        return Instant.parse("2026-05-01T00:00:00Z");
     }
 }

--- a/src/test/java/com/imwoo/airepo/wallet/infra/JdbcWalletRepositoryRollbackTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/infra/JdbcWalletRepositoryRollbackTest.java
@@ -3,6 +3,7 @@ package com.imwoo.airepo.wallet.infra;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.imwoo.airepo.wallet.application.IdempotencyKeyConflictException;
 import com.imwoo.airepo.wallet.domain.Money;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
@@ -10,7 +11,6 @@ import java.time.Instant;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
@@ -61,7 +61,7 @@ class JdbcWalletRepositoryRollbackTest {
                 new Money(new BigDecimal("5000"), "KRW"),
                 "롤백 검증",
                 Instant.parse("2026-05-01T00:00:00Z")
-        )).isInstanceOf(DuplicateKeyException.class);
+        )).isInstanceOf(IdempotencyKeyConflictException.class);
 
         assertThat(amount("wallet-001")).isEqualByComparingTo(initialBalance);
         assertThat(count("transaction_history where wallet_id = 'wallet-001'")).isEqualTo(initialTransactionCount);

--- a/src/test/java/com/imwoo/airepo/wallet/infra/JdbcWalletRepositoryTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/infra/JdbcWalletRepositoryTest.java
@@ -9,6 +9,8 @@ import com.imwoo.airepo.wallet.application.InMemoryWalletLedgerQueryService;
 import com.imwoo.airepo.wallet.application.InvalidWalletOperationException;
 import com.imwoo.airepo.wallet.application.WalletChargeCommand;
 import com.imwoo.airepo.wallet.application.WalletCommandResult;
+import com.imwoo.airepo.wallet.application.WalletOperationOutcome;
+import com.imwoo.airepo.wallet.application.WalletOperationRecord;
 import com.imwoo.airepo.wallet.application.WalletTransferCommand;
 import com.imwoo.airepo.wallet.domain.AdminApiAccessAudit;
 import com.imwoo.airepo.wallet.domain.AdminApiAccessOutcome;
@@ -137,6 +139,72 @@ class JdbcWalletRepositoryTest {
         assertThat(ledgerQueryService.getLedgerEntries("wallet-001")).hasSize(1);
         assertThat(ledgerQueryService.getAuditEvents()).hasSize(1);
         assertThat(repository.findOperationStepLogs("op-001")).hasSize(6);
+        assertThat(repository.findOperationOutboxEvents("op-001")).hasSize(1);
+    }
+
+    @Test
+    void applyChargeReturnsExistingRecordWhenIdempotencyKeyAlreadyApplied() {
+        WalletChargeCommand command = new WalletChargeCommand(money("5000"), "charge-db-001", "DB 충전");
+        WalletCommandResult winner = commandService.charge("wallet-001", command);
+        WalletOperationRecord stored = repository.findOperation("charge-db-001").orElseThrow();
+
+        WalletOperationOutcome recovered = repository.applyCharge(
+                stored.idempotencyKey(),
+                stored.fingerprint(),
+                "wallet-001",
+                command.money(),
+                command.description(),
+                Instant.parse("2026-05-01T00:00:00Z")
+        );
+
+        assertThat(recovered.created()).isFalse();
+        assertThat(recovered.record().result().operationId()).isEqualTo(winner.operation().operationId());
+        assertThat(repository.findBalance("wallet-001").orElseThrow().money()).isEqualTo(money("130000"));
+        assertThat(ledgerQueryService.getLedgerEntries("wallet-001")).hasSize(1);
+        assertThat(ledgerQueryService.getAuditEvents()).hasSize(1);
+        assertThat(repository.findOperationStepLogs("op-001")).hasSize(6);
+        assertThat(repository.findOperationOutboxEvents("op-001")).hasSize(1);
+    }
+
+    @Test
+    void applyChargeRejectsReusedIdempotencyKeyWithDifferentFingerprint() {
+        WalletChargeCommand command = new WalletChargeCommand(money("5000"), "charge-db-001", "DB 충전");
+        commandService.charge("wallet-001", command);
+
+        assertThatThrownBy(() -> repository.applyCharge(
+                "charge-db-001",
+                "CHARGE|wallet-001|9999|KRW|다른 요청",
+                "wallet-001",
+                money("9999"),
+                "다른 요청",
+                Instant.parse("2026-05-01T00:00:00Z")
+        )).isInstanceOf(IdempotencyKeyConflictException.class);
+
+        assertThat(repository.findBalance("wallet-001").orElseThrow().money()).isEqualTo(money("130000"));
+        assertThat(ledgerQueryService.getLedgerEntries("wallet-001")).hasSize(1);
+    }
+
+    @Test
+    void applyTransferReturnsExistingRecordWhenIdempotencyKeyAlreadyApplied() {
+        WalletTransferCommand command = new WalletTransferCommand("wallet-002", money("1000"), "transfer-db-001", "DB 송금");
+        WalletCommandResult winner = commandService.transfer("wallet-001", command);
+        WalletOperationRecord stored = repository.findOperation("transfer-db-001").orElseThrow();
+
+        WalletOperationOutcome recovered = repository.applyTransfer(
+                stored.idempotencyKey(),
+                stored.fingerprint(),
+                "wallet-001",
+                "wallet-002",
+                command.money(),
+                command.description(),
+                Instant.parse("2026-05-01T00:00:00Z")
+        );
+
+        assertThat(recovered.created()).isFalse();
+        assertThat(recovered.record().result().operationId()).isEqualTo(winner.operation().operationId());
+        assertThat(repository.findBalance("wallet-001").orElseThrow().money()).isEqualTo(money("124000"));
+        assertThat(repository.findBalance("wallet-002").orElseThrow().money()).isEqualTo(money("31000"));
+        assertThat(ledgerQueryService.getLedgerEntries("wallet-001")).hasSize(1);
         assertThat(repository.findOperationOutboxEvents("op-001")).hasSize(1);
     }
 

--- a/src/test/java/com/imwoo/airepo/wallet/infra/PostgresContainerWalletRepositoryTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/infra/PostgresContainerWalletRepositoryTest.java
@@ -10,6 +10,7 @@ import com.imwoo.airepo.wallet.application.WalletConcurrencyException;
 import com.imwoo.airepo.wallet.application.InMemoryWalletLedgerQueryService;
 import com.imwoo.airepo.wallet.application.WalletChargeCommand;
 import com.imwoo.airepo.wallet.application.WalletCommandResult;
+import com.imwoo.airepo.wallet.application.WalletOperationOutcome;
 import com.imwoo.airepo.wallet.application.WalletTransferCommand;
 import com.imwoo.airepo.wallet.domain.Money;
 import com.imwoo.airepo.wallet.domain.OperationOutboxRequeueRequestStatus;
@@ -175,6 +176,36 @@ class PostgresContainerWalletRepositoryTest {
                     repository.findOperation("postgres-concurrent-transfer-001").isPresent()
                             ^ repository.findOperation("postgres-concurrent-transfer-002").isPresent()
             ).isTrue();
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    void concurrentChargesWithSameIdempotencyKeyRecoverIdempotentResultInsteadOfFailing() throws Exception {
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        CountDownLatch startLatch = new CountDownLatch(1);
+
+        try {
+            Future<ChargeAttempt> firstAttempt = executorService.submit(() -> applyConcurrentCharge(startLatch));
+            Future<ChargeAttempt> secondAttempt = executorService.submit(() -> applyConcurrentCharge(startLatch));
+
+            startLatch.countDown();
+
+            List<ChargeAttempt> attempts = List.of(
+                    firstAttempt.get(10, TimeUnit.SECONDS),
+                    secondAttempt.get(10, TimeUnit.SECONDS)
+            );
+
+            assertThat(attempts).filteredOn(ChargeAttempt::successful).hasSize(2);
+            assertThat(attempts).extracting(ChargeAttempt::operationId).containsOnly("op-001");
+            assertThat(attempts).filteredOn(ChargeAttempt::created).hasSize(1);
+            assertThat(attempts).filteredOn(attempt -> !attempt.created()).hasSize(1);
+            assertThat(repository.findBalance("wallet-001").orElseThrow().money()).isEqualTo(money("130000"));
+            assertThat(ledgerQueryService.getLedgerEntries("wallet-001")).hasSize(1);
+            assertThat(ledgerQueryService.getAuditEvents()).hasSize(1);
+            assertThat(repository.findOperationStepLogs("op-001")).hasSize(6);
+            assertThat(repository.findOperationOutboxEvents("op-001")).hasSize(1);
         } finally {
             executorService.shutdownNow();
         }
@@ -514,6 +545,24 @@ class PostgresContainerWalletRepositoryTest {
         ));
     }
 
+    private ChargeAttempt applyConcurrentCharge(CountDownLatch startLatch) throws InterruptedException {
+        awaitConcurrentStart(startLatch);
+
+        try {
+            WalletOperationOutcome outcome = repository.applyCharge(
+                    "postgres-concurrent-charge-001",
+                    "postgres-concurrent-charge-fingerprint-001",
+                    "wallet-001",
+                    money("5000"),
+                    "PostgreSQL 동시 충전",
+                    Instant.parse("2026-05-01T00:00:00Z")
+            );
+            return ChargeAttempt.success(outcome.record().result().operationId(), outcome.created());
+        } catch (RuntimeException exception) {
+            return ChargeAttempt.failure(exception);
+        }
+    }
+
     private void awaitConcurrentStart(CountDownLatch startLatch) throws InterruptedException {
         if (!startLatch.await(5, TimeUnit.SECONDS)) {
             throw new IllegalStateException("Timed out waiting for concurrent start");
@@ -558,5 +607,16 @@ class PostgresContainerWalletRepositoryTest {
     }
 
     private record ConsumerProcessedAttempt(boolean recorded) {
+    }
+
+    private record ChargeAttempt(boolean successful, String operationId, boolean created, RuntimeException exception) {
+
+        private static ChargeAttempt success(String operationId, boolean created) {
+            return new ChargeAttempt(true, operationId, created, null);
+        }
+
+        private static ChargeAttempt failure(RuntimeException exception) {
+            return new ChargeAttempt(false, null, false, exception);
+        }
     }
 }

--- a/wiki-drafts/Architecture-Decisions.md
+++ b/wiki-drafts/Architecture-Decisions.md
@@ -78,6 +78,8 @@
    - ADR-0053 Operational Alert Suppression and Pruning
    - ADR-0054 Slack Webhook Operational Alert Publisher
    - ADR-0055 Admin API Path Matching Hardening
+   - ADR-0056 Test Fixture Admin Boundary
+   - ADR-0057 Idempotency Duplicate-Key Recovery
 
 ## 중요한 트레이드오프
 


### PR DESCRIPTION
## 배경

멱등성 진단(2026-06-05, main 핀테크 역량 진단의 최우선 백로그 항목)에서 확정된 correctness 버그를 수정한다. Closes #104.

멀티-JVM 배포에서 같은 idempotency key를 가진 두 요청이 동시에 service의 `findOperation` 체크를 빈 결과로 통과해 apply 단계로 진입할 수 있다. 늦게 INSERT하는 레이스 패자는 `wallet_operations` PK 충돌로 `DuplicateKeyException`을 만나고, 이 예외는 핸들러가 없어 **HTTP 500**으로 노출된다. 멱등성 API가 재시도 클라이언트에게 500을 주는 것은 핵심 계약 위반이다.

## 변경

- `JdbcWalletRepository`: apply 중 `DuplicateKeyException`을 잡아 `findOperation`으로 이미 커밋된 operation을 재조회해 반환(회복). fingerprint가 다르면 `IdempotencyKeyConflictException`.
- `applyCharge`/`applyTransfer` 반환 타입을 `WalletOperationOutcome(record, created)`로 변경 — 새로 적용은 `created=true`, 회복은 `created=false`. `WalletCommandResult.created`로 정확히 전달.
- `InMemoryWalletRepository`도 동일한 회복/충돌 계약 구현(기존에는 같은 key를 조용히 덮어썼다).

## 테스트

- repository-level 회복 + 다른 fingerprint 충돌 회귀 테스트
- rollback 테스트를 `IdempotencyKeyConflictException` 기대로 갱신(롤백 검증 유지)
- **실제 PostgreSQL 동시 charge 레이스**: 정확히 하나는 `created=true`, 하나는 `created=false`, 부작용 1회
- 전체 253 테스트 통과 (`check` + `scenarioTest` + `postgresScenarioTest`), `scripts/check-dev-rules.sh` PASS

## 문서

ADR 0057, progress 0068, issue-draft 0067, release notes, wiki draft 동기화. 인덱스에서 누락돼 있던 ADR 0056도 함께 보강.

## 참고

이 브랜치에는 로컬 에이전트 도구 디렉터리(.claude/, .understand-anything/)를 gitignore하는 무관한 chore 커밋(4dde2c8)이 함께 포함된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)