### PR TITLE
fix: restore ci after workstream merges (e2e assertions + wiki sync)

### DIFF
--- a/docs/adr/0058-audit-events-authorization.md
+++ b/docs/adr/0058-audit-events-authorization.md
@@ -37,7 +37,7 @@ Accepted
 ### 비용
 
 - 소유자 스코프 감사 로그는 `ledger_entries` 조인에 의존하므로 ledger에 남지 않는 operation은 사용자 화면에서 보이지 않는다(현재 감사 대상 흐름은 모두 ledger를 남기므로 무해).
-- step-logs/outbox-events는 operator 전용이 되어 사용자 화면 evidence에서 사라진다.
+- step-logs/outbox-events는 operator 전용이 되어 사용자 화면 evidence에서 사라진다. 사용자 흐름 e2e는 증거를 원장 + 소유자 스코프 감사 로그 단언으로 검증한다.
 - **수용된 노출**: transfer는 operation_id 하나에 양쪽 지갑의 ledger entry가 달리므로, `TRANSFER_COMPLETED` 감사 이벤트(detail: `Transfer completed from {source} to {target}`)가 송신자·수신자 양쪽의 소유자 스코프 조회에 모두 반환되어 상대방 walletId가 노출된다. 이는 의도된 동작으로 수용한다 — 송신자는 이체 시 상대 walletId를 이미 알고 있고, 수신자가 송신자를 보는 것은 은행 입금내역과 동일한 의미론이며, walletId 자체는 소유권 검증(`WalletAccessPolicy`) 때문에 어떤 접근 권한도 부여하지 않는다. 회귀 테스트로 이 동작을 고정한다.
 
 ## 대안

--- a/docs/progress/0068-audit-events-authorization.md
+++ b/docs/progress/0068-audit-events-authorization.md
@@ -21,6 +21,7 @@
 - **HTTP 레이어 교차 배제 미검증**: `returnsWalletAuditEventsForOwner`에 wallet-002 충전 추가 후 op-002 배제 단언.
 - **프론트 mock 회귀 감지 불가**: `endsWith('/audit-events')`가 구 operator 엔드포인트와도 매치 → 전체 wallet 스코프 URL + Bearer 헤더 단언 추가.
 - **빈 패널 잔존**: 유저 화면의 Step Log/Outbox `EvidencePanel` 제거, 고아가 된 `stepLogs`/`outboxEvents` 상태와 `OperationStepLog` 타입 제거(`OperationOutboxEvent`는 operator manual-review에서 사용 중이라 유지).
+- **e2e 후속(main 머지 후 CI 발견)**: `wallet-flow.spec.ts`의 step log/outbox 단언을 원장(`CREDIT · 잔액`)·감사 로그(`CHARGE_COMPLETED`, transfer 상대방 detail 포함) 단언으로 교체.
 
 ## 개선 건수
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -33,6 +33,7 @@
 - 엔드유저 memberId JWT 인증과 wallet ownership 서비스계층 강제(IDOR 차단, 비소유자 403, ledger-entries 포함)
 - 프론트엔드 memberId 로그인 + Bearer 토큰 부착 + 401 자동 재발급/재시도
 - audit-events/step-logs/outbox-events 미인증 노출 차단(operator 게이팅)과 소유자 스코프 `GET /wallets/{walletId}/audit-events` 추가
+- 사용자 흐름 e2e 증거 단언을 원장+감사 로그 기준으로 교체(step log/outbox 패널 제거 후속)
 - 로컬 k8s 배포 스택(Prometheus/Grafana/Loki)과 outbox 커스텀 지표
 - GitHub Actions → GHCR → GitOps → ArgoCD 배포 파이프라인
 

--- a/frontend/e2e/wallet-flow.spec.ts
+++ b/frontend/e2e/wallet-flow.spec.ts
@@ -28,8 +28,9 @@ test('사용자가 로그인 후 지갑 조회, 충전, 송금, 운영 증거 �
   await expect(page.getByText('충전이 완료되었습니다.')).toBeVisible();
   await expect(balanceCard.getByText('132,000 KRW')).toBeVisible();
   await expect(page.getByText(/최근 operation: op-\d+ · CHARGE · COMPLETED/)).toBeVisible();
-  await expect(page.getByText(/LEDGER_RECORDED · COMPLETED/)).toBeVisible();
-  await expect(page.getByText(/CHARGE_COMPLETED · PENDING/)).toBeVisible();
+  // 사용자 증거는 원장 + 소유자 스코프 감사 로그로 확인한다(step log/outbox는 운영자 전용).
+  await expect(page.getByText(/op-\d+ · CREDIT · 잔액 132,000 KRW/)).toBeVisible();
+  await expect(page.getByText(/op-\d+ · CHARGE_COMPLETED · /)).toBeVisible();
 
   await transferAmount.fill('3000');
   await page.getByRole('button', { name: '송금하기' }).click();
@@ -37,7 +38,8 @@ test('사용자가 로그인 후 지갑 조회, 충전, 송금, 운영 증거 �
   await expect(page.getByText('송금이 완료되었습니다.')).toBeVisible();
   await expect(balanceCard.getByText('129,000 KRW')).toBeVisible();
   await expect(page.getByText(/최근 operation: op-\d+ · TRANSFER · COMPLETED/)).toBeVisible();
-  await expect(page.getByText(/TRANSFER_COMPLETED · PENDING/)).toBeVisible();
+  // ADR-0058 수용된 노출: transfer 감사 detail에 양쪽 walletId가 보인다.
+  await expect(page.getByText(/op-\d+ · TRANSFER_COMPLETED · Transfer completed from wallet-001 to wallet-002/)).toBeVisible();
 });
 
 test('잔액 부족 송금은 오류 메시지를 표시한다', async ({ page }) => {

--- a/issue-drafts/0068-audit-events-unauthenticated-exposure.md
+++ b/issue-drafts/0068-audit-events-unauthenticated-exposure.md
@@ -32,3 +32,7 @@ scripts/check-dev-rules.sh
 ```
 
 관련: PR #106, ADR-0056, progress 0066.
+
+## 후속 (main 머지 후)
+
+- 사용자 흐름 e2e의 step log/outbox 단언을 원장+감사 로그 단언으로 교체(패널 제거에 따른 CI e2e 실패 복구).

--- a/wiki-drafts/Architecture-Decisions.md
+++ b/wiki-drafts/Architecture-Decisions.md
@@ -107,6 +107,7 @@
 | Slack webhook operational alert publisher | Incoming Webhook 호환 text payload로 push channel 계약 고정 | 발행 실패 record와 재시도 정책은 후속 과제 |
 | Admin API path matching hardening | 인증·감사 필터가 공통 segment-aware matcher로 root/sub-path만 운영 API로 분류 | Spring Security matcher 목록과 완전한 단일 source of truth는 후속 과제 |
 | Wiki는 요약, ADR은 결정 | 포트폴리오 설명성과 PR 검증성 모두 확보 | Wiki 하나에 모든 결정을 몰아넣는 단순성 |
+| 로컬 k8s 배포와 관측 스택 (ADR-0059) | Docker Desktop k8s + kustomize + Prometheus/Grafana/Loki, GitHub Actions→GHCR→ArgoCD GitOps, deploy는 CI 성공 게이트(workflow_run) 뒤에서만 실행 | 익명 Grafana/평문 자격증명은 로컬 학습 전용, 원격 전환 시 재설계 |
 
 ## 다음 구조 후보
 

--- a/wiki-drafts/Release-Notes.md
+++ b/wiki-drafts/Release-Notes.md
@@ -40,6 +40,9 @@
 - PostgreSQL scenario Testcontainers CI gate
 - MVP local smoke script
 - Wiki draft 최신화와 sync workflow
+- 로컬 k8s 배포 스택(Prometheus/Grafana/Loki)과 outbox 커스텀 지표
+- GitHub Actions → GHCR({version}-{sha8}) → GitOps → ArgoCD 배포 파이프라인
+- Deploy 파이프라인 CI 성공 게이트(workflow_run)
 
 ## 릴리스 후보 검증
 


### PR DESCRIPTION
main CI 실패 2건 복구 (Frontend E2E, Dev Rules Check — run 97c544b).

- **E2E**: #113의 사용자 evidence 패널 정리(step log/outbox 제거)로 `wallet-flow.spec.ts` 단언 3개가 사라진 요소를 참조 → 원장(`op-N · CREDIT · 잔액`) + 소유자 스코프 감사 로그(`CHARGE_COMPLETED`, transfer 상대방 detail 포함) 단언으로 교체. 로컬 e2e 6/6 통과.
- **Dev Rules**: #114가 ADR/progress/source를 변경하며 wiki-drafts 동기화 누락 → Architecture-Decisions(ADR-0059 행)·Release-Notes(배포/관측 3항목) 반영. e2e 변경에 따른 4종 문서 동기화(ADR-0058 부록, progress/unreleased/issue-draft 0068 후속) 포함. `scripts/check-dev-rules.sh` PASS.

게이트 확인: 깨진 CI 동안 deploy는 정상적으로 skip됨(workflow_run 게이트 동작 입증).

🤖 Generated with [Claude Code](https://claude.com/claude-code)