### PR TITLE
fix: allow build/libs into docker context for Dockerfile.ci

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 .git
 .gradle
-build
+build/*
+!build/libs
 frontend/node_modules
 frontend/dist
 docs


### PR DESCRIPTION
#128 후속 — deploy 실패 원인: `.dockerignore`의 `build` 제외로 `Dockerfile.ci`의 `COPY build/libs/*.jar`가 실패(`lstat /build/libs: no such file or directory`). `build/*` 제외 + `!build/libs` 재포함으로 수정. 로컬 멀티스테이지 `Dockerfile`은 build/libs를 사용하지 않아 영향 없음(빌드 스테이지 내부 산출물 사용).

머지 후 CI→deploy가 멀티아치 이미지를 정상 push하면 정체된 롤아웃이 회복됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)