### PR TITLE
feat: k8s 자격증명 Secret 주입(DB/운영 토큰) 전환

### DIFF
--- a/deploy/k8s/app.yaml
+++ b/deploy/k8s/app.yaml
@@ -25,9 +25,30 @@ spec:
             - name: AI_REPO_POSTGRES_URL
               value: jdbc:postgresql://postgres:5432/ai_repo
             - name: AI_REPO_POSTGRES_USERNAME
-              value: ai_repo
+              valueFrom:
+                secretKeyRef:
+                  name: ai-repo-credentials
+                  key: AI_REPO_POSTGRES_USERNAME
             - name: AI_REPO_POSTGRES_PASSWORD
-              value: ai_repo
+              valueFrom:
+                secretKeyRef:
+                  name: ai-repo-credentials
+                  key: AI_REPO_POSTGRES_PASSWORD
+            - name: AI_REPO_OPS_ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: ai-repo-credentials
+                  key: AI_REPO_OPS_ADMIN_TOKEN
+            - name: AI_REPO_OPS_OPERATOR_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: ai-repo-credentials
+                  key: AI_REPO_OPS_OPERATOR_TOKEN
+            - name: AI_REPO_AUTH_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: ai-repo-credentials
+                  key: AI_REPO_AUTH_JWT_SECRET
             - name: AI_REPO_OUTBOX_RELAY_SCHEDULER_ENABLED
               value: "true"
           ports:

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - secrets.yaml
   - postgres.yaml
   - app.yaml
   - prometheus.yaml

--- a/deploy/k8s/postgres.yaml
+++ b/deploy/k8s/postgres.yaml
@@ -32,11 +32,20 @@ spec:
           image: postgres:17-alpine
           env:
             - name: POSTGRES_DB
-              value: ai_repo
+              valueFrom:
+                secretKeyRef:
+                  name: ai-repo-credentials
+                  key: POSTGRES_DB
             - name: POSTGRES_USER
-              value: ai_repo
+              valueFrom:
+                secretKeyRef:
+                  name: ai-repo-credentials
+                  key: POSTGRES_USER
             - name: POSTGRES_PASSWORD
-              value: ai_repo
+              valueFrom:
+                secretKeyRef:
+                  name: ai-repo-credentials
+                  key: POSTGRES_PASSWORD
           ports:
             - containerPort: 5432
           readinessProbe:

--- a/deploy/k8s/secrets.yaml
+++ b/deploy/k8s/secrets.yaml
@@ -1,0 +1,25 @@
+# ai-repo 자격증명 Secret — 로컬 학습 전용 고정값(비프로덕션).
+#
+# 여기 stringData 값은 compose.yml·application.yml 기본값과 동일한 로컬 고정값이다.
+# 로컬 학습 환경에서 재현·초기화 편의를 위해 평문으로 커밋하며, 실제 비밀이 아니다.
+# 원격/스테이징 클러스터에서는 이 매니페스트를 그대로 쓰지 말고,
+# External Secrets/SealedSecrets 등으로 별도 주입한다(원격 전환 시 재설계).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ai-repo-credentials
+  namespace: ai-repo
+type: Opaque
+stringData:
+  # Postgres 컨테이너 초기화(postgres.yaml)
+  POSTGRES_DB: ai_repo
+  POSTGRES_USER: ai_repo
+  POSTGRES_PASSWORD: ai_repo
+  # 앱 DB 접속(app.yaml)
+  AI_REPO_POSTGRES_USERNAME: ai_repo
+  AI_REPO_POSTGRES_PASSWORD: ai_repo
+  # 운영 API 토큰(app.yaml) — application.yml의 env 이름과 일치
+  AI_REPO_OPS_ADMIN_TOKEN: local-ops-token
+  AI_REPO_OPS_OPERATOR_TOKEN: local-operator-token
+  # 엔드유저 JWT 서명 비밀(app.yaml)
+  AI_REPO_AUTH_JWT_SECRET: local-dev-jwt-secret-please-change-32b

--- a/docs/adr/0061-k8s-secret-injection.md
+++ b/docs/adr/0061-k8s-secret-injection.md
@@ -1,0 +1,44 @@
+# ADR-0061: k8s 자격증명 Secret 주입 전환
+
+## 상태
+
+Accepted
+
+## 배경
+
+`deploy/k8s/app.yaml`·`postgres.yaml`이 DB 비밀번호와 운영 토큰을 평문 `env` 값으로 두고 있었다(ADR-0059의 로컬 학습 전용 구성). 값 자체는 `compose.yml`·`application.yml` 기본값과 동일한 로컬 고정값이라 유출되어도 실피해는 없지만, Deployment 매니페스트에 자격증명을 직접 박아두는 것은 다음 문제가 있다.
+
+- 자격증명이 여러 매니페스트에 흩어져 값 변경 시 누락·불일치가 생기기 쉽다.
+- 원격/스테이징 클러스터로 전환할 때 "평문 env → Secret 참조" 리팩터링을 그 시점에 몰아서 해야 하고, 그 사이 실수로 로컬 값이 스테이징에 새어 나갈 위험이 있다.
+
+k8s Secret 리소스로 옮기는 것은 저비용이고, 원격 전환 대비 올바른 습관이다(#116/#121).
+
+## 결정
+
+| 항목 | 결정 |
+| --- | --- |
+| Secret | `deploy/k8s/secrets.yaml`에 `Secret ai-repo-credentials`(Opaque, `stringData`) 신설. `deploy/k8s/kustomization.yaml`에 등록 |
+| 참조 방식 | `postgres.yaml`·`app.yaml`의 자격증명 env를 `valueFrom.secretKeyRef`로 전환. 비밀이 아닌 env(URL, 프로파일, 스케줄러 플래그 등)는 평문 유지 |
+| 키 | `POSTGRES_DB/USER/PASSWORD`(Postgres 초기화), `AI_REPO_POSTGRES_USERNAME/PASSWORD`(앱 DB 접속), `AI_REPO_OPS_ADMIN_TOKEN`/`AI_REPO_OPS_OPERATOR_TOKEN`(운영 API 토큰), `AI_REPO_AUTH_JWT_SECRET`(엔드유저 JWT 서명) — env 이름은 `application.yml` 바인딩과 정확히 일치 |
+| 값 관리 | 로컬 고정값은 `secrets.yaml` 한 곳에서만 관리. 값 변경은 이 파일만 수정 |
+| overlay | `deploy/gitops`는 `../k8s` base를 그대로 참조하므로 별도 변경 없이 Secret이 함께 렌더된다 |
+
+## 트레이드오프
+
+### 장점
+
+- 자격증명이 `secrets.yaml` 한 곳으로 모여 변경·초기화가 단순하고 매니페스트 간 불일치가 사라진다.
+- 원격 전환 시 매니페스트 구조(secretKeyRef)는 그대로 두고 Secret 주입 경로(External Secrets/SealedSecrets 등)만 교체하면 되므로, "평문 env 리팩터링"이라는 위험한 일괄 작업이 사라진다.
+- 앱 매니페스트가 실제 비밀 값을 노출하지 않아, 스테이징에 로컬 값이 딸려 나가는 사고를 구조적으로 줄인다.
+
+### 비용
+
+- **로컬 고정값 Secret도 평문 커밋이다.** `stringData`가 그대로 리포에 들어가므로 이 자체는 "비밀 보호"가 아니다. 이 ADR의 목적은 비밀 은닉이 아니라 **(1) 스테이징 사고 방지(평문 env가 매니페스트에 박혀 원격에 새는 경로 제거)와 (2) 원격 전환 준비(주입 지점 분리)**다. 위협 모델상 값 자체는 여전히 공개 리포에 노출된다.
+- env 정의가 `secretKeyRef` 블록으로 길어져 매니페스트 라인 수가 늘어난다.
+
+## 대안
+
+- **평문 env 유지**: 저비용이지만 원격 전환 시 일괄 리팩터링과 유출 위험이 남는다. 습관·구조 측면에서 지금 옮기는 게 낫다.
+- **`envFrom`로 Secret 전체 주입**: 간결하지만 어떤 env가 어디서 오는지 매니페스트에서 바로 안 보이고, 비밀 아닌 env와 섞이면 추적이 어렵다. 키별 `secretKeyRef`로 명시성을 택했다.
+- **local/prod-ready overlay 분리**: 원격 전환 결정 시점까지 보류(#116 Human Verify). 이 ADR은 Secret 주입까지만 다룬다.
+- **암호화 Secret(SealedSecrets/SOPS) 즉시 도입**: 로컬 학습 환경에는 과한 운영 비용. 원격 전환 시점에 도입한다.

--- a/docs/development/k8s-local-monitoring.md
+++ b/docs/development/k8s-local-monitoring.md
@@ -18,7 +18,7 @@ Docker Desktop 내장 Kubernetes에 ai-repo 전체 스택(앱 + Postgres + Prome
 
 | 서비스 | URL | 계정 / 인증 |
 | --- | --- | --- |
-| 앱 API | http://localhost:30080 | 사용자 API 인증 없음. 운영 API는 헤더 `X-Operator-Token: local-operator-token`(조회) / `X-Admin-Token: local-ops-token`(변경) + `X-Operator-Id: <이름>` |
+| 앱 API | http://localhost:30080 | 사용자 API 인증 없음. 운영 API는 헤더 `X-Operator-Token: local-operator-token`(조회) / `X-Admin-Token: local-ops-token`(변경) + `X-Operator-Id: <이름>`. 토큰 고정값 출처는 `deploy/k8s/secrets.yaml`(Secret `ai-repo-credentials`) |
 | 앱 health | http://localhost:30080/actuator/health | 없음 |
 | 앱 메트릭 | http://localhost:30080/actuator/prometheus | 없음 |
 | Prometheus | http://localhost:30990 | 없음 |
@@ -27,10 +27,10 @@ Docker Desktop 내장 Kubernetes에 ai-repo 전체 스택(앱 + Postgres + Prome
 | Grafana 대시보드 (ai-repo Overview) | http://localhost:30300/d/ai-repo-overview | 익명 Admin |
 | Grafana Explore (Loki 로그 검색) | http://localhost:30300/explore | 익명 Admin |
 | Loki API | 클러스터 내부 http://loki:3100 — 외부는 port-forward 후 http://localhost:3100 | 없음 |
-| Postgres | 클러스터 내부 postgres:5432 — 외부는 port-forward 후 localhost:5432 | 사용자 `ai_repo` / 비밀번호 `ai_repo` / DB `ai_repo` |
+| Postgres | 클러스터 내부 postgres:5432 — 외부는 port-forward 후 localhost:5432 | 사용자 `ai_repo` / 비밀번호 `ai_repo` / DB `ai_repo` — 고정값 출처는 `deploy/k8s/secrets.yaml`(Secret `ai-repo-credentials`) |
 | ArgoCD UI (선택) | port-forward 후 https://localhost:8443 | `admin` / 초기 비밀번호는 아래 명령으로 조회 |
 
-앱 운영 토큰은 `AI_REPO_OPS_OPERATOR_TOKEN`, `AI_REPO_OPS_ADMIN_TOKEN` 환경 변수로 override할 수 있다(`deploy/k8s/app.yaml`). ArgoCD 설치/GitOps 모드는 `docs/development/ci-cd-gitops.md` 참고.
+DB 자격증명·운영 토큰(`AI_REPO_OPS_OPERATOR_TOKEN`, `AI_REPO_OPS_ADMIN_TOKEN`)·JWT 서명 비밀(`AI_REPO_AUTH_JWT_SECRET`)은 평문 env가 아니라 Secret `ai-repo-credentials`(`deploy/k8s/secrets.yaml`)에서 `secretKeyRef`로 주입된다. 값을 바꾸려면 `secrets.yaml`을 수정한다(로컬 전용 고정값이며, 원격에서는 별도 주입). ArgoCD 설치/GitOps 모드는 `docs/development/ci-cd-gitops.md` 참고.
 
 ## 전체 명령어 모음 (리포 루트 기준, 복사-실행)
 
@@ -92,7 +92,8 @@ kubectl --context docker-desktop -n ai-repo get events --sort-by=.lastTimestamp
 deploy/k8s/
 ├── kustomization.yaml
 ├── namespace.yaml          # ai-repo 네임스페이스
-├── postgres.yaml           # postgres:17-alpine + PVC(1Gi), compose.yml과 동일 자격증명
+├── secrets.yaml            # Secret ai-repo-credentials — DB·운영 토큰·JWT 로컬 고정값(원격은 별도 주입)
+├── postgres.yaml           # postgres:17-alpine + PVC(1Gi), 자격증명은 secrets.yaml에서 secretKeyRef 주입
 ├── app.yaml                # ai-repo:local 이미지(imagePullPolicy: Never), NodePort 30080
 ├── prometheus.yaml         # /actuator/prometheus 15s 스크랩, 3d 보존, NodePort 30990
 ├── loki.yaml               # Loki 3.5 single binary, filesystem 저장, 72h 보존
@@ -104,7 +105,7 @@ deploy/k8s/
 - **메트릭 노출**: `micrometer-registry-prometheus` + `management.endpoints.web.exposure.include: health,prometheus`. HTTP 지연시간 분위수(p95/p99)를 위해 `percentiles-histogram.http.server.requests: true`.
 - **대시보드 패널**: HTTP 요청률/오류율/p95·p99, 지갑 거래 요청률(charge·transfer·payment POST), JVM Heap/GC, Hikari 커넥션, CPU, up + Outbox 릴레이/컨슈머 row(아래 커스텀 지표).
 - **이미지 태그**: 로컬은 `ai-repo:local`. GitOps 배포는 `ghcr.io/imwoo94/ai-repo:{version}-{sha8}` — `docs/development/ci-cd-gitops.md` 참고.
-- **보안 주의**: 익명 Grafana Admin, 평문 DB 자격증명은 로컬 학습 환경 전용이다. 원격 클러스터에 그대로 쓰지 않는다.
+- **보안 주의**: 자격증명은 Secret `ai-repo-credentials`(`deploy/k8s/secrets.yaml`)로 분리했으나 로컬 학습 편의를 위해 평문으로 커밋한 고정값이다. 익명 Grafana Admin과 함께 로컬 학습 환경 전용이며, 원격 클러스터에서는 Secret을 별도 주입(External Secrets/SealedSecrets 등)한다.
 
 ## Outbox 커스텀 지표
 

--- a/docs/progress/0072-k8s-secret-injection.md
+++ b/docs/progress/0072-k8s-secret-injection.md
@@ -1,0 +1,36 @@
+# 0072. k8s 자격증명 Secret 주입 전환
+
+## 스펙 목표
+
+- `deploy/k8s`의 평문 DB 비밀번호·운영 토큰 env를 k8s Secret 리소스로 옮긴다.
+- Deployment는 `secretKeyRef`로 자격증명을 참조하고, 비밀이 아닌 env는 평문을 유지한다.
+- GitOps overlay(`deploy/gitops`)에서 동일하게 렌더된다.
+- 가이드 문서의 접속 정보 표·문구를 자격증명 출처(secrets.yaml) 기준으로 갱신한다.
+
+## 완료 결과
+
+- **Secret 신설**(`deploy/k8s/secrets.yaml`): `Secret ai-repo-credentials`(Opaque, `stringData`) — 로컬 학습 전용 고정값. 키: `POSTGRES_DB/USER/PASSWORD`, `AI_REPO_POSTGRES_USERNAME/PASSWORD`, `AI_REPO_OPS_ADMIN_TOKEN`, `AI_REPO_OPS_OPERATOR_TOKEN`, `AI_REPO_AUTH_JWT_SECRET`. env 이름은 `application.yml` 바인딩과 일치. 로컬 전용·원격 별도 주입을 주석으로 명시.
+- **참조 전환**: `postgres.yaml`(3개)·`app.yaml`(5개) 자격증명 env를 `valueFrom.secretKeyRef`로 변경. URL·프로파일·스케줄러 플래그 등 비밀 아닌 env는 평문 유지.
+- **kustomization**: `deploy/k8s/kustomization.yaml`에 `secrets.yaml` 등록(namespace 다음). `deploy/gitops`는 `../k8s` base를 참조하므로 자동 반영.
+- **문서**: `docs/development/k8s-local-monitoring.md` 접속 정보 표(앱 API 토큰·Postgres 행)·구성 목록·보안 주의·토큰 override 문구를 secrets.yaml 출처 기준으로 갱신. ADR-0061 기록.
+
+## 개선 건수
+
+1. `deploy/k8s` 평문 자격증명 env 8종을 `Secret ai-repo-credentials`의 `secretKeyRef`로 전환.
+2. 자격증명 출처를 `secrets.yaml` 한 곳으로 일원화하고 가이드 문서 접속 정보를 갱신.
+
+## 검증
+
+- `kubectl --context docker-desktop kustomize deploy/k8s > /dev/null` 렌더 성공(라이브 클러스터 미적용).
+- `kubectl kustomize deploy/gitops > /dev/null` 렌더 성공. 렌더 결과에 `Secret ai-repo-credentials`와 `secretKeyRef` 8개 확인.
+- `scripts/check-dev-rules.sh`(`AI_REPO_DEV_RULES_BASE=origin/main`) PASS.
+
+## 남은 일
+
+- 원격/스테이징 전환 시 Secret 주입 경로(External Secrets/SealedSecrets 등)와 local/prod-ready overlay 분리 결정(#116 Human Verify).
+
+## 관련 문서
+
+- GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/121
+- `docs/adr/0061-k8s-secret-injection.md`
+- `docs/development/k8s-local-monitoring.md`

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -86,6 +86,7 @@ ADR은 “왜 그렇게 결정했는가”를 기록하고, 이 폴더는 “각
 | 0068 | [Audit Events and Operation Log Authorization](0068-audit-events-authorization.md) | 완료 |
 | 0069 | [로컬 k8s 배포와 관측 스택](0069-k8s-deploy-and-observability.md) | 완료 |
 | 0070 | [Audit Event–Wallet Mapping 명시화](0070-audit-event-wallet-mapping.md) | 완료 |
+| 0072 | [k8s 자격증명 Secret 주입 전환](0072-k8s-secret-injection.md) | 완료 |
 
 ## 현재 기준선
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -37,6 +37,7 @@
 - 로컬 k8s 배포 스택(Prometheus/Grafana/Loki)과 outbox 커스텀 지표
 - GitHub Actions → GHCR → GitOps → ArgoCD 배포 파이프라인
 - 소유자 스코프 audit-events의 ledger 조인 의존 제거 — `audit_event_wallets` 매핑 테이블을 쓰기 시점에 영속화(charge 1행/transfer 2행)하고 조회를 매핑 기반으로 전환(V18 역채움 포함)
+- `deploy/k8s` 평문 자격증명 env(DB/운영 토큰/JWT)를 `Secret ai-repo-credentials`의 `secretKeyRef`로 전환(로컬 고정값, 원격 별도 주입)
 
 ## MVP 출시 판단 기준
 

--- a/issue-drafts/0072-k8s-secret-injection.md
+++ b/issue-drafts/0072-k8s-secret-injection.md
@@ -1,0 +1,26 @@
+# k8s 자격증명 Secret 주입(DB/운영 토큰) 전환
+
+## 배경
+
+`deploy/k8s/app.yaml`·`postgres.yaml`이 DB 비밀번호와 운영 토큰 기본값을 평문 env로 둔다. 로컬 학습 전용 고정값이지만 k8s Secret 리소스로 옮기는 것은 저비용이고 원격 전환 대비 올바른 습관이다(#116).
+
+## 목표
+
+- Secret 매니페스트(로컬 고정값)를 신설하고 `secretKeyRef`로 참조 전환한다(비밀 아닌 env는 평문 유지).
+- GitOps overlay(`deploy/gitops`)에서 동일하게 렌더된다.
+- 가이드 문서의 접속 정보 표에 자격증명 위치(secrets.yaml)를 안내한다.
+
+## 완료 조건
+
+- [x] `Secret ai-repo-credentials`(로컬 고정값) 신설 + `secretKeyRef` 참조로 전환.
+- [x] `kubectl kustomize deploy/k8s`·`deploy/gitops` 렌더 성공(라이브 클러스터 미적용).
+- [x] 가이드 문서 접속 정보 표·문구를 secrets.yaml 출처 기준으로 갱신.
+- [x] ADR-0061, progress 0072 기록.
+
+비고: local/prod-ready overlay 분리는 원격 전환 결정 시점까지 보류(#116 Human Verify) — 이 이슈는 Secret 주입까지만.
+
+## 관련 문서
+
+- `docs/adr/0061-k8s-secret-injection.md`
+- `docs/progress/0072-k8s-secret-injection.md`
+- `docs/development/k8s-local-monitoring.md`

--- a/issue-drafts/README.md
+++ b/issue-drafts/README.md
@@ -124,6 +124,8 @@
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/110
 - `0070-audit-event-wallet-mapping.md`: audit-event↔wallet 매핑 명시화(ledger 조인 제거) 작업 초안
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/117
+- `0072-k8s-secret-injection.md`: k8s 자격증명 Secret 주입(DB/운영 토큰) 전환 작업 초안
+  - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/121
 
 ## GitHub CLI로 생성
 

--- a/wiki-drafts/Architecture-Decisions.md
+++ b/wiki-drafts/Architecture-Decisions.md
@@ -109,6 +109,7 @@
 | Audit event–wallet 매핑 명시화 | `audit_event_wallets` 매핑 테이블을 쓰기 시점에 영속화(charge 1행/transfer 2행)해 소유자 스코프 audit-events 조회의 ledger 조인 의존을 제거 | 쓰기 경로에 매핑 삽입 1~2행 추가와 정합성 책임 |
 | Wiki는 요약, ADR은 결정 | 포트폴리오 설명성과 PR 검증성 모두 확보 | Wiki 하나에 모든 결정을 몰아넣는 단순성 |
 | 로컬 k8s 배포와 관측 스택 (ADR-0059) | Docker Desktop k8s + kustomize + Prometheus/Grafana/Loki, GitHub Actions→GHCR→ArgoCD GitOps, deploy는 CI 성공 게이트(workflow_run) 뒤에서만 실행 | 익명 Grafana/평문 자격증명은 로컬 학습 전용, 원격 전환 시 재설계 |
+| k8s 자격증명 Secret 주입 (ADR-0061) | `deploy/k8s` 평문 env(DB/운영 토큰/JWT)를 `Secret ai-repo-credentials`의 `secretKeyRef`로 전환 | 로컬 고정값 Secret도 평문 커밋 — 목적은 비밀 은닉이 아니라 스테이징 사고 방지+원격 전환 준비 |
 
 ## 다음 구조 후보
 


### PR DESCRIPTION
## 배경

`deploy/k8s/app.yaml`·`postgres.yaml`이 DB 비밀번호·운영 토큰·JWT 서명 비밀을 평문 env로 둔다. 로컬 학습 전용 고정값이지만 k8s Secret 리소스로 옮기는 것은 저비용이고 원격 전환 대비 올바른 습관이다(#116).

## 변경

- **`deploy/k8s/secrets.yaml` 신설**: `Secret ai-repo-credentials`(Opaque, `stringData`). 키 `POSTGRES_DB/USER/PASSWORD`, `AI_REPO_POSTGRES_USERNAME/PASSWORD`, `AI_REPO_OPS_ADMIN_TOKEN`, `AI_REPO_OPS_OPERATOR_TOKEN`, `AI_REPO_AUTH_JWT_SECRET`. env 이름은 `application.yml` 바인딩과 일치. 로컬 전용·원격 별도 주입을 주석으로 명시.
- **참조 전환**: `postgres.yaml`(3) + `app.yaml`(5) 자격증명 env를 `valueFrom.secretKeyRef`로 변경. 비밀 아닌 env(URL/프로파일/스케줄러 플래그)는 평문 유지.
- **kustomization**: `deploy/k8s/kustomization.yaml`에 `secrets.yaml` 등록. `deploy/gitops`는 `../k8s` base 참조라 자동 반영.
- **문서**: `k8s-local-monitoring.md` 접속 정보 표·구성·보안 주의 갱신, ADR-0061, progress 0072, 인덱스 파일 반영.

## 위협 모델 주의

로컬 고정값 Secret도 평문 커밋이므로 이 변경의 목적은 비밀 은닉이 아니라 **스테이징 사고 방지(평문 env가 매니페스트에 박혀 원격에 새는 경로 제거) + 원격 전환 준비(주입 지점 분리)**다. 상세는 ADR-0061 참고.

## 검증

- `kubectl --context docker-desktop kustomize deploy/k8s > /dev/null` 렌더 성공(라이브 클러스터 미적용).
- `kubectl kustomize deploy/gitops > /dev/null` 렌더 성공 — `Secret ai-repo-credentials` + `secretKeyRef` 8개 확인.
- `scripts/check-dev-rules.sh`(`AI_REPO_DEV_RULES_BASE=origin/main`) PASS.

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)