### PR TITLE
chore: k8s-local-up rollout 대상 확장(loki/alloy) + ArgoCD 버전 고정

### DIFF
--- a/docs/adr/0059-k8s-deploy-and-observability.md
+++ b/docs/adr/0059-k8s-deploy-and-observability.md
@@ -17,6 +17,8 @@ ai-repo는 지금까지 `compose.yml`(Postgres 단독)과 로컬 프로세스 �
 | 메트릭 | micrometer-registry-prometheus, `/actuator/prometheus`를 Prometheus가 15s 스크랩. HTTP 지연 분위수는 percentiles-histogram |
 | 커스텀 지표 | outbox 릴레이/컨슈머를 비침습 브리지로 노출 — 게이지는 `OutboxMetricsBinder`가 기존 모니터링 서비스를 스크레이프 시점에 읽고, 릴레이 카운터는 `OutboxRelayMetricsRecorder` 포트로 기록 시점 증가(실행 저장소가 최근 샘플만 보관해 사후 누적 불가하므로) |
 | 로그 | Loki(single binary, filesystem, 72h) + Grafana Alloy가 k8s API로 파드 로그 tail(호스트 마운트 없음). Grafana Explore에서 LogQL 검색 |
+| 로컬 up 대기 범위 | `k8s-local-up.sh`가 postgres/app/prometheus/**loki/alloy**/grafana 전체 rollout을 대기하고, Loki `svc/loki` port-forward + `/ready` curl 스모크로 관측 스택 기동을 확인 |
+| ArgoCD 설치 | 재현성을 위해 설치 매니페스트를 고정 버전(`v3.4.4`) URL로 apply — 이동하는 `stable` 태그 금지 |
 | 대시보드 | Grafana 프로비저닝(ConfigMap) — `ai-repo Overview`: HTTP/지갑거래/JVM/Hikari/CPU + Outbox row |
 | CI/CD | GitHub Actions CI 성공 후 deploy가 `workflow_run`으로 트리거(`if: conclusion == 'success'`) → CI run의 `head_sha` 체크아웃 → 이미지 태그 `{version}-{sha8}` → ghcr.io push → `deploy/gitops/kustomization.yaml` newTag 갱신 커밋(`[skip ci]`) |
 | GitOps | ArgoCD(로컬 설치, `--server-side` apply)가 `deploy/gitops`를 자동 sync(prune+selfHeal). 오버레이는 `../k8s` base + ghcr 이미지 교체 |

--- a/docs/development/ci-cd-gitops.md
+++ b/docs/development/ci-cd-gitops.md
@@ -35,8 +35,10 @@ scripts/argocd-install.sh      # 로컬 ArgoCD 설치 + Application 등록
 
 ## ArgoCD 설치 / 접속
 
+설치 매니페스트는 재현성을 위해 고정 버전(현재 `v3.4.4`)을 apply한다. `stable` 태그는 릴리스마다 이동하므로 쓰지 않는다. 버전 갱신은 `scripts/argocd-install.sh`의 `ARGOCD_VERSION`만 바꾼다.
+
 ```bash
-./scripts/argocd-install.sh    # --server-side apply (CRD 크기 제한 때문에 필수)
+./scripts/argocd-install.sh    # ArgoCD v3.4.4, --server-side apply (CRD 크기 제한 때문에 필수)
 
 # UI
 kubectl -n argocd port-forward svc/argocd-server 8443:443

--- a/docs/progress/0071-k8s-script-hardening.md
+++ b/docs/progress/0071-k8s-script-hardening.md
@@ -1,0 +1,30 @@
+# 0071. k8s 로컬 스크립트 하드닝 (loki/alloy 대기 + ArgoCD 버전 고정)
+
+## 스펙 목표
+
+- `scripts/k8s-local-up.sh` rollout 대기 대상을 kustomization 전체(loki/alloy 포함)로 맞추고 Loki 기동을 스모크로 확인한다.
+- `scripts/argocd-install.sh`가 이동하는 `stable` 태그 대신 고정 버전 매니페스트를 apply해 설치 재현성을 확보한다.
+
+## 완료 결과
+
+- **k8s-local-up 대기 확장**: `deployment/loki`, `deployment/alloy` rollout status 대기를 추가(기존 postgres/app/prometheus/grafana에 이어). kustomization에 선언된 6개 Deployment 전체를 대기한다.
+- **Loki 스모크**: rollout 완료 후 `svc/loki` 3100 port-forward → `curl -sf http://localhost:3100/ready`(2초 간격 최대 10회 재시도), 성공/실패 모두 port-forward 프로세스를 정리(trap EXIT + 명시적 kill). 기존 스크립트의 `set -euo pipefail`/에러 처리 스타일을 유지.
+- **ArgoCD 버전 고정**: `scripts/argocd-install.sh`에 `ARGOCD_VERSION=v3.4.4`를 도입하고 `.../argo-cd/${ARGOCD_VERSION}/manifests/install.yaml`을 apply. 이동하는 `stable` 태그 제거. 버전 갱신은 변수 한 줄만 바꾼다.
+- **문서**: `docs/development/ci-cd-gitops.md` 설치 커맨드/설명 갱신, ADR-0059 결정 표에 rollout 대기 범위·ArgoCD 버전 고정 반영.
+
+## 개선 건수
+
+1. k8s-local-up rollout 대기에 loki/alloy 추가 + Loki `/ready` 스모크.
+2. ArgoCD 설치 매니페스트 버전 고정(`v3.4.4`).
+
+## 검증
+
+- `bash -n scripts/k8s-local-up.sh`, `bash -n scripts/argocd-install.sh` 통과.
+- `scripts/check-dev-rules.sh`(AI_REPO_DEV_RULES_BASE=origin/main) PASS.
+- 스크립트는 활성 클러스터에 실행하지 않음(라이브 클러스터 사용 중).
+
+## 관련 문서
+
+- GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/120
+- `docs/adr/0059-k8s-deploy-and-observability.md`
+- `docs/development/ci-cd-gitops.md`

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -86,6 +86,7 @@ ADR은 “왜 그렇게 결정했는가”를 기록하고, 이 폴더는 “각
 | 0068 | [Audit Events and Operation Log Authorization](0068-audit-events-authorization.md) | 완료 |
 | 0069 | [로컬 k8s 배포와 관측 스택](0069-k8s-deploy-and-observability.md) | 완료 |
 | 0070 | [Audit Event–Wallet Mapping 명시화](0070-audit-event-wallet-mapping.md) | 완료 |
+| 0071 | [k8s 로컬 스크립트 하드닝](0071-k8s-script-hardening.md) | 완료 |
 
 ## 현재 기준선
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -37,6 +37,7 @@
 - 로컬 k8s 배포 스택(Prometheus/Grafana/Loki)과 outbox 커스텀 지표
 - GitHub Actions → GHCR → GitOps → ArgoCD 배포 파이프라인
 - 소유자 스코프 audit-events의 ledger 조인 의존 제거 — `audit_event_wallets` 매핑 테이블을 쓰기 시점에 영속화(charge 1행/transfer 2행)하고 조회를 매핑 기반으로 전환(V18 역채움 포함)
+- k8s 로컬 스크립트 하드닝 — `k8s-local-up.sh`가 loki/alloy rollout까지 대기 + Loki `/ready` 스모크, `argocd-install.sh` 설치 매니페스트 버전 고정(v3.4.4)
 
 ## MVP 출시 판단 기준
 

--- a/issue-drafts/0071-k8s-script-hardening.md
+++ b/issue-drafts/0071-k8s-script-hardening.md
@@ -1,0 +1,23 @@
+# k8s 로컬 스크립트 하드닝 (loki/alloy 대기 + ArgoCD 버전 고정)
+
+## 배경
+
+- `scripts/k8s-local-up.sh` rollout 대기 대상이 postgres/app/prometheus/grafana뿐 — kustomization에 포함된 loki/alloy는 대기·확인 없음.
+- `scripts/argocd-install.sh`가 원격 `stable` 매니페스트를 직접 apply — 태그가 이동해 재현성이 없음.
+
+## 목표
+
+- 로컬 up 스크립트가 관측 스택(loki/alloy)까지 기동을 대기·확인해 부분 기동 상태를 감춘 채 "완료"를 출력하지 않게 한다.
+- ArgoCD 설치를 고정 버전으로 재현 가능하게 만든다.
+
+## 완료 조건
+
+- [x] `loki`/`alloy` rollout status 대기 추가 + Loki `/ready` 최소 스모크(port-forward + curl, 정리 포함).
+- [x] ArgoCD 설치 매니페스트 버전 고정(`v3.4.4` URL) 및 가이드 문서(`docs/development/ci-cd-gitops.md`) 갱신.
+- [x] ADR-0059 결정 표에 rollout 대기 범위·ArgoCD 버전 고정 반영, progress 0071 기록.
+
+## 관련 문서
+
+- GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/120
+- `docs/progress/0071-k8s-script-hardening.md`
+- `docs/adr/0059-k8s-deploy-and-observability.md`

--- a/issue-drafts/README.md
+++ b/issue-drafts/README.md
@@ -124,6 +124,8 @@
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/110
 - `0070-audit-event-wallet-mapping.md`: audit-event↔wallet 매핑 명시화(ledger 조인 제거) 작업 초안
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/117
+- `0071-k8s-script-hardening.md`: k8s 로컬 스크립트 하드닝(loki/alloy 대기 + ArgoCD 버전 고정) 작업 초안
+  - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/120
 
 ## GitHub CLI로 생성
 

--- a/scripts/argocd-install.sh
+++ b/scripts/argocd-install.sh
@@ -4,11 +4,13 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 CONTEXT=docker-desktop
+# 재현성: 설치 매니페스트는 고정 버전을 사용한다(stable 태그는 이동하므로 금지).
+ARGOCD_VERSION=v3.4.4
 
-echo "==> ArgoCD 설치"
+echo "==> ArgoCD 설치 (${ARGOCD_VERSION})"
 kubectl --context "$CONTEXT" create namespace argocd --dry-run=client -o yaml | kubectl --context "$CONTEXT" apply -f -
 # --server-side: ArgoCD CRD가 client-side apply 주석 크기 제한(256KiB)을 초과하므로 필수
-kubectl --context "$CONTEXT" apply -n argocd --server-side --force-conflicts -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+kubectl --context "$CONTEXT" apply -n argocd --server-side --force-conflicts -f "https://raw.githubusercontent.com/argoproj/argo-cd/${ARGOCD_VERSION}/manifests/install.yaml"
 
 echo "==> ArgoCD 서버 대기"
 kubectl --context "$CONTEXT" -n argocd rollout status deployment/argocd-server --timeout=300s

--- a/scripts/k8s-local-up.sh
+++ b/scripts/k8s-local-up.sh
@@ -20,7 +20,22 @@ echo "==> 롤아웃 대기"
 kubectl --context "$CONTEXT" -n ai-repo rollout status deployment/postgres --timeout=180s
 kubectl --context "$CONTEXT" -n ai-repo rollout status deployment/ai-repo --timeout=300s
 kubectl --context "$CONTEXT" -n ai-repo rollout status deployment/prometheus --timeout=180s
+kubectl --context "$CONTEXT" -n ai-repo rollout status deployment/loki --timeout=180s
+kubectl --context "$CONTEXT" -n ai-repo rollout status deployment/alloy --timeout=180s
 kubectl --context "$CONTEXT" -n ai-repo rollout status deployment/grafana --timeout=180s
+
+echo "==> Loki 스모크 (ready)"
+kubectl --context "$CONTEXT" -n ai-repo port-forward svc/loki 3100:3100 >/dev/null 2>&1 &
+PF_PID=$!
+trap 'kill "$PF_PID" 2>/dev/null || true' EXIT
+for i in $(seq 1 10); do
+  curl -sf http://localhost:3100/ready >/dev/null 2>&1 && break
+  [[ $i -eq 10 ]] && { echo "Loki /ready 응답 없음 (port-forward svc/loki 3100)."; exit 1; }
+  sleep 2
+done
+echo "Loki ready OK"
+kill "$PF_PID" 2>/dev/null || true
+trap - EXIT
 
 cat <<'EOF'
 
@@ -28,4 +43,5 @@ cat <<'EOF'
   앱          http://localhost:30080          (health: /actuator/health, metrics: /actuator/prometheus)
   Prometheus  http://localhost:30990          (targets: /targets)
   Grafana     http://localhost:30300          (익명 Admin, 대시보드: ai-repo Overview)
+  Loki        Grafana Explore(Loki)에서 LogQL — Alloy가 파드 로그 수집
 EOF

--- a/wiki-drafts/Release-Notes.md
+++ b/wiki-drafts/Release-Notes.md
@@ -43,6 +43,7 @@
 - 로컬 k8s 배포 스택(Prometheus/Grafana/Loki)과 outbox 커스텀 지표
 - GitHub Actions → GHCR({version}-{sha8}) → GitOps → ArgoCD 배포 파이프라인
 - Deploy 파이프라인 CI 성공 게이트(workflow_run)
+- k8s 로컬 스크립트 하드닝(loki/alloy rollout 대기 + Loki ready 스모크, ArgoCD 설치 버전 고정 v3.4.4)
 
 ## 릴리스 후보 검증
 


### PR DESCRIPTION
## 배경
- `scripts/k8s-local-up.sh`의 rollout 대기 대상이 postgres/app/prometheus/grafana뿐이라, `deploy/k8s/kustomization.yaml`에 포함된 **loki/alloy는 대기·확인 없이** "배포 완료"가 출력됐다.
- `scripts/argocd-install.sh`가 원격 `stable` 매니페스트를 직접 apply — `stable` 태그는 릴리스마다 이동해 재현성이 없었다.

## 변경
### 1. `scripts/k8s-local-up.sh`
- rollout status 대기에 `deployment/loki`, `deployment/alloy` 추가 → kustomization의 6개 Deployment 전체 대기.
- rollout 완료 후 Loki 스모크: `svc/loki` 3100 port-forward → `curl -sf http://localhost:3100/ready`(2초 간격 최대 10회 재시도). 성공/실패 모두 port-forward 프로세스 정리(`trap EXIT` + 명시적 `kill`). 기존 `set -euo pipefail`/에러 처리 스타일 유지.

### 2. `scripts/argocd-install.sh`
- 설치 매니페스트를 고정 버전 URL로 apply. `ARGOCD_VERSION=v3.4.4` 변수 도입 후 `.../argo-cd/${ARGOCD_VERSION}/manifests/install.yaml`.
- **선택 버전: v3.4.4** — argo-cd GitHub 최신 stable release(non-prerelease)이며 매니페스트 URL 존재 확인. 버전 갱신은 변수 한 줄만 바꾼다.

### 문서
- ADR-0059 결정 표에 로컬 up 대기 범위(loki/alloy)·ArgoCD 버전 고정 반영.
- `docs/development/ci-cd-gitops.md` 설치 커맨드/설명 v3.4.4로 갱신.
- progress 0071(신규) + README, issue-draft 0071(신규) + README, unreleased, wiki Release-Notes 한 줄씩 갱신.

## 검증
- `bash -n scripts/k8s-local-up.sh`, `bash -n scripts/argocd-install.sh` 통과.
- `AI_REPO_DEV_RULES_BASE=origin/main scripts/check-dev-rules.sh` → PASS.
- 라이브 클러스터 사용 중이라 스크립트는 실제 클러스터에 실행하지 않음.

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)