### PR TITLE
chore: ignore local ai tooling artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ frontend/node_modules/
 frontend/dist/
 frontend/playwright-report/
 frontend/test-results/
+
+# Local AI tooling artifacts
+.claude/
+.understand-anything/


### PR DESCRIPTION
## 배경

`git add -A` 실행 시 로컬 AI 툴링 디렉터리(`.claude/`, `.understand-anything/`)가 실수로 스테이징될 뻔한 사고가 있었습니다. 해당 디렉터리들은 로컬 개발 환경 전용 아티팩트로, 약 40,000줄 이상의 파일이 포함될 수 있어 저장소에 포함되어서는 안 됩니다.

## 변경 사항

- `.gitignore`에 `.claude/` 및 `.understand-anything/` 항목 추가

## 확인 사항

- `git ls-files | grep -E "^\.claude/|^\.understand-anything/"` 결과: 출력 없음 (현재 트래킹된 파일 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)