### PR TITLE
fix: multi-arch deploy image (arm64 local node crash loop)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,26 @@ jobs:
           SHA8=${HEAD_SHA:0:8}
           echo "tag=${VERSION}-${SHA8}" >> "$GITHUB_OUTPUT"
 
+      - name: Set up Java 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      # jar는 러너에서 네이티브 빌드한다. Dockerfile.ci는 COPY만 하므로
+      # 멀티아치 빌드에서 컴파일이 QEMU 에뮬레이션되지 않는다.
+      - name: Build boot jar
+        run: ./gradlew bootJar
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -52,10 +72,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push image
+      # arm64(Apple Silicon Docker Desktop 노드)와 amd64를 모두 지원해야 한다.
+      # single-arch amd64 이미지는 arm64 노드에서 에뮬레이션 기동이 liveness를 초과해
+      # CrashLoopBackOff를 일으킨다 (#127).
+      - name: Build and push multi-arch image
         uses: docker/build-push-action@v6
         with:
           context: .
+          file: Dockerfile.ci
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ env.IMAGE }}:${{ steps.meta.outputs.tag }}
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,8 @@
+# CI 전용 런타임 이미지 — jar는 러너에서 네이티브 빌드(./gradlew bootJar)하고
+# 여기서는 COPY만 하므로 buildx 멀티아치(linux/amd64,linux/arm64)가 에뮬레이션 없이 빠르다.
+# 로컬 빌드는 기존 멀티스테이지 Dockerfile을 사용한다.
+FROM eclipse-temurin:25-jre
+WORKDIR /app
+COPY build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docs/development/ci-cd-gitops.md
+++ b/docs/development/ci-cd-gitops.md
@@ -18,6 +18,7 @@ main push
 ```
 
 - **이미지 태그 규칙**: 반드시 `{version}-{sha8}`. `latest` 사용 금지. sha8은 CI run의 `head_sha` 앞 8자리다.
+- **멀티아치**: jar는 러너에서 네이티브 빌드 후 `Dockerfile.ci`(COPY 전용)로 `linux/amd64,linux/arm64` 동시 push — amd64 단일 이미지는 Apple Silicon 로컬 노드에서 에뮬레이션 기동이 liveness를 초과해 CrashLoopBackOff가 난다(#127). 로컬 빌드는 기존 멀티스테이지 `Dockerfile`을 그대로 쓴다.
 - **CI 게이트**: deploy는 CI("CI" 워크플로우)가 성공했을 때만 실행된다(`workflow_run` + `if: conclusion == 'success'`). 깨진 커밋(테스트/빌드 실패)은 배포되지 않는다.
 - **재트리거 방지**: 매니페스트 커밋 메시지에 `[skip ci]`를 붙이면 CI가 아예 돌지 않으므로 CI→deploy 루프가 차단된다. (`workflow_run` 트리거에는 paths 필터가 없어 기존 `paths-ignore` 블록은 제거했다.)
 - **동작 변화**: paths 필터가 없어져, CI를 통과한 docs-only push도 이제 이미지 빌드+배포를 트리거한다.


### PR DESCRIPTION
Closes #127

## 문제

`0.7.0-2691b1e1`(Actions 빌드, amd64 single-arch) 롤아웃이 arm64 Docker Desktop 노드에서 CrashLoopBackOff — QEMU 에뮬레이션 JVM 기동이 liveness(초기 30s + 10s×3)를 초과해 SIGTERM(143) 반복. 실측 56초 생존 후 종료.

## 해결

- 러너에서 `./gradlew bootJar` 네이티브 빌드
- `Dockerfile.ci`(jar COPY 전용) + buildx `linux/amd64,linux/arm64` — 컴파일이 에뮬레이션되지 않아 빌드 시간 영향 최소
- 로컬 `k8s-local-up.sh`는 기존 멀티스테이지 `Dockerfile` 유지
- ci-cd-gitops.md 반영

머지 후 이 커밋의 CI→deploy가 멀티아치 이미지를 push하면 정체된 롤아웃이 자연 회복됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)