### PR TITLE
test: operational api path drift guard

### DIFF
--- a/docs/progress/0075-admin-path-drift-guard.md
+++ b/docs/progress/0075-admin-path-drift-guard.md
@@ -1,0 +1,32 @@
+# 0075. Admin Path Drift Guard
+
+## 스펙 목표
+
+운영 API 경로 목록이 `SecurityConfig`(인증 chain의 `securityMatcher`)와 `AdminApiPathMatcher`(헤더 인증·접근 감사 필터)에 별도 상수로 존재해, 한쪽만 갱신하면 drift(#109 계열)가 재발할 수 있다. 두 목록이 같은 운영 API 경로 집합을 다루는지 자동으로 검증한다.
+
+## 완료 결과
+
+- `OperationalApiPathDriftGuardTest`를 추가해 두 상수 목록이 같은 운영 API root 집합을 다루는지 양방향으로 단언했다.
+- 각 `SecurityConfig` 운영 pattern root에 대해 `AdminApiPathMatcher`가 root/sub-path는 true, lookalike prefix는 false로 판정함을 고정했다.
+- 불일치 시 실패 메시지가 누락된 경로 집합을 명시하도록 했다.
+
+## 개선 건수
+
+1. 운영 API 경로 목록 drift 방지 회귀 테스트 추가(단일 source 부재 상태에서의 안전망).
+
+## 검증
+
+- `./gradlew test --tests '*OperationalApiPathDriftGuardTest' --tests '*AdminApiPathMatcherTest'`
+- `./gradlew test`
+- `scripts/check-dev-rules.sh`
+- `git diff --check`
+
+## 남은 일
+
+- Spring Security matcher와 운영 API matcher를 하나의 단일 source of truth 상수로 통합
+- 실제 identity/role scope 연동
+
+## 관련 문서
+
+- `docs/adr/0055-admin-api-path-matching-hardening.md`
+- `docs/releases/unreleased.md`

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -86,6 +86,7 @@ ADR은 “왜 그렇게 결정했는가”를 기록하고, 이 폴더는 “각
 | 0068 | [Audit Events and Operation Log Authorization](0068-audit-events-authorization.md) | 완료 |
 | 0069 | [로컬 k8s 배포와 관측 스택](0069-k8s-deploy-and-observability.md) | 완료 |
 | 0070 | [Audit Event–Wallet Mapping 명시화](0070-audit-event-wallet-mapping.md) | 완료 |
+| 0075 | [Admin Path Drift Guard](0075-admin-path-drift-guard.md) | 완료 |
 
 ## 현재 기준선
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -37,6 +37,7 @@
 - 로컬 k8s 배포 스택(Prometheus/Grafana/Loki)과 outbox 커스텀 지표
 - GitHub Actions → GHCR → GitOps → ArgoCD 배포 파이프라인
 - 소유자 스코프 audit-events의 ledger 조인 의존 제거 — `audit_event_wallets` 매핑 테이블을 쓰기 시점에 영속화(charge 1행/transfer 2행)하고 조회를 매핑 기반으로 전환(V18 역채움 포함)
+- 운영 API 경로 목록 drift 방지 테스트 — `SecurityConfig`와 `AdminApiPathMatcher` 두 상수 목록이 같은 운영 API root 집합을 다루는지 양방향 검증(불일치 시 누락 경로 명시)
 
 ## MVP 출시 판단 기준
 

--- a/issue-drafts/0075-admin-path-drift-guard.md
+++ b/issue-drafts/0075-admin-path-drift-guard.md
@@ -1,0 +1,23 @@
+# Admin Path Drift Guard
+
+## 배경
+
+운영 API 경로 목록이 `SecurityConfig`(인증 chain)와 `AdminApiPathMatcher`(헤더 인증·접근 감사 필터)에 별도 상수로 존재한다. 한쪽만 갱신하면 drift(#109 계열)가 재발할 수 있다.
+
+## 목표
+
+- 두 목록의 일치(또는 단일 source 참조)를 검증하는 테스트를 추가한다.
+- 불일치 시 실패 메시지가 누락 경로를 명시한다.
+
+## 완료 조건
+
+- [x] 두 목록이 같은 운영 API root 집합을 다루는지 양방향으로 검증하는 테스트를 추가한다.
+- [x] 각 운영 pattern root의 root/sub-path는 matcher가 true, lookalike prefix는 false임을 고정한다.
+- [x] 불일치 시 실패 메시지가 누락 경로를 명시한다.
+
+## 검증 명령
+
+```bash
+./gradlew test --tests '*OperationalApiPathDriftGuardTest' --tests '*AdminApiPathMatcherTest'
+scripts/check-dev-rules.sh
+```

--- a/issue-drafts/README.md
+++ b/issue-drafts/README.md
@@ -124,6 +124,8 @@
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/110
 - `0070-audit-event-wallet-mapping.md`: audit-event↔wallet 매핑 명시화(ledger 조인 제거) 작업 초안
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/117
+- `0075-admin-path-drift-guard.md`: SecurityConfig↔AdminApiPathMatcher 운영 API 목록 drift 방지 테스트 작업 초안
+  - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/124
 
 ## GitHub CLI로 생성
 

--- a/src/test/java/com/imwoo/airepo/wallet/api/OperationalApiPathDriftGuardTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/api/OperationalApiPathDriftGuardTest.java
@@ -1,0 +1,93 @@
+package com.imwoo.airepo.wallet.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 운영 API 경로 목록은 {@link SecurityConfig#OPERATIONAL_API_PATHS}(인증 chain의 securityMatcher)와
+ * {@link AdminApiPathMatcher#ADMIN_API_PATH_PREFIXES}(헤더 인증·접근 감사 필터)에 별도 상수로 존재한다.
+ * 한쪽만 갱신하면 drift(#109 계열)가 재발하므로, 두 목록이 같은 운영 API 경로 집합을 다루는지 검증한다.
+ */
+class OperationalApiPathDriftGuardTest {
+
+    @Test
+    void securityConfigPatternsAndMatcherPrefixesCoverSameRoots() throws Exception {
+        Set<String> securityRoots = securityConfigOperationalRoots();
+        Set<String> matcherPrefixes = adminApiPathMatcherPrefixes();
+
+        Set<String> missingInMatcher = new TreeSet<>(securityRoots);
+        missingInMatcher.removeAll(matcherPrefixes);
+        assertThat(missingInMatcher)
+                .as("SecurityConfig 운영 patterns에는 있으나 AdminApiPathMatcher prefix에 없는 경로: %s", missingInMatcher)
+                .isEmpty();
+
+        Set<String> missingInSecurityConfig = new TreeSet<>(matcherPrefixes);
+        missingInSecurityConfig.removeAll(securityRoots);
+        assertThat(missingInSecurityConfig)
+                .as("AdminApiPathMatcher prefix에는 있으나 SecurityConfig 운영 patterns에 없는 경로: %s",
+                        missingInSecurityConfig)
+                .isEmpty();
+    }
+
+    @Test
+    void matcherMatchesEverySecurityConfigOperationalRootAndSubPath() throws Exception {
+        for (String root : securityConfigOperationalRoots()) {
+            assertThat(AdminApiPathMatcher.isAdminApiPath(root))
+                    .as("운영 API root는 matcher가 true여야 함: %s", root)
+                    .isTrue();
+            assertThat(AdminApiPathMatcher.isAdminApiPath(root + "/sub-resource"))
+                    .as("운영 API 하위 path는 matcher가 true여야 함: %s/sub-resource", root)
+                    .isTrue();
+            assertThat(AdminApiPathMatcher.isAdminApiPath(root + "-lookalike"))
+                    .as("운영 API prefix를 흉내 낸 lookalike path는 matcher가 false여야 함: %s-lookalike", root)
+                    .isFalse();
+        }
+    }
+
+    @Test
+    void matcherRejectsCuratedLookalikePrefixes() {
+        List<String> lookalikes = List.of(
+                "/api/v1/outbox-events-v2",
+                "/api/v1/outbox-consumerish",
+                "/api/v1/operations-summary",
+                "/api/v1/audit-events-export",
+                "/api/v1/wallets/wallet-001/audit-events"
+        );
+        for (String lookalike : lookalikes) {
+            assertThat(AdminApiPathMatcher.isAdminApiPath(lookalike))
+                    .as("lookalike prefix는 운영 API로 분류되면 안 됨: %s", lookalike)
+                    .isFalse();
+        }
+    }
+
+    private static Set<String> securityConfigOperationalRoots() throws Exception {
+        Field field = SecurityConfig.class.getDeclaredField("OPERATIONAL_API_PATHS");
+        field.setAccessible(true);
+        String[] patterns = (String[]) field.get(null);
+        return java.util.Arrays.stream(patterns)
+                .map(OperationalApiPathDriftGuardTest::stripSuffixWildcard)
+                .collect(Collectors.toCollection(TreeSet::new));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Set<String> adminApiPathMatcherPrefixes() throws Exception {
+        Field field = AdminApiPathMatcher.class.getDeclaredField("ADMIN_API_PATH_PREFIXES");
+        field.setAccessible(true);
+        List<String> prefixes = (List<String>) field.get(null);
+        return new TreeSet<>(prefixes);
+    }
+
+    private static String stripSuffixWildcard(String pattern) {
+        String normalized = pattern;
+        if (normalized.endsWith("/**")) {
+            normalized = normalized.substring(0, normalized.length() - "/**".length());
+        }
+        return normalized;
+    }
+}

--- a/wiki-drafts/Architecture-Decisions.md
+++ b/wiki-drafts/Architecture-Decisions.md
@@ -112,7 +112,7 @@
 
 ## 다음 구조 후보
 
-- Spring Security matcher와 운영 API matcher 목록 동기화 테스트
+- Spring Security matcher와 운영 API matcher 목록을 단일 source of truth 상수로 통합(현재는 `OperationalApiPathDriftGuardTest`가 두 목록 동기화를 검증)
 - broker-specific adapter와 Testcontainers contract
 - broker replay window별 retention 권장값
 - pruning 실행 이력 저장과 조회 API


### PR DESCRIPTION
Closes #124

## 요약

운영 API 경로 목록이 `SecurityConfig.OPERATIONAL_API_PATHS`(인증 chain)와 `AdminApiPathMatcher`(헤더 인증·접근 감사 필터)에 별도 상수로 존재해 한쪽만 갱신하면 드리프트(#109 계열)가 재발할 수 있음.

`OperationalApiPathDriftGuardTest` 추가 (옵션 b — 테스트 가드, 프로덕션 리팩터링 없음):
- 두 목록이 같은 운영 root 집합을 커버하는지 양방향 검증(누락 경로를 실패 메시지에 명시)
- 모든 운영 root와 하위 경로를 matcher가 true, `-lookalike` 변형은 false
- 큐레이션된 lookalike prefix 목록(`/api/v1/outbox-events-v2`, 소유자 스코프 audit-events 등) false 고정

문서 동기화: progress 0075, issue-draft 0075(+#124 링크), unreleased 한 줄, wiki Architecture-Decisions 행 갱신. dev-rules PASS.

## 검증

- `./gradlew test` BUILD SUCCESSFUL (에이전트 실행 + 신규 테스트 단독 재실행 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)