### PR TITLE
feat: gate deploy pipeline on ci success

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,12 @@
 name: Deploy
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
     branches:
       - main
-    paths-ignore:
-      - 'docs/**'
-      - 'wiki-drafts/**'
-      - 'issue-drafts/**'
-      - 'deploy/gitops/kustomization.yaml' # CI 자체 갱신 커밋 재트리거 방지
 
 permissions:
   contents: write
@@ -25,16 +23,26 @@ jobs:
   build-push-sync:
     name: Build, Push, Update GitOps Manifest
     runs-on: ubuntu-latest
+    # CI("CI" 워크플로우)가 성공했을 때만 배포한다. 깨진 커밋은 배포되지 않는다.
+    if: github.event.workflow_run.conclusion == 'success'
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # workflow_run 이벤트는 기본적으로 default branch HEAD를 체크아웃하므로,
+          # 그 사이 main이 움직였을 수 있다. CI가 검증한 정확한 커밋을 체크아웃한다.
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Resolve image tag ({version}-{sha8})
         id: meta
+        env:
+          # workflow_run 컨텍스트에서 GITHUB_SHA는 default branch HEAD이므로
+          # CI run이 검증한 커밋(head_sha)의 앞 8자리를 태그에 사용한다.
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           VERSION=$(sed -n "s/^version = '\(.*\)'/\1/p" build.gradle)
-          SHA8=${GITHUB_SHA:0:8}
+          SHA8=${HEAD_SHA:0:8}
           echo "tag=${VERSION}-${SHA8}" >> "$GITHUB_OUTPUT"
 
       - name: Login to GHCR
@@ -51,15 +59,16 @@ jobs:
           push: true
           tags: ${{ env.IMAGE }}:${{ steps.meta.outputs.tag }}
 
-      - name: Update GitOps manifest
-        run: |
-          sed -i "s|newTag: .*|newTag: ${{ steps.meta.outputs.tag }}|" deploy/gitops/kustomization.yaml
-          git diff --stat deploy/gitops/kustomization.yaml
-
       - name: Commit and push manifest
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          # 체크아웃이 head_sha에 detached 상태이므로, origin/main 최신을 가져와
+          # main 브랜치로 재설정한 뒤 그 위에 매니페스트 커밋을 올린다.
+          git fetch origin main
+          git checkout -B main origin/main
+          sed -i "s|newTag: .*|newTag: ${{ steps.meta.outputs.tag }}|" deploy/gitops/kustomization.yaml
+          git diff --stat deploy/gitops/kustomization.yaml
           git add deploy/gitops/kustomization.yaml
           git commit -m "chore: deploy ${{ steps.meta.outputs.tag }} [skip ci]" || { echo "no change"; exit 0; }
-          git push
+          git push origin main

--- a/docs/adr/0059-k8s-deploy-and-observability.md
+++ b/docs/adr/0059-k8s-deploy-and-observability.md
@@ -18,7 +18,7 @@ ai-repo는 지금까지 `compose.yml`(Postgres 단독)과 로컬 프로세스 �
 | 커스텀 지표 | outbox 릴레이/컨슈머를 비침습 브리지로 노출 — 게이지는 `OutboxMetricsBinder`가 기존 모니터링 서비스를 스크레이프 시점에 읽고, 릴레이 카운터는 `OutboxRelayMetricsRecorder` 포트로 기록 시점 증가(실행 저장소가 최근 샘플만 보관해 사후 누적 불가하므로) |
 | 로그 | Loki(single binary, filesystem, 72h) + Grafana Alloy가 k8s API로 파드 로그 tail(호스트 마운트 없음). Grafana Explore에서 LogQL 검색 |
 | 대시보드 | Grafana 프로비저닝(ConfigMap) — `ai-repo Overview`: HTTP/지갑거래/JVM/Hikari/CPU + Outbox row |
-| CI/CD | GitHub Actions(main push) → 이미지 태그 `{version}-{sha8}` → ghcr.io push → `deploy/gitops/kustomization.yaml` newTag 갱신 커밋(`[skip ci]`) |
+| CI/CD | GitHub Actions CI 성공 후 deploy가 `workflow_run`으로 트리거(`if: conclusion == 'success'`) → CI run의 `head_sha` 체크아웃 → 이미지 태그 `{version}-{sha8}` → ghcr.io push → `deploy/gitops/kustomization.yaml` newTag 갱신 커밋(`[skip ci]`) |
 | GitOps | ArgoCD(로컬 설치, `--server-side` apply)가 `deploy/gitops`를 자동 sync(prune+selfHeal). 오버레이는 `../k8s` base + ghcr 이미지 교체 |
 | 모드 분리 | 같은 네임스페이스를 관리하므로 로컬 수동 모드(`k8s-local-up.sh`)와 GitOps 모드는 택1 |
 
@@ -33,7 +33,7 @@ ai-repo는 지금까지 `compose.yml`(Postgres 단독)과 로컬 프로세스 �
 ### 비용
 
 - 익명 Grafana Admin·평문 자격증명·단일 replica는 로컬 학습 전용 구성이다. 원격 전환 시 Secret/인증/HA 재설계가 필요하다.
-- CI 검증(ci.yml)과 deploy가 독립이라 깨진 커밋도 배포될 수 있다 — 필요 시 `workflow_run` 게이트로 전환한다.
+- deploy는 CI(ci.yml) 성공 시에만 `workflow_run`으로 트리거되어 깨진 커밋은 배포되지 않는다. 대신 paths 필터가 없어 CI를 통과한 docs-only push도 이미지 빌드+배포를 트리거한다(로컬 학습 랩 규모에서는 무해).
 - Alloy가 k8s API로 로그를 tail하므로 초대형 로그 볼륨에는 부적합하다(로컬 규모에서는 무해).
 
 ## 대안

--- a/docs/development/ci-cd-gitops.md
+++ b/docs/development/ci-cd-gitops.md
@@ -6,17 +6,21 @@ main 브랜치 push가 이미지 빌드부터 로컬 k8s 배포까지 자동으�
 
 ```
 main push
-  → GitHub Actions (.github/workflows/deploy.yml)
-      1. build.gradle version + 커밋 sha 앞 8자리 → 태그 {version}-{sha8} (예: 0.7.0-a1b2c3d4)
-      2. Docker 이미지 빌드 → ghcr.io/imwoo94/ai-repo:{tag} push
-      3. deploy/gitops/kustomization.yaml의 newTag 갱신 → "[skip ci]" 커밋 push
+  → GitHub Actions CI (.github/workflows/ci.yml: gradle check/scenario/frontend)
+      성공(conclusion == 'success')해야만 아래 deploy가 트리거된다
+  → GitHub Actions Deploy (.github/workflows/deploy.yml, workflow_run 트리거)
+      1. CI run의 head_sha를 체크아웃 (main HEAD가 그 사이 움직여도 검증된 커밋 그대로)
+      2. build.gradle version + head_sha 앞 8자리 → 태그 {version}-{sha8} (예: 0.7.0-a1b2c3d4)
+      3. Docker 이미지 빌드 → ghcr.io/imwoo94/ai-repo:{tag} push
+      4. origin/main 최신으로 재설정 후 deploy/gitops/kustomization.yaml의 newTag 갱신 → "[skip ci]" 커밋 push
   → ArgoCD (로컬 docker-desktop 클러스터)
       deploy/gitops 변화 감지 → ai-repo 네임스페이스에 자동 sync (prune + selfHeal)
 ```
 
-- **이미지 태그 규칙**: 반드시 `{version}-{sha8}`. `latest` 사용 금지.
-- **재트리거 방지**: deploy.yml은 `deploy/gitops/kustomization.yaml`을 paths-ignore하고, 매니페스트 커밋 메시지에 `[skip ci]`를 붙여 CI/deploy 루프를 차단한다.
-- CI 검증(ci.yml: gradle check/scenario/frontend)과 deploy는 독립 실행이다. 학습 랩 단순화를 위한 선택으로, 배포 전 CI 게이트가 필요해지면 `workflow_run` 트리거로 전환한다.
+- **이미지 태그 규칙**: 반드시 `{version}-{sha8}`. `latest` 사용 금지. sha8은 CI run의 `head_sha` 앞 8자리다.
+- **CI 게이트**: deploy는 CI("CI" 워크플로우)가 성공했을 때만 실행된다(`workflow_run` + `if: conclusion == 'success'`). 깨진 커밋(테스트/빌드 실패)은 배포되지 않는다.
+- **재트리거 방지**: 매니페스트 커밋 메시지에 `[skip ci]`를 붙이면 CI가 아예 돌지 않으므로 CI→deploy 루프가 차단된다. (`workflow_run` 트리거에는 paths 필터가 없어 기존 `paths-ignore` 블록은 제거했다.)
+- **동작 변화**: paths 필터가 없어져, CI를 통과한 docs-only push도 이제 이미지 빌드+배포를 트리거한다.
 
 ## 디렉토리
 

--- a/docs/progress/0069-k8s-deploy-and-observability.md
+++ b/docs/progress/0069-k8s-deploy-and-observability.md
@@ -13,7 +13,7 @@
 - **메트릭**: micrometer-registry-prometheus + `/actuator/prometheus` 노출, HTTP p95/p99 히스토그램. 커스텀 outbox 지표 6종(`ai_repo_outbox_relay_runs_total`, `relay_published_events_total`, `relay_pending_events`, `relay_health_status`, `consumer_events_total`, `consumer_health_status`) — 비침습 브리지(`OutboxMetricsBinder` 게이지 + `OutboxRelayMetricsRecorder` 포트 카운터).
 - **대시보드**: `ai-repo Overview` 16패널 — HTTP 요청률/오류율/p95·p99, 지갑 거래율, JVM/GC, Hikari, CPU, up + Outbox 릴레이/컨슈머 row.
 - **로그 검색**: Grafana Explore에서 LogQL(`{app="ai-repo"} |= "ERROR"` 등), 라벨 namespace/pod/container/app.
-- **CI/CD**: `.github/workflows/deploy.yml` — main push 시 `{version}-{sha8}` 태그로 ghcr.io/imwoo94/ai-repo push 후 `deploy/gitops` newTag 갱신(`[skip ci]`). ArgoCD Application(`deploy/argocd`)이 자동 sync(prune+selfHeal). 설치는 `scripts/argocd-install.sh`(--server-side).
+- **CI/CD**: `.github/workflows/deploy.yml` — CI("CI" 워크플로우) 성공 시에만 `workflow_run`으로 트리거(`if: conclusion == 'success'`). CI run의 `head_sha`를 체크아웃해 `{version}-{sha8}` 태그로 ghcr.io/imwoo94/ai-repo push 후 `deploy/gitops` newTag 갱신(`[skip ci]`). ArgoCD Application(`deploy/argocd`)이 자동 sync(prune+selfHeal). 설치는 `scripts/argocd-install.sh`(--server-side).
 - **문서**: `docs/development/k8s-local-monitoring.md`(가이드·로그 검색·이슈 트래킹), `docs/development/ci-cd-gitops.md`(파이프라인·트러블슈팅·모드 전환·이슈 트래킹), ADR-0059.
 
 ## 개선 건수
@@ -32,7 +32,7 @@
 
 - main 머지 후 첫 deploy.yml 실행으로 실제 ghcr push·GitOps 갱신 검증(그 전까지 ghcr 패키지 미존재)
 - ghcr 패키지 public 전환(로컬 노드 익명 pull용) 또는 pull secret 등록
-- 배포 전 CI 게이트(`workflow_run`) 도입 여부 검토
+- ~~배포 전 CI 게이트(`workflow_run`) 도입 여부 검토~~ → 완료: deploy를 CI 성공(`workflow_run` + `if: conclusion == 'success'`)에 게이트해 깨진 커밋 배포를 차단.
 
 ## 관련 문서
 


### PR DESCRIPTION
## 배경

기존 `deploy.yml`은 main push에 직접 트리거되어 CI(`ci.yml`, "CI" 워크플로우: gradle check/scenario/frontend)와 **독립적으로** 실행됐다. 그 결과 테스트/빌드가 깨진 커밋도 ghcr 이미지 빌드와 GitOps 배포까지 그대로 이어질 수 있었다.

## 변경 내용

deploy를 CI 성공에 게이트하도록 `workflow_run` 트리거로 전환했다.

- **트리거 전환**: `on: push` → `on: workflow_run` (`workflows: ["CI"]`, `types: [completed]`, `branches: [main]`)
- **성공 게이트**: 잡에 `if: github.event.workflow_run.conclusion == 'success'` 추가. CI가 실패하면 deploy 잡 자체가 실행되지 않는다.
- **정확한 커밋 체크아웃**: `workflow_run` 이벤트는 기본적으로 default branch HEAD를 체크아웃하는데, CI 완료 사이 main이 움직였을 수 있다. `actions/checkout`에 `ref: github.event.workflow_run.head_sha`를 지정해 **CI가 실제로 검증한 커밋**을 체크아웃한다.
- **이미지 태그 sha8 교정**: `workflow_run` 컨텍스트의 `GITHUB_SHA`는 default branch HEAD라 부정확하다. 태그 `{version}-{sha8}`의 sha8을 `github.event.workflow_run.head_sha` 앞 8자리로 사용한다.
- **매니페스트 커밋 push 방식**: 체크아웃이 `head_sha`에 detached 상태라 그대로 `git push`하면 실패한다. "Commit and push manifest" 스텝에서 `git fetch origin main` 후 `git checkout -B main origin/main`으로 main 최신을 재설정하고, 그 위에 `newTag` sed 편집 → 커밋 → `git push origin main` 한다. detached HEAD에서도 안전하게 main으로 push된다.

## 루프 방지 / 동작 변화

- **루프 차단은 그대로 유효**: 매니페스트 커밋 메시지의 `[skip ci]`가 CI를 아예 건너뛰게 하므로 → CI run 없음 → deploy 트리거 없음. `workflow_run`에는 paths 필터가 없어 의미가 사라진 `paths-ignore` 블록은 제거했다.
- **동작 변화**: paths 필터가 없어졌기 때문에, **CI를 통과한 docs-only push도 이제 이미지 빌드+배포를 트리거**한다. 로컬 학습 랩 규모에서는 무해하다.

## 문서 갱신

- `docs/development/ci-cd-gitops.md` — 파이프라인 흐름을 "CI 성공 후 deploy 실행"으로 갱신, "CI와 deploy 독립" 문구 교체.
- `docs/adr/0059-k8s-deploy-and-observability.md` — 비용 섹션의 "CI 검증과 deploy가 독립이라 깨진 커밋도 배포될 수 있다" 항목을 게이트 반영으로 갱신.
- `docs/progress/0069-k8s-deploy-and-observability.md` — 남은 일의 CI 게이트 항목을 완료로 반영.

## 검증

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml'))"` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)