### PR TITLE
feat: local k8s deploy + grafana observability + gitops pipeline (B4)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.gradle
+build
+frontend/node_modules
+frontend/dist
+docs
+wiki-drafts
+issue-drafts
+fintech-harness-spec
+project-skills

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,65 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+      - 'wiki-drafts/**'
+      - 'issue-drafts/**'
+      - 'deploy/gitops/kustomization.yaml' # CI 자체 갱신 커밋 재트리거 방지
+
+permissions:
+  contents: write
+  packages: write
+
+concurrency:
+  group: deploy-main
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/imwoo94/ai-repo
+
+jobs:
+  build-push-sync:
+    name: Build, Push, Update GitOps Manifest
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve image tag ({version}-{sha8})
+        id: meta
+        run: |
+          VERSION=$(sed -n "s/^version = '\(.*\)'/\1/p" build.gradle)
+          SHA8=${GITHUB_SHA:0:8}
+          echo "tag=${VERSION}-${SHA8}" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.IMAGE }}:${{ steps.meta.outputs.tag }}
+
+      - name: Update GitOps manifest
+        run: |
+          sed -i "s|newTag: .*|newTag: ${{ steps.meta.outputs.tag }}|" deploy/gitops/kustomization.yaml
+          git diff --stat deploy/gitops/kustomization.yaml
+
+      - name: Commit and push manifest
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add deploy/gitops/kustomization.yaml
+          git commit -m "chore: deploy ${{ steps.meta.outputs.tag }} [skip ci]" || { echo "no change"; exit 0; }
+          git push

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Build stage: Gradle wrapper + JDK 25
+FROM eclipse-temurin:25-jdk AS build
+WORKDIR /workspace
+
+COPY gradlew settings.gradle build.gradle ./
+COPY gradle gradle
+RUN ./gradlew --no-daemon dependencies --quiet || true
+
+COPY src src
+RUN ./gradlew --no-daemon bootJar
+
+# Runtime stage: JRE only
+FROM eclipse-temurin:25-jre
+WORKDIR /app
+COPY --from=build /workspace/build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -133,6 +133,16 @@ Outbox relay는 publisher port 뒤에 기본 in-memory adapter와 선택형 HTTP
 
 IntelliJ IDEA 기준 설정은 [Local Setup](docs/development/local-setup.md)을 따릅니다.
 
+### k8s 배포와 관측 스택
+
+로컬 Docker Desktop k8s에 전체 스택(앱 + Postgres + Prometheus + Grafana + Loki)을 띄우는 구동 방법과 서비스별 접속 URL·계정 정보, 대시보드/LogQL 로그 검색은 [k8s 로컬 배포 + 모니터링 + 로그 검색](docs/development/k8s-local-monitoring.md)을 따릅니다. main 머지 시 자동 배포되는 GitHub Actions → GHCR → ArgoCD 파이프라인은 [CI/CD GitOps](docs/development/ci-cd-gitops.md)를 따릅니다.
+
+```bash
+./scripts/k8s-local-up.sh     # 전체 스택 기동 — 앱 :30080, Prometheus :30990, Grafana :30300
+./scripts/k8s-local-down.sh   # 전체 제거
+./scripts/argocd-install.sh   # (선택) ArgoCD 설치 + GitOps 모드
+```
+
 현재 기능 흐름은 잔액/거래내역 조회, 회원/지갑 계정, 충전/송금, 원장/감사 로그 1차 API를 제공합니다.
 
 - `GET /api/v1/wallets/wallet-001/balance`

--- a/README.md
+++ b/README.md
@@ -138,10 +138,20 @@ IntelliJ IDEA 기준 설정은 [Local Setup](docs/development/local-setup.md)을
 로컬 Docker Desktop k8s에 전체 스택(앱 + Postgres + Prometheus + Grafana + Loki)을 띄우는 구동 방법과 서비스별 접속 URL·계정 정보, 대시보드/LogQL 로그 검색은 [k8s 로컬 배포 + 모니터링 + 로그 검색](docs/development/k8s-local-monitoring.md)을 따릅니다. main 머지 시 자동 배포되는 GitHub Actions → GHCR → ArgoCD 파이프라인은 [CI/CD GitOps](docs/development/ci-cd-gitops.md)를 따릅니다.
 
 ```bash
-./scripts/k8s-local-up.sh     # 전체 스택 기동 — 앱 :30080, Prometheus :30990, Grafana :30300
+./scripts/k8s-local-up.sh     # 전체 스택 기동
 ./scripts/k8s-local-down.sh   # 전체 제거
 ./scripts/argocd-install.sh   # (선택) ArgoCD 설치 + GitOps 모드
 ```
+
+| 서비스 | URL | 계정 |
+| --- | --- | --- |
+| 앱 API | http://localhost:30080 | 운영 API 헤더: `X-Operator-Token: local-operator-token` / `X-Admin-Token: local-ops-token` |
+| Grafana 대시보드 | http://localhost:30300/d/ai-repo-overview | 익명 Admin (로그인 불필요) |
+| Grafana 로그 검색 | http://localhost:30300/explore | 익명 Admin (로그인 불필요) |
+| Prometheus | http://localhost:30990 | 없음 |
+| ArgoCD | https://localhost:8443 (port-forward 후) | `admin` / 초기 비밀번호 조회 명령은 가이드 참고 |
+
+서비스별 전체 접속 정보(Postgres·Loki 포함)와 복사-실행 명령어 모음은 [k8s 로컬 배포 + 모니터링 + 로그 검색](docs/development/k8s-local-monitoring.md)의 "접속 정보"·"전체 명령어 모음" 섹션에 있습니다.
 
 현재 기능 흐름은 잔액/거래내역 조회, 회원/지갑 계정, 충전/송금, 원장/감사 로그 1차 API를 제공합니다.
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ IntelliJ IDEA 기준 설정은 [Local Setup](docs/development/local-setup.md)을
 | Prometheus | http://localhost:30990 | 없음 |
 | ArgoCD | https://localhost:8443 (port-forward 후) | `admin` / 초기 비밀번호 조회 명령은 가이드 참고 |
 
-서비스별 전체 접속 정보(Postgres·Loki 포함)와 복사-실행 명령어 모음은 [k8s 로컬 배포 + 모니터링 + 로그 검색](docs/development/k8s-local-monitoring.md)의 "접속 정보"·"전체 명령어 모음" 섹션에 있습니다.
+서비스별 전체 접속 정보(Postgres·Loki 포함)와 복사-실행 명령어 모음은 [k8s 로컬 배포 + 모니터링 + 로그 검색](docs/development/k8s-local-monitoring.md)의 "접속 정보"·"전체 명령어 모음" 섹션에 있습니다. 인프라·애플리케이션 구조는 [아키텍처 다이어그램](docs/development/architecture-diagrams.md)(mermaid)을 참고합니다.
 
 현재 기능 흐름은 잔액/거래내역 조회, 회원/지갑 계정, 충전/송금, 원장/감사 로그 1차 API를 제공합니다.
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     implementation 'org.flywaydb:flyway-database-postgresql'
     implementation 'org.springframework.boot:spring-boot-flyway'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'

--- a/deploy/argocd/application.yaml
+++ b/deploy/argocd/application.yaml
@@ -1,0 +1,21 @@
+# ArgoCD Application — deploy/gitops 오버레이를 ai-repo 네임스페이스로 자동 sync
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ai-repo
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/IMWoo94/ai-repo.git
+    targetRevision: main
+    path: deploy/gitops
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ai-repo
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/deploy/gitops/kustomization.yaml
+++ b/deploy/gitops/kustomization.yaml
@@ -1,0 +1,18 @@
+# GitOps 배포 오버레이 — ArgoCD가 이 디렉토리를 sync한다.
+# newTag는 GitHub Actions(deploy.yml)가 {version}-{sha8} 형식으로 갱신한다. 수동 수정 금지.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../k8s
+images:
+  - name: ai-repo
+    newName: ghcr.io/imwoo94/ai-repo
+    newTag: 0.7.0-00000000
+patches:
+  - target:
+      kind: Deployment
+      name: ai-repo
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/imagePullPolicy
+        value: IfNotPresent

--- a/deploy/k8s/alloy.yaml
+++ b/deploy/k8s/alloy.yaml
@@ -1,0 +1,122 @@
+# Grafana Alloy — ai-repo 네임스페이스 파드 로그를 k8s API로 수집해 Loki로 전송
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alloy
+  namespace: ai-repo
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ai-repo-alloy
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ai-repo-alloy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ai-repo-alloy
+subjects:
+  - kind: ServiceAccount
+    name: alloy
+    namespace: ai-repo
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alloy-config
+  namespace: ai-repo
+data:
+  config.alloy: |
+    discovery.kubernetes "pods" {
+      role = "pod"
+      namespaces {
+        names = ["ai-repo"]
+      }
+    }
+
+    discovery.relabel "pods" {
+      targets = discovery.kubernetes.pods.targets
+
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app"]
+        target_label  = "app"
+      }
+    }
+
+    loki.source.kubernetes "pods" {
+      targets    = discovery.relabel.pods.output
+      forward_to = [loki.write.default.receiver]
+    }
+
+    loki.write "default" {
+      endpoint {
+        url = "http://loki:3100/loki/api/v1/push"
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alloy
+  namespace: ai-repo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alloy
+  template:
+    metadata:
+      labels:
+        app: alloy
+    spec:
+      serviceAccountName: alloy
+      containers:
+        - name: alloy
+          image: grafana/alloy:v1.9.1
+          args:
+            - run
+            - /etc/alloy/config.alloy
+            - --server.http.listen-addr=0.0.0.0:12345
+          ports:
+            - containerPort: 12345
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 12345
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 256Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+      volumes:
+        - name: config
+          configMap:
+            name: alloy-config

--- a/deploy/k8s/app.yaml
+++ b/deploy/k8s/app.yaml
@@ -1,0 +1,67 @@
+# ai-repo 애플리케이션. 로컬은 ai-repo:local 태그(imagePullPolicy: Never),
+# CI/CD 파이프라인 도입 시 {version}-{sha8} 태그로 GitOps 매니페스트를 갱신한다.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ai-repo
+  namespace: ai-repo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ai-repo
+  template:
+    metadata:
+      labels:
+        app: ai-repo
+    spec:
+      containers:
+        - name: ai-repo
+          image: ai-repo:local
+          imagePullPolicy: Never
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: postgres
+            - name: AI_REPO_POSTGRES_URL
+              value: jdbc:postgresql://postgres:5432/ai_repo
+            - name: AI_REPO_POSTGRES_USERNAME
+              value: ai_repo
+            - name: AI_REPO_POSTGRES_PASSWORD
+              value: ai_repo
+            - name: AI_REPO_OUTBOX_RELAY_SCHEDULER_ENABLED
+              value: "true"
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 12
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              memory: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ai-repo
+  namespace: ai-repo
+spec:
+  type: NodePort
+  selector:
+    app: ai-repo
+  ports:
+    - port: 8080
+      targetPort: 8080
+      nodePort: 30080

--- a/deploy/k8s/grafana-dashboard.yaml
+++ b/deploy/k8s/grafana-dashboard.yaml
@@ -149,6 +149,119 @@ data:
               "legendFormat": "up"
             }
           ]
+        },
+        {
+          "type": "row",
+          "title": "Outbox 릴레이 / 컨슈머",
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 }
+        },
+        {
+          "type": "timeseries",
+          "title": "릴레이 실행률 (by result)",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 33 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
+          "targets": [
+            {
+              "expr": "sum by (result) (rate(ai_repo_outbox_relay_runs_total{job=\"ai-repo\"}[5m]))",
+              "legendFormat": "{{result}}"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "릴레이 발행 이벤트율 (by outcome)",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 33 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
+          "targets": [
+            {
+              "expr": "sum by (outcome) (rate(ai_repo_outbox_relay_published_events_total{job=\"ai-repo\"}[5m]))",
+              "legendFormat": "{{outcome}}"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "미발행 Outbox 이벤트 (pending)",
+          "gridPos": { "h": 8, "w": 8, "x": 0, "y": 41 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": { "defaults": { "unit": "short", "min": 0 }, "overrides": [] },
+          "targets": [
+            {
+              "expr": "ai_repo_outbox_relay_pending_events{job=\"ai-repo\"}",
+              "legendFormat": "pending"
+            }
+          ]
+        },
+        {
+          "type": "stat",
+          "title": "릴레이 헬스 (0=ok,1=warn,2=crit)",
+          "gridPos": { "h": 8, "w": 8, "x": 8, "y": 41 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "min": 0,
+              "max": 2,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 1 },
+                  { "color": "red", "value": 2 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "max(ai_repo_outbox_relay_health_status{job=\"ai-repo\"})",
+              "legendFormat": "relay"
+            }
+          ]
+        },
+        {
+          "type": "stat",
+          "title": "컨슈머 헬스 (0=ok,1=warn,2=crit)",
+          "gridPos": { "h": 8, "w": 8, "x": 16, "y": 41 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "min": 0,
+              "max": 2,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 1 },
+                  { "color": "red", "value": 2 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "max(ai_repo_outbox_consumer_health_status{job=\"ai-repo\"})",
+              "legendFormat": "consumer"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "컨슈머 처리율 (by outcome)",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 49 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
+          "targets": [
+            {
+              "expr": "sum by (outcome) (rate(ai_repo_outbox_consumer_events_total{job=\"ai-repo\"}[5m]))",
+              "legendFormat": "{{outcome}}"
+            }
+          ]
         }
       ]
     }

--- a/deploy/k8s/grafana-dashboard.yaml
+++ b/deploy/k8s/grafana-dashboard.yaml
@@ -1,0 +1,154 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-ai-repo
+  namespace: ai-repo
+data:
+  ai-repo.json: |
+    {
+      "uid": "ai-repo-overview",
+      "title": "ai-repo Overview",
+      "tags": ["ai-repo"],
+      "timezone": "browser",
+      "schemaVersion": 39,
+      "refresh": "15s",
+      "time": { "from": "now-30m", "to": "now" },
+      "panels": [
+        {
+          "type": "timeseries",
+          "title": "HTTP 요청률 (by uri)",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+          "targets": [
+            {
+              "expr": "sum by (uri) (rate(http_server_requests_seconds_count{job=\"ai-repo\", uri!~\"/actuator.*\"}[1m]))",
+              "legendFormat": "{{uri}}"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "HTTP p95 / p99 지연시간",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{job=\"ai-repo\", uri!~\"/actuator.*\"}[5m])))",
+              "legendFormat": "p95"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_requests_seconds_bucket{job=\"ai-repo\", uri!~\"/actuator.*\"}[5m])))",
+              "legendFormat": "p99"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "지갑 거래 요청률 (charge/transfer/payment)",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+          "targets": [
+            {
+              "expr": "sum by (uri, status) (rate(http_server_requests_seconds_count{job=\"ai-repo\", method=\"POST\", uri=~\"/api/v1/wallets/.*(charges|transfers|payments).*\"}[1m]))",
+              "legendFormat": "{{uri}} [{{status}}]"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "HTTP 오류율 (4xx/5xx)",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+          "targets": [
+            {
+              "expr": "sum by (status) (rate(http_server_requests_seconds_count{job=\"ai-repo\", status=~\"4..|5..\"}[1m]))",
+              "legendFormat": "{{status}}"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "JVM Heap 사용량",
+          "gridPos": { "h": 8, "w": 8, "x": 0, "y": 16 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+          "targets": [
+            {
+              "expr": "sum(jvm_memory_used_bytes{job=\"ai-repo\", area=\"heap\"})",
+              "legendFormat": "used"
+            },
+            {
+              "expr": "sum(jvm_memory_max_bytes{job=\"ai-repo\", area=\"heap\"})",
+              "legendFormat": "max"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "GC Pause",
+          "gridPos": { "h": 8, "w": 8, "x": 8, "y": 16 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+          "targets": [
+            {
+              "expr": "sum by (action, cause) (rate(jvm_gc_pause_seconds_sum{job=\"ai-repo\"}[5m]))",
+              "legendFormat": "{{action}} ({{cause}})"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Hikari DB 커넥션",
+          "gridPos": { "h": 8, "w": 8, "x": 16, "y": 16 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            {
+              "expr": "hikaricp_connections_active{job=\"ai-repo\"}",
+              "legendFormat": "active"
+            },
+            {
+              "expr": "hikaricp_connections_idle{job=\"ai-repo\"}",
+              "legendFormat": "idle"
+            },
+            {
+              "expr": "hikaricp_connections_pending{job=\"ai-repo\"}",
+              "legendFormat": "pending"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "프로세스 CPU",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": { "defaults": { "unit": "percentunit", "max": 1 }, "overrides": [] },
+          "targets": [
+            {
+              "expr": "process_cpu_usage{job=\"ai-repo\"}",
+              "legendFormat": "process"
+            },
+            {
+              "expr": "system_cpu_usage{job=\"ai-repo\"}",
+              "legendFormat": "system"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "앱 가용성 (up)",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": { "defaults": { "min": 0, "max": 1 }, "overrides": [] },
+          "targets": [
+            {
+              "expr": "up{job=\"ai-repo\"}",
+              "legendFormat": "up"
+            }
+          ]
+        }
+      ]
+    }

--- a/deploy/k8s/grafana.yaml
+++ b/deploy/k8s/grafana.yaml
@@ -1,0 +1,100 @@
+# 로컬 학습용 Grafana. 익명 Admin 허용(비프로덕션).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+  namespace: ai-repo
+data:
+  datasource.yml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        uid: prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus:9090
+        isDefault: true
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-provider
+  namespace: ai-repo
+data:
+  provider.yml: |
+    apiVersion: 1
+    providers:
+      - name: ai-repo
+        folder: ai-repo
+        type: file
+        options:
+          path: /var/lib/grafana/dashboards
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: ai-repo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:12.0.2
+          env:
+            - name: GF_AUTH_ANONYMOUS_ENABLED
+              value: "true"
+            - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+              value: Admin
+          ports:
+            - containerPort: 3000
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 256Mi
+          volumeMounts:
+            - name: datasources
+              mountPath: /etc/grafana/provisioning/datasources
+            - name: dashboard-provider
+              mountPath: /etc/grafana/provisioning/dashboards
+            - name: dashboards
+              mountPath: /var/lib/grafana/dashboards
+      volumes:
+        - name: datasources
+          configMap:
+            name: grafana-datasources
+        - name: dashboard-provider
+          configMap:
+            name: grafana-dashboard-provider
+        - name: dashboards
+          configMap:
+            name: grafana-dashboard-ai-repo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: ai-repo
+spec:
+  type: NodePort
+  selector:
+    app: grafana
+  ports:
+    - port: 3000
+      targetPort: 3000
+      nodePort: 30300

--- a/deploy/k8s/grafana.yaml
+++ b/deploy/k8s/grafana.yaml
@@ -14,6 +14,11 @@ data:
         access: proxy
         url: http://prometheus:9090
         isDefault: true
+      - name: Loki
+        uid: loki
+        type: loki
+        access: proxy
+        url: http://loki:3100
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -5,5 +5,7 @@ resources:
   - postgres.yaml
   - app.yaml
   - prometheus.yaml
+  - loki.yaml
+  - alloy.yaml
   - grafana.yaml
   - grafana-dashboard.yaml

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - postgres.yaml
+  - app.yaml
+  - prometheus.yaml
+  - grafana.yaml
+  - grafana-dashboard.yaml

--- a/deploy/k8s/loki.yaml
+++ b/deploy/k8s/loki.yaml
@@ -1,0 +1,109 @@
+# 로컬 학습용 Loki (single binary, filesystem 저장, 72h 보존)
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+  namespace: ai-repo
+data:
+  loki.yml: |
+    auth_enabled: false
+    server:
+      http_listen_port: 3100
+    common:
+      instance_addr: 127.0.0.1
+      path_prefix: /loki
+      storage:
+        filesystem:
+          chunks_directory: /loki/chunks
+          rules_directory: /loki/rules
+      replication_factor: 1
+      ring:
+        kvstore:
+          store: inmemory
+    schema_config:
+      configs:
+        - from: "2024-01-01"
+          store: tsdb
+          object_store: filesystem
+          schema: v13
+          index:
+            prefix: index_
+            period: 24h
+    compactor:
+      working_directory: /loki/compactor
+      retention_enabled: true
+      delete_request_store: filesystem
+    limits_config:
+      retention_period: 72h
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: loki-data
+  namespace: ai-repo
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loki
+  namespace: ai-repo
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: loki
+  template:
+    metadata:
+      labels:
+        app: loki
+    spec:
+      containers:
+        - name: loki
+          image: grafana/loki:3.5.1
+          args:
+            - -config.file=/etc/loki/loki.yml
+          ports:
+            - containerPort: 3100
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 3100
+            initialDelaySeconds: 15
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki
+            - name: data
+              mountPath: /loki
+      volumes:
+        - name: config
+          configMap:
+            name: loki-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: loki-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+  namespace: ai-repo
+spec:
+  selector:
+    app: loki
+  ports:
+    - port: 3100
+      targetPort: 3100

--- a/deploy/k8s/namespace.yaml
+++ b/deploy/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ai-repo

--- a/deploy/k8s/postgres.yaml
+++ b/deploy/k8s/postgres.yaml
@@ -1,0 +1,71 @@
+# 로컬 학습용 Postgres. 자격증명은 compose.yml과 동일한 로컬 고정값(비프로덕션).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data
+  namespace: ai-repo
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: ai-repo
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:17-alpine
+          env:
+            - name: POSTGRES_DB
+              value: ai_repo
+            - name: POSTGRES_USER
+              value: ai_repo
+            - name: POSTGRES_PASSWORD
+              value: ai_repo
+          ports:
+            - containerPort: 5432
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "ai_repo", "-d", "ai_repo"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: postgres-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: ai-repo
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/deploy/k8s/prometheus.yaml
+++ b/deploy/k8s/prometheus.yaml
@@ -1,0 +1,75 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: ai-repo
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+      evaluation_interval: 15s
+    scrape_configs:
+      - job_name: ai-repo
+        metrics_path: /actuator/prometheus
+        static_configs:
+          - targets: ["ai-repo:8080"]
+      - job_name: prometheus
+        static_configs:
+          - targets: ["localhost:9090"]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: ai-repo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v3.4.1
+          args:
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --storage.tsdb.retention.time=3d
+          ports:
+            - containerPort: 9090
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 9090
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: ai-repo
+spec:
+  type: NodePort
+  selector:
+    app: prometheus
+  ports:
+    - port: 9090
+      targetPort: 9090
+      nodePort: 30990

--- a/docs/adr/0059-k8s-deploy-and-observability.md
+++ b/docs/adr/0059-k8s-deploy-and-observability.md
@@ -1,0 +1,44 @@
+# ADR-0059: 로컬 k8s 배포와 관측(모니터링·로그·GitOps) 스택
+
+## 상태
+
+Accepted
+
+## 배경
+
+ai-repo는 지금까지 `compose.yml`(Postgres 단독)과 로컬 프로세스 실행에 의존했고, 배포·모니터링·로그 검색 체계가 없었다. 학습 랩 로드맵 B4로 "로컬에서 k8s로 띄우고 Grafana 기반으로 관측"하는 환경과, main 머지 시 자동 배포되는 GitOps 파이프라인이 필요했다.
+
+## 결정
+
+| 항목 | 결정 |
+| --- | --- |
+| 클러스터 | Docker Desktop 내장 Kubernetes(단일 노드). 별도 kind/minikube 미도입 |
+| 매니페스트 | `deploy/k8s` kustomize 단일 base — 앱, Postgres(PVC), Prometheus, Grafana, Loki, Alloy |
+| 메트릭 | micrometer-registry-prometheus, `/actuator/prometheus`를 Prometheus가 15s 스크랩. HTTP 지연 분위수는 percentiles-histogram |
+| 커스텀 지표 | outbox 릴레이/컨슈머를 비침습 브리지로 노출 — 게이지는 `OutboxMetricsBinder`가 기존 모니터링 서비스를 스크레이프 시점에 읽고, 릴레이 카운터는 `OutboxRelayMetricsRecorder` 포트로 기록 시점 증가(실행 저장소가 최근 샘플만 보관해 사후 누적 불가하므로) |
+| 로그 | Loki(single binary, filesystem, 72h) + Grafana Alloy가 k8s API로 파드 로그 tail(호스트 마운트 없음). Grafana Explore에서 LogQL 검색 |
+| 대시보드 | Grafana 프로비저닝(ConfigMap) — `ai-repo Overview`: HTTP/지갑거래/JVM/Hikari/CPU + Outbox row |
+| CI/CD | GitHub Actions(main push) → 이미지 태그 `{version}-{sha8}` → ghcr.io push → `deploy/gitops/kustomization.yaml` newTag 갱신 커밋(`[skip ci]`) |
+| GitOps | ArgoCD(로컬 설치, `--server-side` apply)가 `deploy/gitops`를 자동 sync(prune+selfHeal). 오버레이는 `../k8s` base + ghcr 이미지 교체 |
+| 모드 분리 | 같은 네임스페이스를 관리하므로 로컬 수동 모드(`k8s-local-up.sh`)와 GitOps 모드는 택1 |
+
+## 트레이드오프
+
+### 장점
+
+- 지표·로그·대시보드가 Grafana 한 곳에 모이고, main 머지만으로 배포가 완결된다.
+- 스택 전체가 리포 안 선언형 매니페스트라 재현·초기화가 쉽다(`k8s-local-down.sh` → up).
+- 커스텀 지표가 기존 도메인 모니터링 서비스를 재사용해 이중 상태가 없다.
+
+### 비용
+
+- 익명 Grafana Admin·평문 자격증명·단일 replica는 로컬 학습 전용 구성이다. 원격 전환 시 Secret/인증/HA 재설계가 필요하다.
+- CI 검증(ci.yml)과 deploy가 독립이라 깨진 커밋도 배포될 수 있다 — 필요 시 `workflow_run` 게이트로 전환한다.
+- Alloy가 k8s API로 로그를 tail하므로 초대형 로그 볼륨에는 부적합하다(로컬 규모에서는 무해).
+
+## 대안
+
+- kind/minikube: Docker Desktop k8s가 이미 있어 추가 도구 불필요.
+- ELK/EFK 로그 스택: Grafana 통합·경량성에서 Loki가 학습 랩에 적합.
+- CI에서 kubectl apply 직접 배포: 클러스터 자격증명이 CI로 나가고 상태 추적이 없어 GitOps(pull 방식)를 채택.
+- Helm 차트: kustomize가 이미 base/overlay 요구를 충족하고 의존성이 없다.

--- a/docs/development/architecture-diagrams.md
+++ b/docs/development/architecture-diagrams.md
@@ -1,0 +1,142 @@
+# 아키텍처 다이어그램
+
+인프라(배포·관측)와 내부 애플리케이션 구조를 mermaid로 정리한다. GitHub에서 자동 렌더링된다.
+
+## 1. 인프라 아키텍처
+
+GitOps 파이프라인(main push → GHCR → ArgoCD)과 로컬 Docker Desktop k8s 스택. 점선은 GitOps 대신 쓰는 수동 모드(`scripts/k8s-local-up.sh`)와 이미지 pull 경로.
+
+```mermaid
+graph TB
+    dev["개발자"]
+
+    subgraph GH["GitHub (IMWoo94/ai-repo)"]
+        repo["main 브랜치"]
+        actions["GitHub Actions<br/>deploy.yml"]
+        gitops["deploy/gitops<br/>kustomization.yaml (newTag)"]
+    end
+
+    ghcr["GHCR 이미지 레지스트리<br/>ghcr.io/imwoo94/ai-repo<br/>태그: version-sha8"]
+
+    subgraph K8S["Docker Desktop Kubernetes (로컬)"]
+        subgraph ARGONS["argocd 네임스페이스"]
+            argocd["ArgoCD<br/>자동 sync (prune + selfHeal)"]
+        end
+        subgraph NS["ai-repo 네임스페이스"]
+            app["ai-repo 앱 (Spring Boot)<br/>:8080 / NodePort 30080"]
+            pg[("PostgreSQL 17<br/>PVC 1Gi")]
+            prom["Prometheus<br/>NodePort 30990"]
+            loki["Loki (72h 보존)<br/>PVC 2Gi"]
+            alloy["Alloy 로그 수집기"]
+            graf["Grafana<br/>NodePort 30300"]
+        end
+    end
+
+    dev -->|git push main| repo
+    repo -->|트리거| actions
+    actions -->|이미지 빌드 + push| ghcr
+    actions -->|newTag 갱신 커밋, skip ci| gitops
+    argocd -->|변경 감지, pull| gitops
+    argocd -->|kustomize sync| app
+    ghcr -.->|이미지 pull| app
+    dev -.->|수동 모드: scripts/k8s-local-up.sh| app
+
+    app -->|JDBC :5432| pg
+    prom -->|15s 스크랩 /actuator/prometheus| app
+    alloy -->|파드 로그 tail, k8s API| app
+    alloy -->|로그 push| loki
+    graf -->|PromQL| prom
+    graf -->|LogQL| loki
+    dev -->|브라우저 localhost:30080 / 30300 / 30990| graf
+```
+
+- 접속 URL·계정: `docs/development/k8s-local-monitoring.md` 접속 정보 표
+- 파이프라인 상세: `docs/development/ci-cd-gitops.md`
+- 수동 모드와 GitOps 모드는 같은 네임스페이스를 관리하므로 택1
+
+## 2. 애플리케이션 아키텍처 (헥사고날)
+
+`api → application → domain`, 포트 인터페이스를 `infra` 어댑터가 구현한다. 저장소 어댑터는 Spring 프로파일로 교체된다(`!postgres` → InMemory, `postgres` → Jdbc+Flyway).
+
+```mermaid
+graph TB
+    user["사용자<br/>(React 프론트)"]
+    ops["운영자<br/>(X-Operator-Token / X-Admin-Token)"]
+
+    subgraph API["api 계층 — 인바운드 어댑터"]
+        sec["SecurityConfig 체인<br/>AdminHeaderAuthenticationFilter<br/>AdminApiAccessAuditFilter"]
+        wapi["WalletCommand / Query /<br/>LedgerController"]
+        oapi["운영 컨트롤러<br/>outbox review·requeue, relay run,<br/>consumer, alert, pruning, audit"]
+    end
+
+    subgraph APPL["application 계층 — 유스케이스 + 포트"]
+        cmd["WalletCommandService<br/>충전·송금 멱등 처리 →<br/>원장+감사+step log+outbox 기록"]
+        qry["WalletQuery / LedgerQueryService<br/>+ WalletAccessPolicy"]
+        relay["OutboxRelayService<br/>+ RelayMonitoringService"]
+        cons["OutboxConsumerService<br/>+ ConsumerMonitoring · Pruning"]
+        alertsvc["OperationalAlertService"]
+        ports["포트 인터페이스<br/>Wallet·Relay·Consumer Repository /<br/>OutboxPublisher / AlertPublisher / RelayMetricsRecorder"]
+    end
+
+    model["domain 계층<br/>WalletAccount · Money · LedgerEntry · AuditEvent ·<br/>OperationStepLog · OutboxEvent · RelayRun · Alert"]
+
+    subgraph INFRA["infra 계층 — 아웃바운드 어댑터"]
+        mem["InMemoryWalletRepository<br/>(!postgres 프로파일)"]
+        jdbc["JdbcWalletRepository<br/>(postgres 프로파일, Flyway)"]
+        pub["InMemory / Http<br/>OutboxPublisher"]
+        slack["Slack / Noop<br/>AlertPublisher"]
+    end
+
+    db[("PostgreSQL")]
+
+    user --> sec
+    ops --> sec
+    sec --> wapi
+    sec --> oapi
+
+    wapi --> cmd
+    wapi --> qry
+    oapi --> relay
+    oapi --> cons
+    oapi --> alertsvc
+
+    cmd --> ports
+    qry --> ports
+    relay --> ports
+    cons --> ports
+    alertsvc --> ports
+
+    ports -.->|도메인 모델 사용| model
+    ports -->|구현| mem
+    ports -->|구현| jdbc
+    ports -->|구현| pub
+    ports -->|구현| slack
+    jdbc --> db
+```
+
+- 돈 이동(충전·송금)은 하나의 operation으로 원장 + 감사 로그 + step log + outbox event를 남긴다(증적 원자성).
+- 운영 API는 operator(조회)/admin(변경) 토큰과 접근 감사 필터로 보호된다.
+
+## 3. 구동·관측 흐름 (스케줄러 → 지표 → Grafana)
+
+스케줄러가 relay를 주기 구동하고, 지표는 카운터(기록 시점 증가)와 게이지(스크레이프 시점 조회) 두 경로로 Micrometer에 모여 Prometheus → Grafana로 흐른다.
+
+```mermaid
+graph LR
+    sched["스케줄러<br/>(OutboxRelayScheduler 등)"] -->|주기 구동| relay["OutboxRelayService<br/>+ Monitoring"]
+    relay -->|recordSuccess / recordFailure| reg["OutboxRelayMetricsRegistry<br/>(카운터)"]
+    relay -.->|스크레이프 시점 조회| binder["OutboxMetricsBinder<br/>(게이지)"]
+    reg --> mm["Micrometer<br/>Registry"]
+    binder --> mm
+    mm --> act["/actuator/prometheus"]
+    act -->|15s 스크랩| prom["Prometheus"]
+    prom -->|PromQL| graf["Grafana<br/>ai-repo Overview"]
+```
+
+지표 목록과 대시보드 패널: `docs/development/k8s-local-monitoring.md` Outbox 커스텀 지표 섹션.
+
+## 관련 문서
+
+- `docs/development/k8s-local-monitoring.md` — 접속 정보·명령어·지표·로그 검색
+- `docs/development/ci-cd-gitops.md` — 배포 파이프라인·트러블슈팅
+- `docs/adr/0059-k8s-deploy-and-observability.md` — 설계 결정

--- a/docs/development/architecture-diagrams.md
+++ b/docs/development/architecture-diagrams.md
@@ -48,7 +48,29 @@ graph TB
     graf -->|PromQL| prom
     graf -->|LogQL| loki
     dev -->|브라우저 localhost:30080 / 30300 / 30990| graf
+
+    classDef actor fill:#fff3cd,stroke:#b45309,stroke-width:2px
+    classDef github fill:#dbeafe,stroke:#1d4ed8
+    classDef registry fill:#ede9fe,stroke:#7c3aed
+    classDef gitopsTool fill:#ffedd5,stroke:#ea580c
+    classDef workload fill:#dcfce7,stroke:#16a34a
+    classDef observability fill:#fce7f3,stroke:#be185d
+    classDef storage fill:#e2e8f0,stroke:#475569
+
+    class dev actor
+    class repo,actions,gitops github
+    class ghcr registry
+    class argocd gitopsTool
+    class app workload
+    class prom,loki,alloy,graf observability
+    class pg storage
+    style GH fill:#eff6ff,stroke:#93c5fd
+    style K8S fill:#f8fafc,stroke:#94a3b8
+    style ARGONS fill:#fff7ed,stroke:#fdba74
+    style NS fill:#f0fdf4,stroke:#86efac
 ```
+
+> 색상: 🟡 개발자 · 🔵 GitHub · 🟣 레지스트리 · 🟠 ArgoCD · 🟢 앱 워크로드 · 🩷 관측(모니터링·로그) · ⚪ 저장소
 
 - 접속 URL·계정: `docs/development/k8s-local-monitoring.md` 접속 정보 표
 - 파이프라인 상세: `docs/development/ci-cd-gitops.md`
@@ -112,7 +134,28 @@ graph TB
     ports -->|구현| pub
     ports -->|구현| slack
     jdbc --> db
+
+    classDef actor fill:#fff3cd,stroke:#b45309,stroke-width:2px
+    classDef apiLayer fill:#dbeafe,stroke:#1d4ed8
+    classDef applLayer fill:#dcfce7,stroke:#16a34a
+    classDef portNode fill:#bbf7d0,stroke:#15803d,stroke-width:2px
+    classDef domainLayer fill:#fef9c3,stroke:#ca8a04,stroke-width:2px
+    classDef infraLayer fill:#ede9fe,stroke:#7c3aed
+    classDef storage fill:#e2e8f0,stroke:#475569
+
+    class user,ops actor
+    class sec,wapi,oapi apiLayer
+    class cmd,qry,relay,cons,alertsvc applLayer
+    class ports portNode
+    class model domainLayer
+    class mem,jdbc,pub,slack infraLayer
+    class db storage
+    style API fill:#eff6ff,stroke:#93c5fd
+    style APPL fill:#f0fdf4,stroke:#86efac
+    style INFRA fill:#f5f3ff,stroke:#c4b5fd
 ```
+
+> 색상: 🟡 액터 · 🔵 api(인바운드) · 🟢 application(유스케이스, 진한 초록 = 포트) · 🟨 domain · 🟣 infra(아웃바운드) · ⚪ DB
 
 - 돈 이동(충전·송금)은 하나의 operation으로 원장 + 감사 로그 + step log + outbox event를 남긴다(증적 원자성).
 - 운영 API는 operator(조회)/admin(변경) 토큰과 접근 감사 필터로 보호된다.
@@ -131,7 +174,22 @@ graph LR
     mm --> act["/actuator/prometheus"]
     act -->|15s 스크랩| prom["Prometheus"]
     prom -->|PromQL| graf["Grafana<br/>ai-repo Overview"]
+
+    classDef driver fill:#fff3cd,stroke:#b45309
+    classDef service fill:#dcfce7,stroke:#16a34a
+    classDef counter fill:#dbeafe,stroke:#1d4ed8
+    classDef gauge fill:#fce7f3,stroke:#be185d
+    classDef expose fill:#ede9fe,stroke:#7c3aed
+
+    class sched driver
+    class relay service
+    class reg counter
+    class binder gauge
+    class mm,act expose
+    class prom,graf expose
 ```
+
+> 색상: 🟡 구동(스케줄러) · 🟢 서비스 · 🔵 카운터 경로(기록 시점) · 🩷 게이지 경로(스크레이프 시점) · 🟣 노출·수집
 
 지표 목록과 대시보드 패널: `docs/development/k8s-local-monitoring.md` Outbox 커스텀 지표 섹션.
 

--- a/docs/development/ci-cd-gitops.md
+++ b/docs/development/ci-cd-gitops.md
@@ -1,0 +1,80 @@
+# CI/CD — GitHub Actions → GHCR → GitOps → ArgoCD
+
+main 브랜치 push가 이미지 빌드부터 로컬 k8s 배포까지 자동으로 이어지는 파이프라인 가이드.
+
+## 파이프라인 흐름
+
+```
+main push
+  → GitHub Actions (.github/workflows/deploy.yml)
+      1. build.gradle version + 커밋 sha 앞 8자리 → 태그 {version}-{sha8} (예: 0.7.0-a1b2c3d4)
+      2. Docker 이미지 빌드 → ghcr.io/imwoo94/ai-repo:{tag} push
+      3. deploy/gitops/kustomization.yaml의 newTag 갱신 → "[skip ci]" 커밋 push
+  → ArgoCD (로컬 docker-desktop 클러스터)
+      deploy/gitops 변화 감지 → ai-repo 네임스페이스에 자동 sync (prune + selfHeal)
+```
+
+- **이미지 태그 규칙**: 반드시 `{version}-{sha8}`. `latest` 사용 금지.
+- **재트리거 방지**: deploy.yml은 `deploy/gitops/kustomization.yaml`을 paths-ignore하고, 매니페스트 커밋 메시지에 `[skip ci]`를 붙여 CI/deploy 루프를 차단한다.
+- CI 검증(ci.yml: gradle check/scenario/frontend)과 deploy는 독립 실행이다. 학습 랩 단순화를 위한 선택으로, 배포 전 CI 게이트가 필요해지면 `workflow_run` 트리거로 전환한다.
+
+## 디렉토리
+
+```
+.github/workflows/deploy.yml   # 빌드→push→매니페스트 갱신
+deploy/k8s/                    # base 매니페스트 (로컬 수동 모드도 이 디렉토리 사용)
+deploy/gitops/                 # ArgoCD가 sync하는 오버레이 (ghcr 이미지 + newTag)
+deploy/argocd/application.yaml # ArgoCD Application 정의
+scripts/argocd-install.sh      # 로컬 ArgoCD 설치 + Application 등록
+```
+
+## ArgoCD 설치 / 접속
+
+```bash
+./scripts/argocd-install.sh    # --server-side apply (CRD 크기 제한 때문에 필수)
+
+# UI
+kubectl -n argocd port-forward svc/argocd-server 8443:443
+# https://localhost:8443 — admin / 아래 명령의 출력
+kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' | base64 -d
+```
+
+## 배포 상태 확인
+
+```bash
+kubectl -n argocd get application ai-repo                     # Synced / Healthy 확인
+kubectl -n argocd describe application ai-repo | tail -30     # sync 이력·오류
+kubectl -n ai-repo get pods -o wide                           # 실제 파드 이미지 태그 확인
+kubectl -n ai-repo get deploy ai-repo -o jsonpath='{.spec.template.spec.containers[0].image}'
+```
+
+GitHub Actions 실행 확인: `gh run list --workflow deploy.yml`, 실패 로그는 `gh run view <id> --log-failed`.
+
+## 로컬 수동 모드 vs GitOps 모드
+
+같은 `ai-repo` 네임스페이스를 두 방식이 관리하므로 **동시에 쓰지 않는다**.
+
+| 모드 | 사용 | 전환 |
+| --- | --- | --- |
+| 수동 (기본) | `./scripts/k8s-local-up.sh` — 로컬 빌드 이미지 즉시 반영, 개발 루프용 | ArgoCD Application 삭제: `kubectl -n argocd delete application ai-repo` |
+| GitOps | main 머지 → 자동 배포. selfHeal이 수동 kubectl 변경을 되돌림 | `kubectl apply -f deploy/argocd/application.yaml` |
+
+## 트러블슈팅 / 로그 검색
+
+- **Actions 빌드 실패**: `gh run view --log-failed`. Dockerfile 빌드는 로컬에서 `docker build -t test .`로 재현.
+- **ArgoCD sync 실패**: `kubectl -n argocd get app ai-repo -o jsonpath='{.status.conditions}'`. repo-server 로그: `kubectl -n argocd logs deploy/argocd-repo-server --tail=100`.
+- **ImagePullBackOff**: ghcr 패키지가 private이면 로컬 노드가 pull 불가 → GitHub Packages에서 public 전환 또는 pull secret 등록. `kubectl -n ai-repo describe pod <pod>`로 원인 확인.
+- **앱 런타임 로그**: Grafana Explore(Loki)에서 `{app="ai-repo"} |= "ERROR"` — 자세한 LogQL 가이드는 `docs/development/k8s-local-monitoring.md` 로그 검색 섹션 참고. 즉석 확인은 `kubectl -n ai-repo logs deploy/ai-repo --tail=100 -f`.
+
+## 이슈 트래킹
+
+파이프라인/배포 문제를 발견하면:
+
+1. `issue-drafts/`에 `.github/ISSUE_TEMPLATE/bug.yml`(결함) 또는 `feature.yml`(개선) 형식으로 초안 작성
+2. GitHub Issue 생성 후 초안에 이슈 링크 기록 (`issue-drafts/README.md` 목록 갱신)
+3. 수정 PR에는 이슈 번호를 연결하고, 배포 관련 결정 변경은 ADR로 남긴다
+
+## 관련 문서
+
+- `docs/development/k8s-local-monitoring.md` — 로컬 k8s 스택, Grafana/Prometheus/Loki
+- `docs/adr/0059-k8s-deploy-and-observability.md` — 배포·관측 설계 결정

--- a/docs/development/k8s-local-monitoring.md
+++ b/docs/development/k8s-local-monitoring.md
@@ -19,13 +19,72 @@ Docker Desktop 내장 Kubernetes에 ai-repo 전체 스택(앱 + Postgres + Prome
 | 서비스 | URL | 계정 / 인증 |
 | --- | --- | --- |
 | 앱 API | http://localhost:30080 | 사용자 API 인증 없음. 운영 API는 헤더 `X-Operator-Token: local-operator-token`(조회) / `X-Admin-Token: local-ops-token`(변경) + `X-Operator-Id: <이름>` |
-| Prometheus | http://localhost:30990 | 없음 — `/targets`에서 ai-repo job UP 확인 |
-| Grafana | http://localhost:30300 | **익명 Admin, 로그인 불필요**(로컬 전용). `ai-repo Overview` 대시보드 자동 프로비저닝, Explore에서 Loki 로그 검색 |
-| Loki | 클러스터 내부 `http://loki:3100` | 없음. 외부 직접 조회 시 `kubectl -n ai-repo port-forward svc/loki 3100:3100` |
-| Postgres | 클러스터 내부 `postgres:5432` | `ai_repo` / `ai_repo`, DB `ai_repo`. 외부 접속 시 `kubectl -n ai-repo port-forward svc/postgres 5432:5432` |
-| ArgoCD (선택) | `kubectl -n argocd port-forward svc/argocd-server 8443:443` → https://localhost:8443 | `admin` / `kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' \| base64 -d` |
+| 앱 health | http://localhost:30080/actuator/health | 없음 |
+| 앱 메트릭 | http://localhost:30080/actuator/prometheus | 없음 |
+| Prometheus | http://localhost:30990 | 없음 |
+| Prometheus 타겟 상태 | http://localhost:30990/targets | 없음 — ai-repo job UP 확인 |
+| Grafana | http://localhost:30300 | **익명 Admin, 로그인 불필요**(로컬 전용) |
+| Grafana 대시보드 (ai-repo Overview) | http://localhost:30300/d/ai-repo-overview | 익명 Admin |
+| Grafana Explore (Loki 로그 검색) | http://localhost:30300/explore | 익명 Admin |
+| Loki API | 클러스터 내부 http://loki:3100 — 외부는 port-forward 후 http://localhost:3100 | 없음 |
+| Postgres | 클러스터 내부 postgres:5432 — 외부는 port-forward 후 localhost:5432 | 사용자 `ai_repo` / 비밀번호 `ai_repo` / DB `ai_repo` |
+| ArgoCD UI (선택) | port-forward 후 https://localhost:8443 | `admin` / 초기 비밀번호는 아래 명령으로 조회 |
 
 앱 운영 토큰은 `AI_REPO_OPS_OPERATOR_TOKEN`, `AI_REPO_OPS_ADMIN_TOKEN` 환경 변수로 override할 수 있다(`deploy/k8s/app.yaml`). ArgoCD 설치/GitOps 모드는 `docs/development/ci-cd-gitops.md` 참고.
+
+## 전체 명령어 모음 (리포 루트 기준, 복사-실행)
+
+```bash
+# ── 스택 기동 / 제거 ──────────────────────────────────────────────
+./scripts/k8s-local-up.sh                 # 이미지 빌드 → 배포 → 롤아웃 대기
+./scripts/k8s-local-down.sh               # 전체 제거 (Postgres 데이터 포함)
+./scripts/argocd-install.sh               # (선택) ArgoCD 설치 + ai-repo Application 등록
+
+# ── 앱 확인 ──────────────────────────────────────────────────────
+curl -s http://localhost:30080/actuator/health
+curl -s http://localhost:30080/actuator/prometheus | grep ai_repo_outbox
+
+# 사용자 API 예시 — 충전
+curl -s -X POST http://localhost:30080/api/v1/wallets/wallet-001/charges \
+  -H "Content-Type: application/json" \
+  -d '{"amount":1000,"currency":"KRW","idempotencyKey":"smoke-001","description":"스모크 충전"}'
+
+# 운영 API 예시 — relay health (operator 토큰)
+curl -s http://localhost:30080/api/v1/outbox-relay-runs/health \
+  -H "X-Operator-Token: local-operator-token" \
+  -H "X-Operator-Id: local-dev"
+
+# ── Prometheus ───────────────────────────────────────────────────
+open http://localhost:30990/targets                                  # 타겟 UP 확인 (macOS)
+curl -s -G http://localhost:30990/api/v1/query \
+  --data-urlencode 'query=ai_repo_outbox_relay_runs_total'           # 지표 직접 조회
+
+# ── Grafana ──────────────────────────────────────────────────────
+open http://localhost:30300/d/ai-repo-overview                       # 대시보드
+open http://localhost:30300/explore                                  # Loki 로그 검색 (LogQL)
+
+# ── Loki 직접 조회 (Grafana 없이) ────────────────────────────────
+kubectl --context docker-desktop -n ai-repo port-forward svc/loki 3100:3100 &
+curl -s -G http://localhost:3100/loki/api/v1/query_range \
+  --data-urlencode 'query={app="ai-repo"} |= "ERROR"' \
+  --data-urlencode 'limit=20'
+
+# ── Postgres 직접 접속 ───────────────────────────────────────────
+kubectl --context docker-desktop -n ai-repo port-forward svc/postgres 5432:5432 &
+psql -h localhost -p 5432 -U ai_repo -d ai_repo                      # 비밀번호: ai_repo
+
+# ── ArgoCD (선택, GitOps 모드) ───────────────────────────────────
+kubectl --context docker-desktop -n argocd port-forward svc/argocd-server 8443:443 &
+open https://localhost:8443                                          # admin / 아래 비밀번호
+kubectl --context docker-desktop -n argocd get secret argocd-initial-admin-secret \
+  -o jsonpath='{.data.password}' | base64 -d; echo
+kubectl --context docker-desktop -n argocd get application ai-repo   # Synced / Healthy 확인
+
+# ── 파드 상태 / 즉석 로그 ────────────────────────────────────────
+kubectl --context docker-desktop -n ai-repo get pods -o wide
+kubectl --context docker-desktop -n ai-repo logs deploy/ai-repo --tail=100 -f
+kubectl --context docker-desktop -n ai-repo get events --sort-by=.lastTimestamp
+```
 
 ## 구성
 

--- a/docs/development/k8s-local-monitoring.md
+++ b/docs/development/k8s-local-monitoring.md
@@ -14,11 +14,18 @@ Docker Desktop 내장 Kubernetes에 ai-repo 전체 스택(앱 + Postgres + Prome
 ./scripts/k8s-local-down.sh  # 전체 제거 (namespace 삭제, Postgres 데이터 포함)
 ```
 
-| 서비스 | URL | 비고 |
+## 접속 정보 (URL · 계정)
+
+| 서비스 | URL | 계정 / 인증 |
 | --- | --- | --- |
-| 앱 | http://localhost:30080 | postgres 프로파일, outbox relay scheduler 활성 |
-| Prometheus | http://localhost:30990 | `/targets`에서 ai-repo job UP 확인 |
-| Grafana | http://localhost:30300 | 익명 Admin(로컬 전용), `ai-repo Overview` 대시보드 자동 프로비저닝, Explore에서 Loki 로그 검색 |
+| 앱 API | http://localhost:30080 | 사용자 API 인증 없음. 운영 API는 헤더 `X-Operator-Token: local-operator-token`(조회) / `X-Admin-Token: local-ops-token`(변경) + `X-Operator-Id: <이름>` |
+| Prometheus | http://localhost:30990 | 없음 — `/targets`에서 ai-repo job UP 확인 |
+| Grafana | http://localhost:30300 | **익명 Admin, 로그인 불필요**(로컬 전용). `ai-repo Overview` 대시보드 자동 프로비저닝, Explore에서 Loki 로그 검색 |
+| Loki | 클러스터 내부 `http://loki:3100` | 없음. 외부 직접 조회 시 `kubectl -n ai-repo port-forward svc/loki 3100:3100` |
+| Postgres | 클러스터 내부 `postgres:5432` | `ai_repo` / `ai_repo`, DB `ai_repo`. 외부 접속 시 `kubectl -n ai-repo port-forward svc/postgres 5432:5432` |
+| ArgoCD (선택) | `kubectl -n argocd port-forward svc/argocd-server 8443:443` → https://localhost:8443 | `admin` / `kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' \| base64 -d` |
+
+앱 운영 토큰은 `AI_REPO_OPS_OPERATOR_TOKEN`, `AI_REPO_OPS_ADMIN_TOKEN` 환경 변수로 override할 수 있다(`deploy/k8s/app.yaml`). ArgoCD 설치/GitOps 모드는 `docs/development/ci-cd-gitops.md` 참고.
 
 ## 구성
 

--- a/docs/development/k8s-local-monitoring.md
+++ b/docs/development/k8s-local-monitoring.md
@@ -1,6 +1,6 @@
-# 로컬 k8s 배포 + Grafana 모니터링
+# 로컬 k8s 배포 + Grafana 모니터링 + 로그 검색
 
-Docker Desktop 내장 Kubernetes에 ai-repo 전체 스택(앱 + Postgres + Prometheus + Grafana)을 배포하는 가이드.
+Docker Desktop 내장 Kubernetes에 ai-repo 전체 스택(앱 + Postgres + Prometheus + Grafana + Loki)을 배포하는 가이드.
 
 ## 전제 조건
 
@@ -18,7 +18,7 @@ Docker Desktop 내장 Kubernetes에 ai-repo 전체 스택(앱 + Postgres + Prome
 | --- | --- | --- |
 | 앱 | http://localhost:30080 | postgres 프로파일, outbox relay scheduler 활성 |
 | Prometheus | http://localhost:30990 | `/targets`에서 ai-repo job UP 확인 |
-| Grafana | http://localhost:30300 | 익명 Admin(로컬 전용), `ai-repo Overview` 대시보드 자동 프로비저닝 |
+| Grafana | http://localhost:30300 | 익명 Admin(로컬 전용), `ai-repo Overview` 대시보드 자동 프로비저닝, Explore에서 Loki 로그 검색 |
 
 ## 구성
 
@@ -29,26 +29,76 @@ deploy/k8s/
 ├── postgres.yaml           # postgres:17-alpine + PVC(1Gi), compose.yml과 동일 자격증명
 ├── app.yaml                # ai-repo:local 이미지(imagePullPolicy: Never), NodePort 30080
 ├── prometheus.yaml         # /actuator/prometheus 15s 스크랩, 3d 보존, NodePort 30990
-├── grafana.yaml            # 데이터소스·대시보드 프로비저닝, NodePort 30300
+├── loki.yaml               # Loki 3.5 single binary, filesystem 저장, 72h 보존
+├── alloy.yaml              # Grafana Alloy — ai-repo 네임스페이스 파드 로그를 k8s API로 수집해 Loki 전송
+├── grafana.yaml            # 데이터소스(Prometheus·Loki)·대시보드 프로비저닝, NodePort 30300
 └── grafana-dashboard.yaml  # ai-repo Overview 대시보드 JSON
 ```
 
 - **메트릭 노출**: `micrometer-registry-prometheus` + `management.endpoints.web.exposure.include: health,prometheus`. HTTP 지연시간 분위수(p95/p99)를 위해 `percentiles-histogram.http.server.requests: true`.
-- **대시보드 패널**: HTTP 요청률/오류율/p95·p99, 지갑 거래 요청률(charge·transfer·payment POST), JVM Heap/GC, Hikari 커넥션, CPU, up.
-- **이미지 태그**: 로컬은 `ai-repo:local`. CI/CD 도입 시 `{version}-{sha8}` 태그로 전환하고 GitOps 매니페스트를 갱신한다(ArgoCD sync — 후속 작업).
+- **대시보드 패널**: HTTP 요청률/오류율/p95·p99, 지갑 거래 요청률(charge·transfer·payment POST), JVM Heap/GC, Hikari 커넥션, CPU, up + Outbox 릴레이/컨슈머 row(아래 커스텀 지표).
+- **이미지 태그**: 로컬은 `ai-repo:local`. GitOps 배포는 `ghcr.io/imwoo94/ai-repo:{version}-{sha8}` — `docs/development/ci-cd-gitops.md` 참고.
 - **보안 주의**: 익명 Grafana Admin, 평문 DB 자격증명은 로컬 학습 환경 전용이다. 원격 클러스터에 그대로 쓰지 않는다.
+
+## Outbox 커스텀 지표
+
+기존 outbox 모니터링 도메인 서비스를 재구조화하지 않고 비침습적 브리지로 노출한다. 게이지(pending, health, consumer 누적)는 `OutboxMetricsBinder`(MeterBinder)가 스크레이프 시점에 모니터링 서비스를 읽고, 릴레이 실행/발행 카운터는 `OutboxRelayMetricsRecorder` 포트를 통해 `recordSuccess/recordFailure` 시점에 증가시켜 단조 증가를 보장한다(릴레이 실행 저장소는 최근 샘플만 보관하므로 사후 누적 불가). health enum은 0/1/2 수치로 매핑해 알람 임계값에 바로 쓸 수 있다.
+
+| Prometheus 지표 | 타입 | 태그 |
+| --- | --- | --- |
+| `ai_repo_outbox_relay_runs_total` | counter | `result=success\|failure` |
+| `ai_repo_outbox_relay_published_events_total` | counter | `outcome=published\|failed` |
+| `ai_repo_outbox_relay_pending_events` | gauge | — |
+| `ai_repo_outbox_relay_health_status` | gauge | 0=ok, 1=warning, 2=critical |
+| `ai_repo_outbox_consumer_events_total` | counter | `outcome=processed\|duplicate` |
+| `ai_repo_outbox_consumer_health_status` | gauge | 0=ok, 1=warning, 2=critical |
+
+(컨슈머는 실패 시 예외로 중단되어 기록이 남지 않으므로 `failed` outcome이 없다 — 도메인 의미론과 일치.)
+
+## 로그 검색 (Loki)
+
+수집 경로: Alloy가 ai-repo 네임스페이스의 모든 파드 로그를 k8s API로 tail(호스트 마운트 없음) → Loki(72h 보존). 라벨: `namespace`, `pod`, `container`, `app`.
+
+**Grafana Explore** (http://localhost:30300 → Explore → Loki) LogQL 예시:
+
+```logql
+{app="ai-repo"}                                  # 앱 전체 로그
+{app="ai-repo"} |= "ERROR"                       # 에러만
+{app="ai-repo"} |= "op-001"                      # 특정 operation 추적
+{app="ai-repo"} |~ "Transfer|TRANSFER"           # 정규식 매칭
+{namespace="ai-repo", app="postgres"}            # DB 로그
+sum by (app) (rate({namespace="ai-repo"}[5m]))   # 컴포넌트별 로그 발생률
+```
+
+즉석 확인(kubectl):
+
+```bash
+kubectl -n ai-repo logs deploy/ai-repo --tail=100 -f          # 앱 로그 follow
+kubectl -n ai-repo logs deploy/ai-repo --previous             # 재시작 직전 로그(크래시 원인)
+kubectl -n ai-repo get events --sort-by=.lastTimestamp        # 파드 이벤트(OOM, probe 실패 등)
+```
 
 ## 스모크 확인
 
 ```bash
 curl -s http://localhost:30080/actuator/health | jq .status          # "UP"
-curl -s http://localhost:30080/actuator/prometheus | head            # 메트릭 텍스트
+curl -s http://localhost:30080/actuator/prometheus | grep ai_repo_outbox | head   # 커스텀 지표
 curl -s http://localhost:30990/api/v1/targets | jq '.data.activeTargets[].health'  # "up"
+kubectl -n ai-repo port-forward svc/loki 3100:3100 &                 # Loki 직접 조회 시
+curl -s -G http://localhost:3100/loki/api/v1/query_range --data-urlencode 'query={app="ai-repo"}' --data-urlencode 'limit=5'
 ```
 
 트래픽을 만들어 대시보드를 확인하려면 지갑 API를 호출한다(예: `scripts/mvp-local-smoke.sh` 참고).
 
-## 후속 작업 (로드맵)
+## 이슈 트래킹
 
-- GitHub Actions 이미지 빌드 → `{version}-{sha8}` 푸시 → GitOps 매니페스트 갱신 → ArgoCD sync
-- outbox relay/consumer 커스텀 Micrometer 지표 노출(현재는 HTTP/JVM/Hikari 표준 지표 기반)
+모니터링/로그에서 문제(지표 이상, 에러 로그, 파드 크래시)를 발견하면:
+
+1. Grafana 패널 스크린샷 또는 LogQL 쿼리 결과, `kubectl describe` 출력을 증적으로 수집
+2. `issue-drafts/`에 `.github/ISSUE_TEMPLATE/bug.yml` 형식으로 초안 작성(재현 절차 + 증적 포함)
+3. GitHub Issue 생성 후 `issue-drafts/README.md` 목록에 링크 기록, 수정 PR에 이슈 연결
+
+## 관련 문서
+
+- `docs/development/ci-cd-gitops.md` — GitHub Actions → GHCR → GitOps → ArgoCD 배포 파이프라인
+- `docs/adr/0059-k8s-deploy-and-observability.md` — 배포·관측 설계 결정

--- a/docs/development/k8s-local-monitoring.md
+++ b/docs/development/k8s-local-monitoring.md
@@ -1,0 +1,54 @@
+# 로컬 k8s 배포 + Grafana 모니터링
+
+Docker Desktop 내장 Kubernetes에 ai-repo 전체 스택(앱 + Postgres + Prometheus + Grafana)을 배포하는 가이드.
+
+## 전제 조건
+
+- Docker Desktop 실행 중, **Settings → Kubernetes → Enable Kubernetes** 활성화
+- `kubectl` 설치 (`docker-desktop` context 자동 생성됨)
+
+## 기동 / 정리
+
+```bash
+./scripts/k8s-local-up.sh    # 이미지 빌드 → kubectl apply -k → 롤아웃 대기
+./scripts/k8s-local-down.sh  # 전체 제거 (namespace 삭제, Postgres 데이터 포함)
+```
+
+| 서비스 | URL | 비고 |
+| --- | --- | --- |
+| 앱 | http://localhost:30080 | postgres 프로파일, outbox relay scheduler 활성 |
+| Prometheus | http://localhost:30990 | `/targets`에서 ai-repo job UP 확인 |
+| Grafana | http://localhost:30300 | 익명 Admin(로컬 전용), `ai-repo Overview` 대시보드 자동 프로비저닝 |
+
+## 구성
+
+```
+deploy/k8s/
+├── kustomization.yaml
+├── namespace.yaml          # ai-repo 네임스페이스
+├── postgres.yaml           # postgres:17-alpine + PVC(1Gi), compose.yml과 동일 자격증명
+├── app.yaml                # ai-repo:local 이미지(imagePullPolicy: Never), NodePort 30080
+├── prometheus.yaml         # /actuator/prometheus 15s 스크랩, 3d 보존, NodePort 30990
+├── grafana.yaml            # 데이터소스·대시보드 프로비저닝, NodePort 30300
+└── grafana-dashboard.yaml  # ai-repo Overview 대시보드 JSON
+```
+
+- **메트릭 노출**: `micrometer-registry-prometheus` + `management.endpoints.web.exposure.include: health,prometheus`. HTTP 지연시간 분위수(p95/p99)를 위해 `percentiles-histogram.http.server.requests: true`.
+- **대시보드 패널**: HTTP 요청률/오류율/p95·p99, 지갑 거래 요청률(charge·transfer·payment POST), JVM Heap/GC, Hikari 커넥션, CPU, up.
+- **이미지 태그**: 로컬은 `ai-repo:local`. CI/CD 도입 시 `{version}-{sha8}` 태그로 전환하고 GitOps 매니페스트를 갱신한다(ArgoCD sync — 후속 작업).
+- **보안 주의**: 익명 Grafana Admin, 평문 DB 자격증명은 로컬 학습 환경 전용이다. 원격 클러스터에 그대로 쓰지 않는다.
+
+## 스모크 확인
+
+```bash
+curl -s http://localhost:30080/actuator/health | jq .status          # "UP"
+curl -s http://localhost:30080/actuator/prometheus | head            # 메트릭 텍스트
+curl -s http://localhost:30990/api/v1/targets | jq '.data.activeTargets[].health'  # "up"
+```
+
+트래픽을 만들어 대시보드를 확인하려면 지갑 API를 호출한다(예: `scripts/mvp-local-smoke.sh` 참고).
+
+## 후속 작업 (로드맵)
+
+- GitHub Actions 이미지 빌드 → `{version}-{sha8}` 푸시 → GitOps 매니페스트 갱신 → ArgoCD sync
+- outbox relay/consumer 커스텀 Micrometer 지표 노출(현재는 HTTP/JVM/Hikari 표준 지표 기반)

--- a/docs/progress/0069-k8s-deploy-and-observability.md
+++ b/docs/progress/0069-k8s-deploy-and-observability.md
@@ -1,0 +1,41 @@
+# 0069. 로컬 k8s 배포와 관측 스택 (B4 로드맵)
+
+## 스펙 목표
+
+- Docker Desktop k8s에 ai-repo 전체 스택을 로컬 배포하고 Grafana 기반 모니터링을 구축한다.
+- Grafana에서 로그 검색이 가능해야 한다(Loki).
+- main 머지 시 자동 배포되는 CI/CD GitOps 파이프라인(GitHub Actions → GHCR → ArgoCD)을 구성한다.
+- outbox relay/consumer 커스텀 Micrometer 지표를 노출한다.
+
+## 완료 결과
+
+- **k8s 스택**(`deploy/k8s`, kustomize): 앱(postgres 프로파일, liveness/readiness probe, NodePort 30080) + Postgres 17(PVC) + Prometheus(15s 스크랩, NodePort 30990) + Grafana(데이터소스·대시보드 프로비저닝, NodePort 30300) + Loki(72h 보존) + Alloy(k8s API 로그 수집). `scripts/k8s-local-up.sh`/`k8s-local-down.sh`.
+- **메트릭**: micrometer-registry-prometheus + `/actuator/prometheus` 노출, HTTP p95/p99 히스토그램. 커스텀 outbox 지표 6종(`ai_repo_outbox_relay_runs_total`, `relay_published_events_total`, `relay_pending_events`, `relay_health_status`, `consumer_events_total`, `consumer_health_status`) — 비침습 브리지(`OutboxMetricsBinder` 게이지 + `OutboxRelayMetricsRecorder` 포트 카운터).
+- **대시보드**: `ai-repo Overview` 16패널 — HTTP 요청률/오류율/p95·p99, 지갑 거래율, JVM/GC, Hikari, CPU, up + Outbox 릴레이/컨슈머 row.
+- **로그 검색**: Grafana Explore에서 LogQL(`{app="ai-repo"} |= "ERROR"` 등), 라벨 namespace/pod/container/app.
+- **CI/CD**: `.github/workflows/deploy.yml` — main push 시 `{version}-{sha8}` 태그로 ghcr.io/imwoo94/ai-repo push 후 `deploy/gitops` newTag 갱신(`[skip ci]`). ArgoCD Application(`deploy/argocd`)이 자동 sync(prune+selfHeal). 설치는 `scripts/argocd-install.sh`(--server-side).
+- **문서**: `docs/development/k8s-local-monitoring.md`(가이드·로그 검색·이슈 트래킹), `docs/development/ci-cd-gitops.md`(파이프라인·트러블슈팅·모드 전환·이슈 트래킹), ADR-0059.
+
+## 개선 건수
+
+1. 로컬 k8s 배포 + Prometheus/Grafana/Loki 관측 스택 신설.
+2. outbox relay/consumer 커스텀 지표 6종 노출과 대시보드 반영.
+3. GitHub Actions → GHCR → GitOps → ArgoCD 자동 배포 파이프라인 신설.
+
+## 검증
+
+- `./gradlew test` 통과(신규 지표 브리지 단위 테스트 포함), `./gradlew postgresScenarioTest` 통과
+- 실배포 스모크: health UP → 충전 API 트래픽 → Prometheus target up·지표 수집 → Grafana 대시보드/Loki LogQL 조회 확인
+- ArgoCD Application Synced/Healthy (검증은 feature 브랜치 대상, main 머지 후 `deploy/argocd/application.yaml` 재적용)
+
+## 남은 일
+
+- main 머지 후 첫 deploy.yml 실행으로 실제 ghcr push·GitOps 갱신 검증(그 전까지 ghcr 패키지 미존재)
+- ghcr 패키지 public 전환(로컬 노드 익명 pull용) 또는 pull secret 등록
+- 배포 전 CI 게이트(`workflow_run`) 도입 여부 검토
+
+## 관련 문서
+
+- `docs/adr/0059-k8s-deploy-and-observability.md`
+- `docs/development/k8s-local-monitoring.md`
+- `docs/development/ci-cd-gitops.md`

--- a/docs/progress/0069-k8s-deploy-and-observability.md
+++ b/docs/progress/0069-k8s-deploy-and-observability.md
@@ -36,6 +36,7 @@
 
 ## 관련 문서
 
+- GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/110
 - `docs/adr/0059-k8s-deploy-and-observability.md`
 - `docs/development/k8s-local-monitoring.md`
 - `docs/development/ci-cd-gitops.md`

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -81,10 +81,11 @@ ADR은 “왜 그렇게 결정했는가”를 기록하고, 이 폴더는 “각
 | 0063 | [Operational Alert Suppression and Pruning](0063-operational-alert-suppression-pruning.md) | 완료 |
 | 0064 | [Slack Webhook Operational Alert Publisher](0064-slack-webhook-operational-alert-publisher.md) | 완료 |
 | 0065 | [Admin API Path Matching Hardening](0065-admin-api-path-matching-hardening.md) | 완료 |
+| 0069 | [로컬 k8s 배포와 관측 스택](0069-k8s-deploy-and-observability.md) | 완료 |
 
 ## 현재 기준선
 
 - 최신 병합 기준: `main`
-- 최신 완료 기능: Admin API Path Matching Hardening
+- 최신 완료 기능: 로컬 k8s 배포와 관측 스택
 - 현재 릴리스 후보: `v0.7.0`
 - 아직 미완료: Kafka/RabbitMQ/SQS adapter, pruning 실행 이력, Slack 발행 실패 record와 재시도 정책, broker-specific Testcontainers 정책, broker replay window별 retention 권장값, 실제 identity/role scope 연동, 운영 alert 화면 연결

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -29,6 +29,8 @@
 - Operational alert suppression and pruning
 - Slack webhook operational alert publisher
 - `.dev/rules` 자동 문서/테스트 동기화 체크
+- 로컬 k8s 배포 스택(Prometheus/Grafana/Loki)과 outbox 커스텀 지표
+- GitHub Actions → GHCR → GitOps → ArgoCD 배포 파이프라인
 
 ## MVP 출시 판단 기준
 

--- a/issue-drafts/0069-k8s-deploy-and-observability.md
+++ b/issue-drafts/0069-k8s-deploy-and-observability.md
@@ -1,0 +1,32 @@
+# 로컬 k8s 배포와 관측 스택 (B4 로드맵)
+
+## 배경
+
+ai-repo는 `compose.yml`(Postgres 단독)과 로컬 프로세스 실행에 의존했고, 배포·모니터링·로그 검색 체계가 없었다. 로컬에서 k8s로 전체 스택을 띄우고 Grafana 기반으로 지표·로그를 관측하며, main 머지 시 자동 배포되는 파이프라인이 필요하다.
+
+## 목표
+
+- Docker Desktop k8s에 앱 + Postgres + Prometheus + Grafana + Loki 전체 스택을 배포한다.
+- Grafana 대시보드(ai-repo Overview)와 Explore 로그 검색(LogQL)을 제공한다.
+- outbox relay/consumer 커스텀 Micrometer 지표를 노출한다.
+- GitHub Actions → GHCR(`{version}-{sha8}`) → GitOps 매니페스트 갱신 → ArgoCD 자동 sync 파이프라인을 구성한다.
+- 각 작업의 가이드(구동 방법, 접속 URL·계정, 로그 검색, 이슈 트래킹) 문서를 필수로 남긴다.
+
+## 완료 조건
+
+- [x] `deploy/k8s` kustomize 스택과 `scripts/k8s-local-up.sh`/`k8s-local-down.sh`로 기동·제거된다.
+- [x] `/actuator/prometheus` 노출과 HTTP p95/p99 히스토그램이 활성화된다.
+- [x] outbox 지표 6종(`ai_repo_outbox_*`)이 노출되고 대시보드 패널로 표시된다.
+- [x] Loki + Alloy로 파드 로그가 수집되고 Grafana Explore에서 검색된다.
+- [x] `deploy.yml`이 main push에서 이미지 push와 `deploy/gitops` newTag 갱신을 수행한다(`[skip ci]` 루프 차단).
+- [x] ArgoCD Application이 `deploy/gitops`를 자동 sync(prune+selfHeal)하고 Synced/Healthy가 된다.
+- [x] README 진입점 + 접속 정보 표 + 전체 명령어 모음 + 아키텍처 다이어그램(색상 구분 mermaid)이 문서화된다.
+- [x] ADR-0059, progress 0069가 기록된다.
+
+## 관련 문서
+
+- `docs/adr/0059-k8s-deploy-and-observability.md`
+- `docs/progress/0069-k8s-deploy-and-observability.md`
+- `docs/development/k8s-local-monitoring.md`
+- `docs/development/ci-cd-gitops.md`
+- `docs/development/architecture-diagrams.md`

--- a/issue-drafts/README.md
+++ b/issue-drafts/README.md
@@ -117,6 +117,8 @@
 - `0063-operational-alert-suppression-pruning.md`: Operational alert suppression and pruning 작업 초안
 - `0064-slack-webhook-operational-alert-publisher.md`: Slack webhook operational alert publisher 작업 초안
 - `0065-admin-api-path-matching-hardening.md`: Admin API path matching hardening 작업 초안
+- `0069-k8s-deploy-and-observability.md`: 로컬 k8s 배포와 관측 스택(B4) 작업 초안
+  - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/110
 
 ## GitHub CLI로 생성
 

--- a/scripts/argocd-install.sh
+++ b/scripts/argocd-install.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# 로컬 Docker Desktop k8s에 ArgoCD를 설치하고 ai-repo Application을 등록한다.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+CONTEXT=docker-desktop
+
+echo "==> ArgoCD 설치"
+kubectl --context "$CONTEXT" create namespace argocd --dry-run=client -o yaml | kubectl --context "$CONTEXT" apply -f -
+kubectl --context "$CONTEXT" apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+
+echo "==> ArgoCD 서버 대기"
+kubectl --context "$CONTEXT" -n argocd rollout status deployment/argocd-server --timeout=300s
+kubectl --context "$CONTEXT" -n argocd rollout status deployment/argocd-repo-server --timeout=300s
+
+echo "==> ai-repo Application 등록"
+kubectl --context "$CONTEXT" apply -f deploy/argocd/application.yaml
+
+PASSWORD=$(kubectl --context "$CONTEXT" -n argocd get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' | base64 -d)
+
+cat <<EOF
+
+ArgoCD 설치 완료:
+  UI 접속:   kubectl -n argocd port-forward svc/argocd-server 8443:443
+             https://localhost:8443 (admin / ${PASSWORD})
+  상태 확인: kubectl -n argocd get application ai-repo
+EOF

--- a/scripts/argocd-install.sh
+++ b/scripts/argocd-install.sh
@@ -7,7 +7,8 @@ CONTEXT=docker-desktop
 
 echo "==> ArgoCD 설치"
 kubectl --context "$CONTEXT" create namespace argocd --dry-run=client -o yaml | kubectl --context "$CONTEXT" apply -f -
-kubectl --context "$CONTEXT" apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+# --server-side: ArgoCD CRD가 client-side apply 주석 크기 제한(256KiB)을 초과하므로 필수
+kubectl --context "$CONTEXT" apply -n argocd --server-side --force-conflicts -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
 
 echo "==> ArgoCD 서버 대기"
 kubectl --context "$CONTEXT" -n argocd rollout status deployment/argocd-server --timeout=300s

--- a/scripts/k8s-local-down.sh
+++ b/scripts/k8s-local-down.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# 로컬 k8s의 ai-repo 스택을 제거한다. (namespace 삭제로 Postgres 데이터도 함께 초기화됨)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+kubectl --context docker-desktop delete -k deploy/k8s --ignore-not-found
+echo "정리 완료 (Postgres 데이터 포함 전체 삭제)"

--- a/scripts/k8s-local-up.sh
+++ b/scripts/k8s-local-up.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# 로컬 Docker Desktop k8s에 ai-repo + Postgres + Prometheus + Grafana를 배포한다.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+CONTEXT=docker-desktop
+
+echo "==> Docker/K8s 확인"
+docker info >/dev/null || { echo "Docker Desktop이 실행 중이어야 합니다."; exit 1; }
+kubectl --context "$CONTEXT" get nodes >/dev/null || {
+  echo "docker-desktop k8s 클러스터에 연결할 수 없습니다 (Docker Desktop 설정에서 Kubernetes 활성화)."; exit 1; }
+
+echo "==> 이미지 빌드 (ai-repo:local)"
+docker build -t ai-repo:local .
+
+echo "==> 매니페스트 적용"
+kubectl --context "$CONTEXT" apply -k deploy/k8s
+
+echo "==> 롤아웃 대기"
+kubectl --context "$CONTEXT" -n ai-repo rollout status deployment/postgres --timeout=180s
+kubectl --context "$CONTEXT" -n ai-repo rollout status deployment/ai-repo --timeout=300s
+kubectl --context "$CONTEXT" -n ai-repo rollout status deployment/prometheus --timeout=180s
+kubectl --context "$CONTEXT" -n ai-repo rollout status deployment/grafana --timeout=180s
+
+cat <<'EOF'
+
+배포 완료:
+  앱          http://localhost:30080          (health: /actuator/health, metrics: /actuator/prometheus)
+  Prometheus  http://localhost:30990          (targets: /targets)
+  Grafana     http://localhost:30300          (익명 Admin, 대시보드: ai-repo Overview)
+EOF

--- a/src/main/java/com/imwoo/airepo/wallet/application/OperationOutboxRelayMonitoringService.java
+++ b/src/main/java/com/imwoo/airepo/wallet/application/OperationOutboxRelayMonitoringService.java
@@ -18,17 +18,20 @@ public class OperationOutboxRelayMonitoringService {
     private final OperationOutboxRelayRunRepository operationOutboxRelayRunRepository;
     private final OutboxRelayHealthPolicy outboxRelayHealthPolicy;
     private final OperationalAlertService operationalAlertService;
+    private final OutboxRelayMetricsRecorder metricsRecorder;
     private final Clock clock;
 
     public OperationOutboxRelayMonitoringService(
             OperationOutboxRelayRunRepository operationOutboxRelayRunRepository,
             OutboxRelayHealthPolicy outboxRelayHealthPolicy,
             OperationalAlertService operationalAlertService,
+            OutboxRelayMetricsRecorder metricsRecorder,
             Clock clock
     ) {
         this.operationOutboxRelayRunRepository = operationOutboxRelayRunRepository;
         this.outboxRelayHealthPolicy = outboxRelayHealthPolicy;
         this.operationalAlertService = operationalAlertService;
+        this.metricsRecorder = metricsRecorder;
         this.clock = clock;
     }
 
@@ -49,6 +52,7 @@ public class OperationOutboxRelayMonitoringService {
                 result.failedCount(),
                 null
         ));
+        metricsRecorder.recordRelaySuccess(result.publishedCount(), result.failedCount());
     }
 
     public void recordFailure(Instant startedAt, Instant completedAt, int batchSize, String errorMessage) {
@@ -63,6 +67,7 @@ public class OperationOutboxRelayMonitoringService {
                 0,
                 normalizedErrorMessage(errorMessage)
         ));
+        metricsRecorder.recordRelayFailure();
     }
 
     public List<OperationOutboxRelayRun> getRecentRuns(int limit) {

--- a/src/main/java/com/imwoo/airepo/wallet/application/OperationOutboxRelayRepository.java
+++ b/src/main/java/com/imwoo/airepo/wallet/application/OperationOutboxRelayRepository.java
@@ -10,6 +10,8 @@ public interface OperationOutboxRelayRepository {
 
     List<OperationOutboxEvent> findPendingOutboxEvents(int limit);
 
+    long countPendingOutboxEvents();
+
     List<OperationOutboxEvent> findManualReviewOutboxEvents(int limit);
 
     List<OperationOutboxRequeueAudit> findOutboxRequeueAudits(String outboxEventId);

--- a/src/main/java/com/imwoo/airepo/wallet/application/OperationOutboxRelayService.java
+++ b/src/main/java/com/imwoo/airepo/wallet/application/OperationOutboxRelayService.java
@@ -37,6 +37,10 @@ public class OperationOutboxRelayService {
         return operationOutboxRelayRepository.findPendingOutboxEvents(limit);
     }
 
+    public long getPendingEventCount() {
+        return operationOutboxRelayRepository.countPendingOutboxEvents();
+    }
+
     public List<OperationOutboxEvent> getManualReviewEvents(int limit) {
         if (limit <= 0) {
             throw new InvalidWalletOperationException("limit must be positive");

--- a/src/main/java/com/imwoo/airepo/wallet/application/OutboxRelayMetricsRecorder.java
+++ b/src/main/java/com/imwoo/airepo/wallet/application/OutboxRelayMetricsRecorder.java
@@ -1,0 +1,22 @@
+package com.imwoo.airepo.wallet.application;
+
+/**
+ * Application port that records relay run outcomes into a metrics sink.
+ *
+ * <p>The relay run store keeps only a bounded recent sample, so cumulative counters cannot be
+ * derived from it after the fact. This recorder captures each relay outcome at the moment it is
+ * recorded, allowing an infrastructure adapter (Micrometer) to expose monotonically increasing
+ * counters. The default no-op implementation keeps the monitoring service usable without a metrics
+ * backend.
+ */
+public interface OutboxRelayMetricsRecorder {
+
+    OutboxRelayMetricsRecorder NO_OP = new OutboxRelayMetricsRecorder() {
+    };
+
+    default void recordRelaySuccess(int publishedCount, int failedCount) {
+    }
+
+    default void recordRelayFailure() {
+    }
+}

--- a/src/main/java/com/imwoo/airepo/wallet/infra/InMemoryWalletRepository.java
+++ b/src/main/java/com/imwoo/airepo/wallet/infra/InMemoryWalletRepository.java
@@ -230,6 +230,14 @@ public class InMemoryWalletRepository implements
     }
 
     @Override
+    public synchronized long countPendingOutboxEvents() {
+        return operationOutboxEvents.values().stream()
+                .flatMap(List::stream)
+                .filter(outboxEvent -> outboxEvent.status() == OperationOutboxStatus.PENDING)
+                .count();
+    }
+
+    @Override
     public synchronized List<OperationOutboxEvent> findManualReviewOutboxEvents(int limit) {
         return operationOutboxEvents.values().stream()
                 .flatMap(List::stream)

--- a/src/main/java/com/imwoo/airepo/wallet/infra/JdbcWalletRepository.java
+++ b/src/main/java/com/imwoo/airepo/wallet/infra/JdbcWalletRepository.java
@@ -216,6 +216,20 @@ public class JdbcWalletRepository implements
     }
 
     @Override
+    public long countPendingOutboxEvents() {
+        Long count = jdbcTemplate.queryForObject(
+                """
+                        select count(*)
+                        from operation_outbox_events
+                        where status = ?
+                        """,
+                Long.class,
+                OperationOutboxStatus.PENDING.name()
+        );
+        return count == null ? 0L : count;
+    }
+
+    @Override
     public List<OperationOutboxEvent> findManualReviewOutboxEvents(int limit) {
         return jdbcTemplate.query(
                 """

--- a/src/main/java/com/imwoo/airepo/wallet/infra/OutboxMetricsBinder.java
+++ b/src/main/java/com/imwoo/airepo/wallet/infra/OutboxMetricsBinder.java
@@ -1,0 +1,89 @@
+package com.imwoo.airepo.wallet.infra;
+
+import com.imwoo.airepo.wallet.application.OperationOutboxConsumerHealthStatus;
+import com.imwoo.airepo.wallet.application.OperationOutboxConsumerMetrics;
+import com.imwoo.airepo.wallet.application.OperationOutboxConsumerMonitoringService;
+import com.imwoo.airepo.wallet.application.OperationOutboxRelayMonitoringService;
+import com.imwoo.airepo.wallet.application.OperationOutboxRelayService;
+import com.imwoo.airepo.wallet.application.OutboxRelayHealthStatus;
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import org.springframework.stereotype.Component;
+
+/**
+ * Non-invasive Micrometer bridge that exposes outbox relay and consumer metrics for Prometheus.
+ *
+ * <p>Gauges read the existing monitoring services on each scrape, so no service state is duplicated.
+ * Consumer counters are {@link FunctionCounter}s over the cumulative consumer metrics (they advance
+ * as {@code consume} runs). Relay run/publish counters live in {@link OutboxRelayMetricsRegistry},
+ * which is driven from the relay monitoring service's record points.
+ */
+@Component
+public class OutboxMetricsBinder implements MeterBinder {
+
+    static final String RELAY_PENDING_METRIC = "ai.repo.outbox.relay.pending.events";
+    static final String RELAY_HEALTH_METRIC = "ai.repo.outbox.relay.health.status";
+    static final String CONSUMER_EVENTS_METRIC = "ai.repo.outbox.consumer.events";
+    static final String CONSUMER_HEALTH_METRIC = "ai.repo.outbox.consumer.health.status";
+
+    private final OperationOutboxRelayService relayService;
+    private final OperationOutboxRelayMonitoringService relayMonitoringService;
+    private final OperationOutboxConsumerMonitoringService consumerMonitoringService;
+
+    public OutboxMetricsBinder(
+            OperationOutboxRelayService relayService,
+            OperationOutboxRelayMonitoringService relayMonitoringService,
+            OperationOutboxConsumerMonitoringService consumerMonitoringService
+    ) {
+        this.relayService = relayService;
+        this.relayMonitoringService = relayMonitoringService;
+        this.consumerMonitoringService = consumerMonitoringService;
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        Gauge.builder(RELAY_PENDING_METRIC, relayService, service -> service.getPendingEventCount())
+                .description("Pending (unpublished) outbox events awaiting relay")
+                .register(registry);
+
+        Gauge.builder(RELAY_HEALTH_METRIC, relayMonitoringService, this::relayHealthValue)
+                .description("Outbox relay health status (0=ok/no-data, 1=warning, 2=critical)")
+                .register(registry);
+
+        Gauge.builder(CONSUMER_HEALTH_METRIC, consumerMonitoringService, this::consumerHealthValue)
+                .description("Outbox consumer health status (0=ok/no-data, 1=warning, 2=critical)")
+                .register(registry);
+
+        FunctionCounter.builder(CONSUMER_EVENTS_METRIC, consumerMonitoringService,
+                        service -> service.getMetrics().processedEventCount())
+                .description("Outbox consumer events by outcome")
+                .tag("outcome", "processed")
+                .register(registry);
+
+        FunctionCounter.builder(CONSUMER_EVENTS_METRIC, consumerMonitoringService,
+                        service -> service.getMetrics().duplicateEventCount())
+                .description("Outbox consumer events by outcome")
+                .tag("outcome", "duplicate")
+                .register(registry);
+    }
+
+    private double relayHealthValue(OperationOutboxRelayMonitoringService service) {
+        OutboxRelayHealthStatus status = service.getHealthSummary().status();
+        return switch (status) {
+            case OK, NO_DATA -> 0.0;
+            case WARNING -> 1.0;
+            case CRITICAL -> 2.0;
+        };
+    }
+
+    private double consumerHealthValue(OperationOutboxConsumerMonitoringService service) {
+        OperationOutboxConsumerHealthStatus status = service.getHealthSummary().status();
+        return switch (status) {
+            case OK, NO_DATA -> 0.0;
+            case WARNING -> 1.0;
+            case CRITICAL -> 2.0;
+        };
+    }
+}

--- a/src/main/java/com/imwoo/airepo/wallet/infra/OutboxRelayMetricsRegistry.java
+++ b/src/main/java/com/imwoo/airepo/wallet/infra/OutboxRelayMetricsRegistry.java
@@ -1,0 +1,58 @@
+package com.imwoo.airepo.wallet.infra;
+
+import com.imwoo.airepo.wallet.application.OutboxRelayMetricsRecorder;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.stereotype.Component;
+
+/**
+ * Micrometer-backed adapter for {@link OutboxRelayMetricsRecorder}. Holds monotonic relay counters
+ * so they survive the relay run store's bounded retention. It has no dependency on the monitoring
+ * services, which keeps it free of the wiring cycle that gauges (which read those services) create.
+ */
+@Component
+public class OutboxRelayMetricsRegistry implements OutboxRelayMetricsRecorder {
+
+    static final String RELAY_RUNS_METRIC = "ai.repo.outbox.relay.runs";
+    static final String RELAY_PUBLISHED_METRIC = "ai.repo.outbox.relay.published.events";
+
+    private final Counter successRunCounter;
+    private final Counter failureRunCounter;
+    private final Counter publishedEventCounter;
+    private final Counter failedPublishEventCounter;
+
+    public OutboxRelayMetricsRegistry(MeterRegistry meterRegistry) {
+        this.successRunCounter = Counter.builder(RELAY_RUNS_METRIC)
+                .description("Outbox relay runs by result")
+                .tag("result", "success")
+                .register(meterRegistry);
+        this.failureRunCounter = Counter.builder(RELAY_RUNS_METRIC)
+                .description("Outbox relay runs by result")
+                .tag("result", "failure")
+                .register(meterRegistry);
+        this.publishedEventCounter = Counter.builder(RELAY_PUBLISHED_METRIC)
+                .description("Outbox events published by the relay by outcome")
+                .tag("outcome", "published")
+                .register(meterRegistry);
+        this.failedPublishEventCounter = Counter.builder(RELAY_PUBLISHED_METRIC)
+                .description("Outbox events published by the relay by outcome")
+                .tag("outcome", "failed")
+                .register(meterRegistry);
+    }
+
+    @Override
+    public void recordRelaySuccess(int publishedCount, int failedCount) {
+        successRunCounter.increment();
+        if (publishedCount > 0) {
+            publishedEventCounter.increment(publishedCount);
+        }
+        if (failedCount > 0) {
+            failedPublishEventCounter.increment(failedCount);
+        }
+    }
+
+    @Override
+    public void recordRelayFailure() {
+        failureRunCounter.increment();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,11 +14,15 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health,prometheus
   endpoint:
     health:
       probes:
         enabled: true
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
 
 ai-repo:
   ops:

--- a/src/test/java/com/imwoo/airepo/wallet/application/OperationOutboxRelayMonitoringServiceTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/application/OperationOutboxRelayMonitoringServiceTest.java
@@ -18,6 +18,7 @@ class OperationOutboxRelayMonitoringServiceTest {
             new OutboxRelayHealthPolicy(5, 2, 3, 50, 15),
             new OperationalAlertService(repository, new OperationalAlertPolicy(15, 30), operationalAlert -> {
             }),
+            OutboxRelayMetricsRecorder.NO_OP,
             Clock.fixed(Instant.parse("2026-05-01T00:20:00Z"), ZoneOffset.UTC)
     );
 

--- a/src/test/java/com/imwoo/airepo/wallet/infra/OutboxMetricsBinderTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/infra/OutboxMetricsBinderTest.java
@@ -1,0 +1,124 @@
+package com.imwoo.airepo.wallet.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.imwoo.airepo.wallet.application.OperationOutboxConsumerHealthStatus;
+import com.imwoo.airepo.wallet.application.OperationOutboxConsumerHealthSummary;
+import com.imwoo.airepo.wallet.application.OperationOutboxConsumerMetrics;
+import com.imwoo.airepo.wallet.application.OperationOutboxConsumerMonitoringService;
+import com.imwoo.airepo.wallet.application.OperationOutboxRelayMonitoringService;
+import com.imwoo.airepo.wallet.application.OperationOutboxRelayService;
+import com.imwoo.airepo.wallet.application.OutboxRelayHealthStatus;
+import com.imwoo.airepo.wallet.application.OutboxRelayHealthSummary;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OutboxMetricsBinderTest {
+
+    private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    private final OperationOutboxRelayService relayService = mock(OperationOutboxRelayService.class);
+    private final OperationOutboxRelayMonitoringService relayMonitoringService =
+            mock(OperationOutboxRelayMonitoringService.class);
+    private final OperationOutboxConsumerMonitoringService consumerMonitoringService =
+            mock(OperationOutboxConsumerMonitoringService.class);
+    private final OutboxMetricsBinder binder = new OutboxMetricsBinder(
+            relayService,
+            relayMonitoringService,
+            consumerMonitoringService
+    );
+
+    @Test
+    void exposesPendingGaugeReadingRelayService() {
+        when(relayService.getPendingEventCount()).thenReturn(7L);
+        binder.bindTo(registry);
+
+        assertThat(registry.get(OutboxMetricsBinder.RELAY_PENDING_METRIC).gauge().value()).isEqualTo(7.0);
+
+        when(relayService.getPendingEventCount()).thenReturn(3L);
+        assertThat(registry.get(OutboxMetricsBinder.RELAY_PENDING_METRIC).gauge().value()).isEqualTo(3.0);
+    }
+
+    @Test
+    void mapsRelayHealthStatusToNumericGauge() {
+        when(relayMonitoringService.getHealthSummary()).thenReturn(healthSummary(OutboxRelayHealthStatus.CRITICAL));
+        binder.bindTo(registry);
+
+        assertThat(registry.get(OutboxMetricsBinder.RELAY_HEALTH_METRIC).gauge().value()).isEqualTo(2.0);
+
+        when(relayMonitoringService.getHealthSummary()).thenReturn(healthSummary(OutboxRelayHealthStatus.WARNING));
+        assertThat(registry.get(OutboxMetricsBinder.RELAY_HEALTH_METRIC).gauge().value()).isEqualTo(1.0);
+
+        when(relayMonitoringService.getHealthSummary()).thenReturn(healthSummary(OutboxRelayHealthStatus.OK));
+        assertThat(registry.get(OutboxMetricsBinder.RELAY_HEALTH_METRIC).gauge().value()).isEqualTo(0.0);
+    }
+
+    @Test
+    void mapsConsumerHealthStatusToNumericGauge() {
+        when(consumerMonitoringService.getHealthSummary())
+                .thenReturn(consumerHealthSummary(OperationOutboxConsumerHealthStatus.CRITICAL));
+        binder.bindTo(registry);
+
+        assertThat(registry.get(OutboxMetricsBinder.CONSUMER_HEALTH_METRIC).gauge().value()).isEqualTo(2.0);
+
+        when(consumerMonitoringService.getHealthSummary())
+                .thenReturn(consumerHealthSummary(OperationOutboxConsumerHealthStatus.OK));
+        assertThat(registry.get(OutboxMetricsBinder.CONSUMER_HEALTH_METRIC).gauge().value()).isEqualTo(0.0);
+    }
+
+    @Test
+    void exposesConsumerEventCountersByOutcome() {
+        when(consumerMonitoringService.getMetrics()).thenReturn(consumerMetrics(5, 2));
+        binder.bindTo(registry);
+
+        assertThat(consumerEventsCounter("processed")).isEqualTo(5.0);
+        assertThat(consumerEventsCounter("duplicate")).isEqualTo(2.0);
+
+        when(consumerMonitoringService.getMetrics()).thenReturn(consumerMetrics(8, 3));
+        assertThat(consumerEventsCounter("processed")).isEqualTo(8.0);
+        assertThat(consumerEventsCounter("duplicate")).isEqualTo(3.0);
+    }
+
+    private double consumerEventsCounter(String outcome) {
+        return registry.get(OutboxMetricsBinder.CONSUMER_EVENTS_METRIC)
+                .tag("outcome", outcome).functionCounter().count();
+    }
+
+    private OutboxRelayHealthSummary healthSummary(OutboxRelayHealthStatus status) {
+        return new OutboxRelayHealthSummary(
+                Instant.parse("2026-05-01T00:00:00Z"),
+                status,
+                5, 5, 4, 1, 0.2, 0,
+                Instant.parse("2026-05-01T00:00:00Z"),
+                Instant.parse("2026-05-01T00:00:00Z"),
+                null,
+                List.of()
+        );
+    }
+
+    private OperationOutboxConsumerHealthSummary consumerHealthSummary(OperationOutboxConsumerHealthStatus status) {
+        return new OperationOutboxConsumerHealthSummary(
+                Instant.parse("2026-05-01T00:00:00Z"),
+                status,
+                10, 1, 10, 0.09,
+                Instant.parse("2026-05-01T00:00:00Z"),
+                Instant.parse("2026-05-01T00:05:00Z"),
+                10, 1, 0.09,
+                5, 5, 0.2, 0.5,
+                List.of()
+        );
+    }
+
+    private OperationOutboxConsumerMetrics consumerMetrics(long processed, long duplicate) {
+        return new OperationOutboxConsumerMetrics(
+                processed,
+                duplicate,
+                processed,
+                Instant.parse("2026-05-01T00:05:00Z"),
+                Instant.parse("2026-05-01T00:05:00Z")
+        );
+    }
+}

--- a/src/test/java/com/imwoo/airepo/wallet/infra/OutboxRelayMetricsRegistryTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/infra/OutboxRelayMetricsRegistryTest.java
@@ -1,0 +1,67 @@
+package com.imwoo.airepo.wallet.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.imwoo.airepo.wallet.application.OperationalAlertPolicy;
+import com.imwoo.airepo.wallet.application.OperationalAlertService;
+import com.imwoo.airepo.wallet.application.OperationOutboxPublishBatchResult;
+import com.imwoo.airepo.wallet.application.OperationOutboxRelayMonitoringService;
+import com.imwoo.airepo.wallet.application.OutboxRelayHealthPolicy;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+
+class OutboxRelayMetricsRegistryTest {
+
+    private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    private final OutboxRelayMetricsRegistry metricsRegistry = new OutboxRelayMetricsRegistry(registry);
+    private final InMemoryWalletRepository repository = new InMemoryWalletRepository();
+    private final OperationOutboxRelayMonitoringService monitoringService = new OperationOutboxRelayMonitoringService(
+            repository,
+            new OutboxRelayHealthPolicy(5, 2, 3, 50, 15),
+            new OperationalAlertService(repository, new OperationalAlertPolicy(15, 30), operationalAlert -> {
+            }),
+            metricsRegistry,
+            Clock.fixed(Instant.parse("2026-05-01T00:20:00Z"), ZoneOffset.UTC)
+    );
+
+    @Test
+    void countsSuccessfulRelayRunsAndPublishedEvents() {
+        monitoringService.recordSuccess(
+                Instant.parse("2026-05-01T00:00:00Z"),
+                Instant.parse("2026-05-01T00:00:01Z"),
+                10,
+                new OperationOutboxPublishBatchResult(3, 2, 1)
+        );
+
+        assertThat(runsCounter("success")).isEqualTo(1.0);
+        assertThat(runsCounter("failure")).isEqualTo(0.0);
+        assertThat(publishedCounter("published")).isEqualTo(2.0);
+        assertThat(publishedCounter("failed")).isEqualTo(1.0);
+    }
+
+    @Test
+    void countsFailedRelayRuns() {
+        monitoringService.recordFailure(
+                Instant.parse("2026-05-01T00:00:00Z"),
+                Instant.parse("2026-05-01T00:00:01Z"),
+                10,
+                "publisher down"
+        );
+
+        assertThat(runsCounter("failure")).isEqualTo(1.0);
+        assertThat(runsCounter("success")).isEqualTo(0.0);
+        assertThat(publishedCounter("published")).isEqualTo(0.0);
+    }
+
+    private double runsCounter(String result) {
+        return registry.get(OutboxRelayMetricsRegistry.RELAY_RUNS_METRIC).tag("result", result).counter().count();
+    }
+
+    private double publishedCounter(String outcome) {
+        return registry.get(OutboxRelayMetricsRegistry.RELAY_PUBLISHED_METRIC)
+                .tag("outcome", outcome).counter().count();
+    }
+}


### PR DESCRIPTION
Closes #110

## 요약

로컬 Docker Desktop k8s 배포 + Grafana 기반 관측(지표·로그) + GitOps 자동 배포 파이프라인(B4 로드맵).

- **k8s 스택** (`deploy/k8s`, kustomize): 앱(postgres 프로파일, probes, NodePort 30080) + Postgres 17(PVC) + Prometheus(30990) + Grafana(30300) + Loki(72h) + Alloy — `scripts/k8s-local-up.sh`/`k8s-local-down.sh`
- **지표**: micrometer-registry-prometheus, p95/p99 히스토그램, outbox 커스텀 지표 6종(`ai_repo_outbox_*`, 비침습 브리지) + 대시보드 16패널
- **로그 검색**: Alloy(k8s API tail) → Loki → Grafana Explore LogQL
- **CI/CD**: `deploy.yml` — main push → `ghcr.io/imwoo94/ai-repo:{version}-{sha8}` push → `deploy/gitops` newTag 갱신(`[skip ci]`) → ArgoCD 자동 sync(prune+selfHeal), 설치는 `scripts/argocd-install.sh`(--server-side)
- **문서**: README 진입점, 접속 정보(URL·계정)·전체 명령어 모음, 색상 구분 mermaid 아키텍처 다이어그램 3종, ADR-0059, progress 0069, issue draft 0069

## 검증

- `./gradlew test` / `postgresScenarioTest` 통과, frontend test/build 통과
- 실배포 e2e: 4+3개 Deployment 롤아웃 → health UP → 충전 트래픽 → Prometheus 수집(`ai_repo_outbox_relay_runs_total` 확인) → Grafana 대시보드/Loki LogQL 조회 → ArgoCD Synced/Healthy
- 문서의 접속 명령 실검증(relay health OK, dashboard 200)

## 머지 후

- [ ] 첫 deploy.yml 실행 확인(실제 ghcr push + gitops newTag 커밋)
- [ ] ghcr 패키지 public 전환(로컬 노드 익명 pull)
- [ ] ArgoCD Application을 main으로 복귀: `kubectl apply -f deploy/argocd/application.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)