### PR TITLE
feat: audit event–wallet 매핑 명시화(ledger 조인 제거)

### DIFF
--- a/docs/adr/0060-audit-event-wallet-mapping.md
+++ b/docs/adr/0060-audit-event-wallet-mapping.md
@@ -1,0 +1,47 @@
+# ADR-0060: Audit Event–Wallet Mapping 명시화
+
+## 상태
+
+Accepted
+
+## 배경
+
+ADR-0058에서 소유자 스코프 `GET /api/v1/wallets/{walletId}/audit-events`를 추가하면서, `AuditEvent`(auditEventId, operationId, type, occurredAt, detail)에 walletId가 없다는 이유로 소유권을 `ledger_entries` 조인으로 해소했다.
+
+- Jdbc: `audit_events WHERE operation_id IN (SELECT operation_id FROM ledger_entries WHERE wallet_id = ?)`
+- InMemory: 해당 지갑의 ledger operation_id 집합으로 필터
+
+이 방식은 "감사 이벤트의 소유자"라는 개념을 원장(ledger) 의미론에 종속시킨다. ledger에 남지 않는 감사 흐름이 생기면 소유자 조회에서 사라지고(ADR-0058 비용 항목), 조회 성능도 조인에 의존한다. ADR-0058 대안 절에서 이 결합을 "비정규화로 제거 가능하나 범위가 크다"고 유보했고, progress 0068 "남은 일"에 후속으로 남겼다.
+
+## 결정
+
+audit-event↔wallet 매핑을 쓰기 시점에 **명시적 매핑 테이블 `audit_event_wallets(audit_event_id, wallet_id)`**로 영속화하고, 소유자 스코프 조회를 이 매핑으로 전환한다.
+
+| 항목 | 결정 |
+| --- | --- |
+| 매핑 저장 | `audit_event_wallets(audit_event_id, wallet_id)` — 복합 PK, `wallet_id` 인덱스. audit_event 삽입과 동일 트랜잭션에서 기록 |
+| 쓰기 경로 | charge → 1행(`walletId`), transfer → 2행(`sourceWalletId`, `targetWalletId`). 현재 감사되는 흐름은 이 둘뿐(`insertAuditEvent` 호출 지점 전수 확인) |
+| 조회 경로 | Jdbc: `audit_events WHERE audit_event_id IN (SELECT audit_event_id FROM audit_event_wallets WHERE wallet_id = ?)`. InMemory: `Map<walletId, List<auditEventId>>` 유지 |
+| 파라미터 없는 조회 | operator용 `getAuditEvents()`(전체)는 변경 없음 |
+| 마이그레이션 | V18에서 테이블·인덱스 생성 후, 기존 행을 ledger 조인으로 역채움해 로컬 DB 호환 유지 |
+| 동작 보존 | transfer 감사 이벤트가 양쪽 소유자에게 보이고 detail에 양쪽 walletId가 포함되는 ADR-0058 수용 노출을 그대로 유지 |
+
+## 트레이드오프
+
+### 장점
+
+- 소유자 매핑이 ledger 의미론과 분리된다. ledger를 남기지 않는 감사 흐름이 생겨도 소유자 조회가 독립적으로 정확하다.
+- 조회가 매핑 인덱스 단일 조회로 단순화된다(ledger_entries 스캔 불필요).
+- transfer의 "1 operation → 2 owner" 동작이 매핑 2행으로 명시적으로 표현된다.
+
+### 비용
+
+- 쓰기 경로에 삽입 1~2행이 추가된다(동일 트랜잭션이라 원자성은 유지).
+- 매핑과 audit_events의 정합성을 쓰기 경로가 책임진다. 현재 삽입 지점은 두 곳뿐이라 관리 비용은 낮다.
+- 새 감사 흐름을 추가할 때 관련 walletId를 매핑에 함께 기록해야 한다는 규약이 생긴다.
+
+## 대안
+
+- **`audit_events`에 wallet_id 배열 컬럼 추가**: 조인은 없애지만 기존 테이블 스키마를 변경하고, InMemory 미러가 복잡해지며, FK·인덱스 등 표준 관계형 의미론을 활용하기 어렵다. 매핑 테이블이 transfer의 다대일(2 owner) 관계를 더 자연스럽게 표현하므로 기각.
+- **조인 유지(현행)**: 변경 없음이지만 ledger 결합이 남고 ADR-0058 비용이 지속된다.
+- **audit_events에 단일 wallet_id 컬럼**: transfer가 한 operation에 양쪽 지갑을 매핑해야 하는 요구를 표현할 수 없어 기각.

--- a/docs/progress/0068-audit-events-authorization.md
+++ b/docs/progress/0068-audit-events-authorization.md
@@ -35,7 +35,7 @@
 
 ## 남은 일
 
-- `audit_events` wallet_id 비정규화로 ledger 조인 제거(현재는 조인 의존)
+- ~~`audit_events` wallet_id 비정규화로 ledger 조인 제거(현재는 조인 의존)~~ → 완료(참조 0070, `audit_event_wallets` 매핑 테이블로 해소)
 - 소유자 스코프 step-logs/outbox-events가 필요하면 별도 후속 검토
 - Docker 환경에서 `./gradlew postgresScenarioTest` 실행으로 신규 JDBC 테스트 검증(작성 시점 Docker 미가동으로 컴파일만 확인)
 

--- a/docs/progress/0070-audit-event-wallet-mapping.md
+++ b/docs/progress/0070-audit-event-wallet-mapping.md
@@ -1,0 +1,32 @@
+# 0070. Audit Event–Wallet Mapping 명시화
+
+## 스펙 목표
+
+- 소유자 스코프 `GET /api/v1/wallets/{walletId}/audit-events`가 의존하던 `ledger_entries` 조인을 제거한다.
+- audit-event↔wallet 매핑을 쓰기 시점에 명시적으로 영속화한다.
+- ADR-0058에서 고정한 현재 동작(transfer 감사 이벤트가 송신자·수신자 양쪽에 보이고 detail에 양쪽 walletId 포함)을 정확히 보존한다.
+
+## 완료 결과
+
+- 매핑 테이블 `audit_event_wallets(audit_event_id, wallet_id)`를 추가했다(복합 PK, `wallet_id` 인덱스). `V18__create_audit_event_wallets.sql`.
+- 마이그레이션이 기존 audit_events를 ledger 조인으로 역채움해 로컬 DB 호환성을 유지한다.
+- Jdbc/InMemory 쓰기 경로의 `insertAuditEvent`/`auditEvent` 삽입 지점에서 매핑을 동일 트랜잭션(InMemory는 동일 synchronized 블록)에 기록한다: charge → 1행(`walletId`), transfer → 2행(`sourceWalletId`, `targetWalletId`). `insertAuditEvent` 호출 지점 전수 확인 결과 감사 흐름은 이 둘뿐이다.
+- `findAuditEventsByWallet`를 매핑 기반으로 전환했다. Jdbc는 `audit_event_wallets` 서브쿼리, InMemory는 `Map<walletId, List<auditEventId>>` 유지. 파라미터 없는 operator용 `getAuditEvents()`는 변경하지 않았다.
+
+## 검증
+
+- `./gradlew test` — BUILD SUCCESSFUL (281 통과, 1 skipped, 0 실패)
+- `./gradlew postgresScenarioTest` — BUILD SUCCESSFUL (Docker Testcontainers, 컨테이너에서 V18 마이그레이션 실행; 소유 지갑 한정 + 역채움 경로 테스트 통과)
+- 회귀 고정: InMemory 교차 지갑 배제(`returnsWalletScopedAuditEventsForOwnerExcludingOtherWallets`), transfer 양쪽 소유자 가시성(`returnsTransferAuditEventWithCounterpartyToBothWalletOwners`), Postgres 컨테이너 소유 지갑 한정(`findAuditEventsByWalletReturnsOnlyOwningWalletEventsInRealPostgres`) + 역채움 경로(`findAuditEventsByWalletReturnsBackfilledLegacyEventInRealPostgres`).
+
+## 남은 일
+
+- 새 감사 흐름 추가 시 관련 walletId를 매핑에 함께 기록하는 규약을 유지한다.
+- 소유자 스코프 step-logs/outbox-events가 필요하면 별도 후속 검토(0068에서 이월).
+
+## 관련 문서
+
+- `docs/adr/0060-audit-event-wallet-mapping.md`
+- `docs/progress/0068-audit-events-authorization.md`
+- `docs/releases/unreleased.md`
+- GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/117

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -85,10 +85,11 @@ ADR은 “왜 그렇게 결정했는가”를 기록하고, 이 폴더는 “각
 | 0067 | [Frontend Login and Bearer Auth](0067-frontend-login-bearer-auth.md) | 완료 |
 | 0068 | [Audit Events and Operation Log Authorization](0068-audit-events-authorization.md) | 완료 |
 | 0069 | [로컬 k8s 배포와 관측 스택](0069-k8s-deploy-and-observability.md) | 완료 |
+| 0070 | [Audit Event–Wallet Mapping 명시화](0070-audit-event-wallet-mapping.md) | 완료 |
 
 ## 현재 기준선
 
 - 최신 병합 기준: `main`
-- 최신 완료 기능: Audit Events and Operation Log Authorization
+- 최신 완료 기능: Audit Event–Wallet Mapping 명시화
 - 현재 릴리스 후보: `v0.7.0`
 - 아직 미완료: JWT 만료 후 갱신 정책, Kafka/RabbitMQ/SQS adapter, pruning 실행 이력, Slack 발행 실패 record와 재시도 정책, broker-specific Testcontainers 정책, broker replay window별 retention 권장값, 실제 identity/role scope 연동, 운영 alert 화면 연결

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -35,6 +35,7 @@
 - audit-events/step-logs/outbox-events 미인증 노출 차단(operator 게이팅)과 소유자 스코프 `GET /wallets/{walletId}/audit-events` 추가
 - 로컬 k8s 배포 스택(Prometheus/Grafana/Loki)과 outbox 커스텀 지표
 - GitHub Actions → GHCR → GitOps → ArgoCD 배포 파이프라인
+- 소유자 스코프 audit-events의 ledger 조인 의존 제거 — `audit_event_wallets` 매핑 테이블을 쓰기 시점에 영속화(charge 1행/transfer 2행)하고 조회를 매핑 기반으로 전환(V18 역채움 포함)
 
 ## MVP 출시 판단 기준
 

--- a/issue-drafts/0070-audit-event-wallet-mapping.md
+++ b/issue-drafts/0070-audit-event-wallet-mapping.md
@@ -1,0 +1,24 @@
+# Audit Event–Wallet 매핑 명시화(ledger 조인 제거)
+
+## 배경
+
+소유자 스코프 `GET /api/v1/wallets/{walletId}/audit-events`(ADR-0058)는 `AuditEvent`에 walletId가 없어 소유권을 `ledger_entries` 조인으로 해소했다: `audit_events WHERE operation_id IN (SELECT operation_id FROM ledger_entries WHERE wallet_id = ?)`. 이 결합은 감사 이벤트 소유자를 원장 의미론에 종속시켜, ledger를 남기지 않는 감사 흐름이 생기면 소유자 조회에서 누락된다(ADR-0058 비용 항목, progress 0068 "남은 일").
+
+## 목표
+
+- audit-event↔wallet 매핑을 쓰기 시점에 명시적으로 영속화해 ledger 조인 의존을 제거한다.
+- ADR-0058이 고정한 현재 동작(transfer 감사 이벤트가 송신자·수신자 양쪽에 보이고 detail에 양쪽 walletId 포함)을 정확히 보존한다.
+
+## 완료 조건
+
+- [x] 매핑 테이블 `audit_event_wallets(audit_event_id, wallet_id)`를 추가한다(복합 PK, `wallet_id` 인덱스).
+- [x] Flyway V18에서 테이블 생성 + 기존 행을 ledger 조인으로 역채움한다(로컬 DB 호환).
+- [x] Jdbc/InMemory 쓰기 경로가 audit event와 동일 트랜잭션에 매핑을 기록한다(charge 1행, transfer 2행).
+- [x] `findAuditEventsByWallet`를 매핑 기반으로 전환한다. operator용 `getAuditEvents()`는 불변.
+- [x] InMemory 교차 지갑 배제 / transfer 양쪽 소유자 가시성 / Postgres 컨테이너 소유 지갑 한정 + 역채움 경로 테스트가 통과한다.
+- [x] ADR-0060, progress 0070 기록.
+
+## 관련 문서
+
+- `docs/adr/0060-audit-event-wallet-mapping.md`
+- `docs/progress/0070-audit-event-wallet-mapping.md`

--- a/issue-drafts/README.md
+++ b/issue-drafts/README.md
@@ -122,6 +122,8 @@
 - `0068-audit-events-unauthenticated-exposure.md`: audit-events 미인증 전체 노출 결함 (PR #106 리뷰 후속)
 - `0069-k8s-deploy-and-observability.md`: 로컬 k8s 배포와 관측 스택(B4) 작업 초안
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/110
+- `0070-audit-event-wallet-mapping.md`: audit-event↔wallet 매핑 명시화(ledger 조인 제거) 작업 초안
+  - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/117
 
 ## GitHub CLI로 생성
 

--- a/src/main/java/com/imwoo/airepo/wallet/infra/InMemoryWalletRepository.java
+++ b/src/main/java/com/imwoo/airepo/wallet/infra/InMemoryWalletRepository.java
@@ -52,7 +52,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
@@ -79,6 +78,7 @@ public class InMemoryWalletRepository implements
     private final Map<String, List<TransactionHistoryItem>> transactions = new HashMap<>();
     private final Map<String, List<LedgerEntry>> ledgerEntries = new HashMap<>();
     private final List<AuditEvent> auditEvents = new ArrayList<>();
+    private final Map<String, List<String>> auditEventIdsByWallet = new HashMap<>();
     private final Map<String, List<OperationStepLog>> operationStepLogs = new HashMap<>();
     private final Map<String, List<OperationOutboxEvent>> operationOutboxEvents = new HashMap<>();
     private final Map<String, List<OperationOutboxRequeueAudit>> outboxRequeueAudits = new HashMap<>();
@@ -207,11 +207,9 @@ public class InMemoryWalletRepository implements
 
     @Override
     public synchronized List<AuditEvent> findAuditEventsByWallet(String walletId) {
-        Set<String> operationIds = ledgerEntries.getOrDefault(walletId, List.of()).stream()
-                .map(LedgerEntry::operationId)
-                .collect(Collectors.toSet());
+        Set<String> auditEventIds = Set.copyOf(auditEventIdsByWallet.getOrDefault(walletId, List.of()));
         return auditEvents.stream()
-                .filter(auditEvent -> operationIds.contains(auditEvent.operationId()))
+                .filter(auditEvent -> auditEventIds.contains(auditEvent.auditEventId()))
                 .toList();
     }
 
@@ -839,12 +837,14 @@ public class InMemoryWalletRepository implements
         );
         ledgerEntries.computeIfAbsent(walletId, ignored -> new ArrayList<>()).add(ledgerEntry);
         addStepLog(operationId, OperationStep.LEDGER_RECORDED, occurredAt, "Ledger entry recorded for wallet " + walletId);
-        auditEvents.add(auditEvent(
+        AuditEvent chargeAuditEvent = auditEvent(
                 operationId,
                 AuditEventType.CHARGE_COMPLETED,
                 occurredAt,
                 "Charge completed for wallet " + walletId
-        ));
+        );
+        auditEvents.add(chargeAuditEvent);
+        mapAuditEventToWallets(chargeAuditEvent.auditEventId(), List.of(walletId));
         addStepLog(operationId, OperationStep.AUDIT_RECORDED, occurredAt, "Audit event recorded for operation " + operationId);
 
         WalletOperationResult result = new WalletOperationResult(
@@ -939,12 +939,14 @@ public class InMemoryWalletRepository implements
         ledgerEntries.computeIfAbsent(sourceWalletId, ignored -> new ArrayList<>()).add(sourceLedgerEntry);
         ledgerEntries.computeIfAbsent(targetWalletId, ignored -> new ArrayList<>()).add(targetLedgerEntry);
         addStepLog(operationId, OperationStep.LEDGER_RECORDED, occurredAt, "Ledger entries recorded for transfer " + sourceWalletId + " to " + targetWalletId);
-        auditEvents.add(auditEvent(
+        AuditEvent transferAuditEvent = auditEvent(
                 operationId,
                 AuditEventType.TRANSFER_COMPLETED,
                 occurredAt,
                 "Transfer completed from " + sourceWalletId + " to " + targetWalletId
-        ));
+        );
+        auditEvents.add(transferAuditEvent);
+        mapAuditEventToWallets(transferAuditEvent.auditEventId(), List.of(sourceWalletId, targetWalletId));
         addStepLog(operationId, OperationStep.AUDIT_RECORDED, occurredAt, "Audit event recorded for operation " + operationId);
 
         WalletOperationResult result = new WalletOperationResult(
@@ -1152,6 +1154,12 @@ public class InMemoryWalletRepository implements
                 balanceAfter,
                 description
         );
+    }
+
+    private void mapAuditEventToWallets(String auditEventId, List<String> walletIds) {
+        for (String walletId : walletIds) {
+            auditEventIdsByWallet.computeIfAbsent(walletId, ignored -> new ArrayList<>()).add(auditEventId);
+        }
     }
 
     private AuditEvent auditEvent(

--- a/src/main/java/com/imwoo/airepo/wallet/infra/JdbcWalletRepository.java
+++ b/src/main/java/com/imwoo/airepo/wallet/infra/JdbcWalletRepository.java
@@ -163,8 +163,8 @@ public class JdbcWalletRepository implements
                 """
                         select ae.audit_event_id, ae.operation_id, ae.type, ae.occurred_at, ae.detail
                         from audit_events ae
-                        where ae.operation_id in (
-                            select operation_id from ledger_entries where wallet_id = ?
+                        where ae.audit_event_id in (
+                            select audit_event_id from audit_event_wallets where wallet_id = ?
                         )
                         """,
                 auditEventMapper(),
@@ -1226,7 +1226,8 @@ public class JdbcWalletRepository implements
                     operationId,
                     AuditEventType.CHARGE_COMPLETED,
                     occurredAt,
-                    "Charge completed for wallet " + walletId
+                    "Charge completed for wallet " + walletId,
+                    List.of(walletId)
             );
             insertOperationStepLog(
                     operationId,
@@ -1365,7 +1366,8 @@ public class JdbcWalletRepository implements
                     operationId,
                     AuditEventType.TRANSFER_COMPLETED,
                     occurredAt,
-                    "Transfer completed from " + sourceWalletId + " to " + targetWalletId
+                    "Transfer completed from " + sourceWalletId + " to " + targetWalletId,
+                    List.of(sourceWalletId, targetWalletId)
             );
             insertOperationStepLog(
                     operationId,
@@ -1545,7 +1547,14 @@ public class JdbcWalletRepository implements
         );
     }
 
-    private void insertAuditEvent(String auditEventId, String operationId, AuditEventType type, Instant occurredAt, String detail) {
+    private void insertAuditEvent(
+            String auditEventId,
+            String operationId,
+            AuditEventType type,
+            Instant occurredAt,
+            String detail,
+            List<String> walletIds
+    ) {
         jdbcTemplate.update(
                 """
                         insert into audit_events (audit_event_id, operation_id, type, occurred_at, detail)
@@ -1557,6 +1566,16 @@ public class JdbcWalletRepository implements
                 timestamp(occurredAt),
                 detail
         );
+        for (String walletId : walletIds) {
+            jdbcTemplate.update(
+                    """
+                            insert into audit_event_wallets (audit_event_id, wallet_id)
+                            values (?, ?)
+                            """,
+                    auditEventId,
+                    walletId
+            );
+        }
     }
 
     private void insertOperation(WalletOperationRecord record) {

--- a/src/main/resources/db/migration/V18__create_audit_event_wallets.sql
+++ b/src/main/resources/db/migration/V18__create_audit_event_wallets.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS audit_event_wallets (
+    audit_event_id VARCHAR(64) NOT NULL REFERENCES audit_events(audit_event_id),
+    wallet_id VARCHAR(64) NOT NULL REFERENCES wallet_accounts(wallet_id),
+    PRIMARY KEY (audit_event_id, wallet_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_event_wallets_wallet_id
+    ON audit_event_wallets (wallet_id);
+
+-- 기존 audit_events를 ledger_entries 조인으로 역채움해 로컬 DB 호환성을 유지한다.
+INSERT INTO audit_event_wallets (audit_event_id, wallet_id)
+SELECT DISTINCT ae.audit_event_id, le.wallet_id
+FROM audit_events ae
+JOIN ledger_entries le ON le.operation_id = ae.operation_id
+ON CONFLICT DO NOTHING;

--- a/src/main/resources/db/postgresql/schema.sql
+++ b/src/main/resources/db/postgresql/schema.sql
@@ -72,6 +72,15 @@ CREATE TABLE IF NOT EXISTS audit_events (
     detail VARCHAR(255) NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS audit_event_wallets (
+    audit_event_id VARCHAR(64) NOT NULL REFERENCES audit_events(audit_event_id),
+    wallet_id VARCHAR(64) NOT NULL REFERENCES wallet_accounts(wallet_id),
+    PRIMARY KEY (audit_event_id, wallet_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_event_wallets_wallet_id
+    ON audit_event_wallets (wallet_id);
+
 CREATE TABLE IF NOT EXISTS operation_step_logs (
     operation_step_log_id VARCHAR(64) PRIMARY KEY,
     operation_id VARCHAR(64) NOT NULL,

--- a/src/test/java/com/imwoo/airepo/wallet/infra/PostgresContainerWalletRepositoryTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/infra/PostgresContainerWalletRepositoryTest.java
@@ -54,6 +54,7 @@ class PostgresContainerWalletRepositoryTest {
     private InMemoryWalletCommandService commandService;
     private InMemoryWalletLedgerQueryService ledgerQueryService;
     private DriverManagerDataSource dataSource;
+    private JdbcTemplate jdbcTemplate;
 
     @BeforeEach
     void setUp() {
@@ -64,7 +65,7 @@ class PostgresContainerWalletRepositoryTest {
 
         resetDatabase(dataSource);
 
-        JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+        jdbcTemplate = new JdbcTemplate(dataSource);
 
         repository = new JdbcWalletRepository(
                 jdbcTemplate,
@@ -121,6 +122,62 @@ class PostgresContainerWalletRepositoryTest {
                 .singleElement()
                 .satisfies(auditEvent -> assertThat(auditEvent.operationId())
                         .isEqualTo(walletBResult.operation().operationId()));
+    }
+
+    @Test
+    void findAuditEventsByWalletReturnsBackfilledLegacyEventInRealPostgres() {
+        // 매핑 테이블 없이 존재하던 레거시 audit_event + ledger_entry를 직접 심는다.
+        jdbcTemplate.update(
+                """
+                        insert into ledger_entries (
+                            ledger_entry_id, operation_id, wallet_id, occurred_at, type, direction,
+                            amount, currency, balance_after_amount, balance_after_currency, description
+                        )
+                        values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                "ledger-legacy-001",
+                "op-legacy-001",
+                "wallet-001",
+                java.sql.Timestamp.from(Instant.parse("2026-04-01T00:00:00Z")),
+                "CHARGE",
+                "CREDIT",
+                new BigDecimal("1000"),
+                "KRW",
+                new BigDecimal("1000"),
+                "KRW",
+                "레거시 충전"
+        );
+        jdbcTemplate.update(
+                """
+                        insert into audit_events (audit_event_id, operation_id, type, occurred_at, detail)
+                        values (?, ?, ?, ?, ?)
+                        """,
+                "audit-legacy-001",
+                "op-legacy-001",
+                "CHARGE_COMPLETED",
+                java.sql.Timestamp.from(Instant.parse("2026-04-01T00:00:00Z")),
+                "레거시 충전 완료"
+        );
+
+        // 매핑이 없으면 소유자 스코프 조회가 비어 있어야 한다.
+        assertThat(repository.findAuditEventsByWallet("wallet-001"))
+                .noneMatch(auditEvent -> auditEvent.auditEventId().equals("audit-legacy-001"));
+
+        // V18 마이그레이션의 역채움 SQL을 재실행해 레거시 매핑을 복원한다.
+        jdbcTemplate.update(
+                """
+                        insert into audit_event_wallets (audit_event_id, wallet_id)
+                        select distinct ae.audit_event_id, le.wallet_id
+                        from audit_events ae
+                        join ledger_entries le on le.operation_id = ae.operation_id
+                        on conflict do nothing
+                        """
+        );
+
+        assertThat(repository.findAuditEventsByWallet("wallet-001"))
+                .anyMatch(auditEvent -> auditEvent.auditEventId().equals("audit-legacy-001"));
+        assertThat(repository.findAuditEventsByWallet("wallet-002"))
+                .noneMatch(auditEvent -> auditEvent.auditEventId().equals("audit-legacy-001"));
     }
 
     @Test

--- a/wiki-drafts/Architecture-Decisions.md
+++ b/wiki-drafts/Architecture-Decisions.md
@@ -106,6 +106,7 @@
 | Operational alert suppression/pruning | 같은 alert의 짧은 시간 중복 저장을 막고 보존 기간 기준으로 삭제 | suppression 기준이 reason 문자열에 의존 |
 | Slack webhook operational alert publisher | Incoming Webhook 호환 text payload로 push channel 계약 고정 | 발행 실패 record와 재시도 정책은 후속 과제 |
 | Admin API path matching hardening | 인증·감사 필터가 공통 segment-aware matcher로 root/sub-path만 운영 API로 분류 | Spring Security matcher 목록과 완전한 단일 source of truth는 후속 과제 |
+| Audit event–wallet 매핑 명시화 | `audit_event_wallets` 매핑 테이블을 쓰기 시점에 영속화(charge 1행/transfer 2행)해 소유자 스코프 audit-events 조회의 ledger 조인 의존을 제거 | 쓰기 경로에 매핑 삽입 1~2행 추가와 정합성 책임 |
 | Wiki는 요약, ADR은 결정 | 포트폴리오 설명성과 PR 검증성 모두 확보 | Wiki 하나에 모든 결정을 몰아넣는 단순성 |
 
 ## 다음 구조 후보


### PR DESCRIPTION
## 배경

소유자 스코프 `GET /api/v1/wallets/{walletId}/audit-events`(ADR-0058)는 `AuditEvent`에 walletId가 없어 소유권을 `ledger_entries` 조인으로 해소했다: `audit_events WHERE operation_id IN (SELECT operation_id FROM ledger_entries WHERE wallet_id = ?)`. 이 결합은 감사 이벤트 소유자를 원장 의미론에 종속시킨다(ADR-0058 비용, progress 0068 "남은 일").

## 변경

- 매핑 테이블 `audit_event_wallets(audit_event_id, wallet_id)` 추가(복합 PK, `wallet_id` 인덱스).
- 쓰기 경로가 audit event와 **동일 트랜잭션**에 매핑을 기록: charge → 1행(`walletId`), transfer → 2행(`sourceWalletId`, `targetWalletId`). `insertAuditEvent` 호출 지점 전수 확인.
- `findAuditEventsByWallet`를 매핑 기반으로 전환. Jdbc는 `audit_event_wallets` 서브쿼리, InMemory는 `Map<walletId, List<auditEventId>>`. operator용 `getAuditEvents()`는 불변.
- Flyway V18: 테이블·인덱스 생성 + 기존 행을 ledger 조인으로 역채움(로컬 DB 호환). H2 테스트용 `db/postgresql/schema.sql`도 동기화.

## 동작 보존

- ADR-0058 수용 노출을 정확히 유지한다: transfer 감사 이벤트가 송신자·수신자 **양쪽 소유자**에게 보이고 detail에 양쪽 walletId 포함. `returnsTransferAuditEventWithCounterpartyToBothWalletOwners`로 고정.

## 테스트

- `./gradlew test` — BUILD SUCCESSFUL (281 통과, 1 skipped)
- `./gradlew postgresScenarioTest` — BUILD SUCCESSFUL. 컨테이너에서 V18 마이그레이션 실행. 신규 `findAuditEventsByWalletReturnsBackfilledLegacyEventInRealPostgres`(역채움 경로) + 기존 소유 지갑 한정 테스트 통과.
- InMemory 교차 지갑 배제(`returnsWalletScopedAuditEventsForOwnerExcludingOtherWallets`) 통과.

## 설계 선택

매핑 테이블을 택했다. `audit_events` 배열 컬럼은 기존 테이블 스키마 변경과 InMemory 미러 복잡도가 크고 표준 관계형 의미론(FK/인덱스)을 활용하기 어렵다. 매핑 테이블이 transfer의 "1 operation → 2 owner"를 2행으로 자연스럽게 표현한다. 상세는 ADR-0060.

## 문서

- `docs/adr/0060-audit-event-wallet-mapping.md`
- `docs/progress/0070-audit-event-wallet-mapping.md`, progress 0068 남은 일 완료 표시
- `docs/releases/unreleased.md`, issue-drafts, wiki-drafts 갱신

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)