### PR TITLE
refactor: decompose JDBC persistence adapter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     testImplementation platform('org.testcontainers:testcontainers-bom:1.21.4')
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:postgresql'
+    testImplementation 'com.tngtech.archunit:archunit-junit5:1.4.1'
 }
 
 tasks.named('test') {

--- a/docs/adr/0063-application-layer-spring-annotation-policy.md
+++ b/docs/adr/0063-application-layer-spring-annotation-policy.md
@@ -1,0 +1,49 @@
+# ADR-0063: Application Layer Spring Annotation Policy
+
+## 상태
+
+Accepted
+
+## 배경
+
+`application` 패키지는 지갑 명령/조회, outbox relay/consumer, 운영 로그 pruning, health policy 같은 use case와 port를 담는다. 현재 구현은 순수 Java application layer와 Spring wiring을 완전히 분리하지 않고, 일부 service와 policy 객체에 `@Service`, `@Component`, `@Value`, `@Transactional`을 사용한다.
+
+Issue #125는 `JdbcWalletRepository` 분해와 함께 레이어 규칙을 구조 테스트로 고정해야 한다. 이때 application layer의 Spring annotation 허용 범위를 먼저 결정하지 않으면 ArchUnit 규칙이 실제 설계와 충돌한다.
+
+## 결정
+
+현재 단계에서는 application layer의 제한적 Spring annotation 사용을 허용한다.
+
+| 항목 | 결정 |
+| --- | --- |
+| Service wiring | use case service는 `@Service`를 사용할 수 있다. |
+| Policy/properties wiring | 설정값 기반 policy/properties 객체는 `@Component`와 생성자 `@Value`를 사용할 수 있다. |
+| Transaction boundary | 여러 repository port 호출을 하나의 use case 원자성으로 묶어야 하는 application service는 `@Transactional`을 사용할 수 있다. |
+| 금지 의존성 | application layer는 `api`, `infra`, `config`, Spring Web/JDBC/Security 구현 세부사항에 의존하지 않는다. |
+| 검증 | ArchUnit 테스트로 domain/application/api/infra의 핵심 의존 방향을 고정한다. |
+
+## 대안
+
+### 선택지 A: application layer에서 Spring annotation을 모두 제거한다
+
+순수 use case를 만들 수 있지만 현재 서비스/정책 객체 wiring을 별도 configuration으로 모두 옮겨야 한다. 이 변경은 #125의 persistence 분해보다 범위가 커지고, 기존 테스트와 component scan 구조를 크게 흔든다.
+
+### 선택지 B: 제한적 Spring annotation을 허용하고 외부 adapter 의존만 금지한다
+
+현재 구조와 맞고 변경 범위가 작다. 대신 application layer가 완전히 framework-free는 아니므로, 장기적으로 순수 use case 모듈화가 필요해지면 새 ADR로 전환해야 한다.
+
+### 선택지 C: annotation 정책을 정하지 않고 ArchUnit만 도입한다
+
+규칙이 모호해져 나중에 Spring annotation 사용을 둘러싼 drift를 막지 못한다.
+
+## 결과
+
+- application layer는 Spring DI/transaction annotation을 제한적으로 사용할 수 있다.
+- domain layer는 Spring과 outer layer 의존을 갖지 않는다.
+- application layer는 adapter 구현인 `api`, `infra`, `config`를 모른다.
+- 구조 테스트는 현재 정책을 기준으로 작성한다.
+
+## 후속 작업
+
+- application layer를 framework-free use case로 분리할 필요가 생기면 이 ADR을 대체하는 새 ADR을 작성한다.
+- 신규 Spring dependency가 application layer에 들어올 때는 ArchUnit 규칙 또는 이 ADR의 허용 범위를 함께 검토한다.

--- a/docs/adr/0064-jdbc-persistence-adapter-decomposition.md
+++ b/docs/adr/0064-jdbc-persistence-adapter-decomposition.md
@@ -1,0 +1,53 @@
+# ADR-0064: JDBC Persistence Adapter Decomposition
+
+## 상태
+
+Accepted
+
+## 배경
+
+`JdbcWalletRepository`는 PostgreSQL profile에서 여러 application port를 한 번에 구현해 왔다. 시간이 지나면서 wallet command/query, ledger, outbox relay, consumer idempotency/monitoring/pruning, operational alert, admin API access audit SQL이 한 클래스에 모였다.
+
+이 구조는 단일 bean wiring은 단순하지만, 변경 리뷰와 장애 분석 비용이 높다. 특히 outbox/consumer/alert/admin audit 기능이 계속 추가되면서 하나의 persistence adapter가 여러 bounded context의 SQL과 row mapper를 모두 소유하는 god-adapter가 됐다.
+
+## 결정
+
+Spring bean으로 노출되는 `JdbcWalletRepository`는 유지하되, SQL 구현은 bounded context별 package-private JDBC adapter로 분해한다.
+
+| Context | Adapter | 책임 |
+| --- | --- | --- |
+| Wallet/Ledger | `JdbcWalletLedgerRepository` | member/account/balance 조회, charge/transfer command, transaction/ledger/audit/outbox 쓰기 |
+| Outbox Relay | `JdbcOutboxRelayRepository` | pending/claim/published/failed/manual review/requeue/relay run |
+| Outbox Consumer | `JdbcOutboxConsumerRepository` | idempotency, receipt, delivery metrics, monitoring, pruning |
+| Operational Alert | `JdbcOperationalAlertRepository` | alert 저장, suppression lookup, 조회, pruning |
+| Admin Audit | `JdbcAdminApiAccessAuditRepository` | admin access audit id 발급, 저장, 조회, pruning |
+| Shared support | `WalletJdbcSupport` | `JdbcTemplate`, `TransactionTemplate`, mapper, timestamp/id/query helper |
+
+`JdbcWalletRepository`는 기존 생성자와 구현 port 목록을 유지하고 각 method를 세부 adapter로 위임한다. 이렇게 해서 Spring wiring, `@Profile("postgres")`, 테스트의 생성 계약은 유지하면서 SQL 소유권만 나눈다.
+
+## 대안
+
+### 선택지 A: 기존 단일 `JdbcWalletRepository`를 유지한다
+
+작업량은 가장 작지만, 기능이 늘어날수록 하나의 파일에서 여러 context의 SQL을 동시에 수정해야 한다. #116 평가에서 지적된 유지보수 문제를 해소하지 못한다.
+
+### 선택지 B: 각 context adapter를 독립 Spring bean으로 등록한다
+
+포트별 bean wiring이 더 명확해진다. 하지만 현재 서비스들은 여러 repository port를 같은 `JdbcWalletRepository` bean으로 주입받는 구조이고, profile별 bean 선택/테스트 생성자 변경 범위가 커진다.
+
+### 선택지 C: composite bean 유지 + package-private 세부 adapter 분해
+
+외부 wiring 안정성과 내부 책임 분리를 동시에 얻는다. 단점은 composite class가 여전히 많은 port interface를 구현한다는 점이다. 이 비용은 Spring bean 호환성을 지키기 위한 의도적 절충으로 둔다.
+
+## 결과
+
+- `JdbcWalletRepository`는 SQL을 직접 소유하지 않는 composite/delegator가 된다.
+- context별 SQL은 작은 adapter 파일에 모여 변경 리뷰 범위가 좁아진다.
+- `WalletJdbcSupport`는 mapper/helper 중복을 줄이되 외부에 공개하지 않는다.
+- 기존 JDBC repository tests와 rollback tests는 같은 public adapter 계약을 계속 검증한다.
+- ArchUnit 테스트로 domain/application/api/infra 핵심 의존 방향을 고정한다.
+
+## 후속 작업
+
+- 세부 adapter를 독립 Spring bean으로 승격할 필요가 생기면 별도 ADR에서 profile wiring과 bean 충돌 정책을 결정한다.
+- `JdbcWalletRepositoryTest`가 너무 커지면 context별 repository slice test로 나누는 후속 작업을 검토한다.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -73,3 +73,10 @@ ADR은 이 저장소에서 중요한 결정의 source of truth입니다. README�
 | ADR-0055 | Admin API Path Matching Hardening | Accepted |
 | ADR-0056 | End-User JWT Authentication and Wallet Ownership | Accepted |
 | ADR-0057 | Frontend Member Login and Bearer Token with 401 Re-issue | Accepted |
+| ADR-0058 | Audit Events and Operation Log Authorization | Accepted |
+| ADR-0059 | 로컬 k8s 배포와 관측(모니터링·로그·GitOps) 스택 | Accepted |
+| ADR-0060 | Audit Event–Wallet Mapping 명시화 | Accepted |
+| ADR-0061 | k8s 자격증명 Secret 주입 전환 | Accepted |
+| ADR-0062 | 배포 프로파일에서 기본 자격증명 fail-fast | Accepted |
+| ADR-0063 | Application Layer Spring Annotation Policy | Accepted |
+| ADR-0064 | JDBC Persistence Adapter Decomposition | Accepted |

--- a/docs/progress/0076-jdbc-persistence-adapter-decomposition.md
+++ b/docs/progress/0076-jdbc-persistence-adapter-decomposition.md
@@ -1,0 +1,38 @@
+# 0076. JDBC Persistence Adapter Decomposition
+
+## 스펙 목표
+
+- Issue #125의 `JdbcWalletRepository` bounded-context 분해를 마무리한다.
+- application layer Spring annotation 정책과 JDBC adapter 분해 전략을 ADR로 확정한다.
+- 레이어 의존 방향을 ArchUnit 테스트로 고정한다.
+
+## 완료 결과
+
+- `JdbcWalletRepository`를 PostgreSQL profile composite bean으로 유지하고, SQL 구현을 context별 package-private adapter로 분해했다.
+  - `JdbcWalletLedgerRepository`
+  - `JdbcOutboxRelayRepository`
+  - `JdbcOutboxConsumerRepository`
+  - `JdbcOperationalAlertRepository`
+  - `JdbcAdminApiAccessAuditRepository`
+  - `WalletJdbcSupport`
+- application layer의 제한적 Spring annotation 허용 정책을 ADR-0063으로 기록했다.
+- JDBC persistence adapter 분해 전략을 ADR-0064로 기록했다.
+- ArchUnit 의존성 방향 테스트를 추가해 domain/application/api/infra 경계를 고정했다.
+- ADR index와 unreleased release note에 변경 내용을 반영했다.
+
+## 검증
+
+- `./gradlew compileJava`
+- `./gradlew test --tests '*JdbcWalletRepositoryTest' --tests '*JdbcWalletRepositoryRollbackTest'`
+- `./gradlew test`
+- `./gradlew postgresScenarioTest`
+
+## 남은 일
+
+- 세부 JDBC adapter별 slice test 분리가 필요하면 별도 후속 작업으로 다룬다.
+
+## 관련 문서
+
+- `docs/adr/0063-application-layer-spring-annotation-policy.md`
+- `docs/adr/0064-jdbc-persistence-adapter-decomposition.md`
+- `docs/releases/unreleased.md`

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -90,10 +90,11 @@ ADR은 “왜 그렇게 결정했는가”를 기록하고, 이 폴더는 “각
 | 0072 | [k8s 자격증명 Secret 주입 전환](0072-k8s-secret-injection.md) | 완료 |
 | 0075 | [Admin Path Drift Guard](0075-admin-path-drift-guard.md) | 완료 |
 | 0073 | [배포 프로파일 기본 자격증명 fail-fast](0073-default-credential-fail-fast.md) | 완료 |
+| 0076 | [JDBC Persistence Adapter Decomposition](0076-jdbc-persistence-adapter-decomposition.md) | 완료 |
 
 ## 현재 기준선
 
 - 최신 병합 기준: `main`
-- 최신 완료 기능: Audit Event–Wallet Mapping 명시화
+- 최신 완료 기능: JDBC Persistence Adapter Decomposition
 - 현재 릴리스 후보: `v0.7.0`
 - 아직 미완료: JWT 만료 후 갱신 정책, Kafka/RabbitMQ/SQS adapter, pruning 실행 이력, Slack 발행 실패 record와 재시도 정책, broker-specific Testcontainers 정책, broker replay window별 retention 권장값, 실제 identity/role scope 연동, 운영 alert 화면 연결

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -41,6 +41,7 @@
 - `deploy/k8s` 평문 자격증명 env(DB/운영 토큰/JWT)를 `Secret ai-repo-credentials`의 `secretKeyRef`로 전환(로컬 고정값, 원격 별도 주입)
 - 운영 API 경로 목록 drift 방지 테스트 — `SecurityConfig`와 `AdminApiPathMatcher` 두 상수 목록이 같은 운영 API root 집합을 다루는지 양방향 검증(불일치 시 누락 경로 명시)
 - 배포 프로파일(`postgres`/`prod`)에서 공개된 기본 JWT secret·운영 토큰 fail-fast 확장(`JwtSecretGuard`/`OpsTokenGuard`)과 `deploy/k8s/app.yaml` 명시 값 주입
+- JDBC persistence adapter 분해 — `JdbcWalletRepository`를 PostgreSQL profile composite bean으로 유지하면서 wallet/ledger, outbox relay, outbox consumer, operational alert, admin audit SQL을 context별 package-private adapter로 분리하고 ArchUnit 레이어 규칙을 추가
 
 ## MVP 출시 판단 기준
 
@@ -67,6 +68,7 @@
 - 프론트 build, unit, E2E가 CI에서 분리 검증된다.
 - 백엔드 unit/API, scenario, PostgreSQL scenario가 CI에서 분리 검증된다.
 - README, ADR, progress, issue draft, local test guide가 현재 상태와 모순되지 않는다.
+- JDBC persistence adapter는 bounded context별 adapter로 분해되어도 기존 repository contract와 레이어 의존 규칙을 통과한다.
 
 ## 검증 게이트
 

--- a/docs/reviews/2026-07-04-jdbc-persistence-adapter-decomposition-codex-review.md
+++ b/docs/reviews/2026-07-04-jdbc-persistence-adapter-decomposition-codex-review.md
@@ -1,0 +1,63 @@
+# JDBC Persistence Adapter Decomposition Codex Review
+
+## 검토 대상
+
+- 범위: Issue #125 `JdbcWalletRepository` bounded-context 분해와 ArchUnit 레이어 규칙
+- 변경 의도: PostgreSQL profile의 기존 composite bean 계약은 유지하면서 SQL 구현을 wallet/ledger, outbox relay, outbox consumer, operational alert, admin audit adapter로 분리하고, application annotation 정책과 persistence 분해 전략을 ADR로 고정한다.
+
+## 검증
+
+리뷰 과정에서 다음을 확인했다.
+
+```bash
+./gradlew test --tests '*LayerDependencyTest'
+./gradlew postgresScenarioTest
+./gradlew test scenarioTest postgresScenarioTest
+scripts/check-dev-rules.sh
+git diff --check
+```
+
+## 판정
+
+통과. 블로커 없음.
+
+## 백엔드 구조
+
+- `JdbcWalletRepository`가 기존 Spring bean과 public constructor를 유지하고 내부 adapter에 위임하므로 service wiring과 기존 repository tests의 호출 계약이 유지된다.
+- context별 adapter는 package-private으로 남아 외부 API를 늘리지 않는다.
+- `WalletJdbcSupport`가 mapper/helper를 공유해 분해 과정에서 SQL row mapping 중복을 과하게 늘리지 않는다.
+- composite가 여전히 여러 port를 구현하는 비용은 ADR-0064에서 명시한 호환성 절충으로 설명되어 있다.
+
+## 아키텍처 규칙
+
+- ArchUnit 테스트는 production class만 분석하도록 `DoNotIncludeTests`를 사용한다.
+- 규칙은 domain 순수성, application의 adapter 비의존, api의 infra/config 비의존, infra의 api 비의존을 확인한다.
+- application layer의 `@Service`, policy/properties `@Component`/`@Value`, 필요한 `@Transactional` 허용은 ADR-0063과 일치한다.
+
+## 테스트
+
+- `./gradlew test scenarioTest postgresScenarioTest`가 통과했다.
+- PostgreSQL scenario는 `postgres` profile의 기본 JWT/운영 토큰 fail-fast 정책 때문에 테스트용 secret/token override가 필요했고, `DynamicPropertySource`에 명시 값을 추가해 통과시켰다.
+- 기존 JDBC repository/rollback 계약은 전체 unit test와 PostgreSQL scenario로 함께 검증된다.
+
+## 문서
+
+- ADR-0063/0064, progress 0076, unreleased release note, issue draft, Wiki draft가 함께 갱신되어 dev rule sync를 통과한다.
+- 기존 ADR index가 0057에서 멈춰 있던 drift도 0058-0064까지 보강했다.
+
+## 리뷰 반영
+
+### 수용
+
+- PostgreSQL scenario가 deployed profile fail-fast 정책을 통과하도록 테스트용 JWT/admin/operator token property를 명시했다.
+- ArchUnit 분석 대상에서 test classes를 제외하고, package matcher를 project package로 한정해 Spring `security.config` 패키지 오탐을 제거했다.
+- dev rules가 요구한 issue draft와 Wiki draft sync를 추가했다.
+
+### 반박
+
+- 없음.
+
+### 후속 과제
+
+- 세부 JDBC adapter별 slice test 분리가 필요하면 별도 이슈로 다룬다.
+- composite bean을 제거하고 각 context adapter를 독립 Spring bean으로 승격할지는 별도 ADR에서 결정한다.

--- a/issue-drafts/0076-jdbc-persistence-adapter-decomposition.md
+++ b/issue-drafts/0076-jdbc-persistence-adapter-decomposition.md
@@ -1,0 +1,37 @@
+# JdbcWalletRepository bounded-context 분해 + ArchUnit 레이어 규칙
+
+GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/125
+
+## 배경
+
+`JdbcWalletRepository`는 PostgreSQL profile에서 wallet command/query, ledger, outbox relay, consumer idempotency/monitoring/pruning, operational alert, admin access audit port를 한 클래스에서 구현했다. 기능이 누적되면서 SQL 변경 리뷰 범위가 커졌고, 레이어 의존 규칙도 문서 계약에 머물렀다.
+
+## 목표
+
+- application layer Spring annotation 정책을 ADR로 확정한다.
+- JDBC persistence adapter 분해 전략을 ADR로 확정한다.
+- `JdbcWalletRepository`를 context별 JDBC adapter로 분해하되 기존 Spring bean 계약은 유지한다.
+- ArchUnit 테스트로 레이어 의존 방향을 고정한다.
+
+## 완료 조건
+
+- [x] ADR-0063: application layer Spring annotation policy
+- [x] ADR-0064: JDBC persistence adapter decomposition
+- [x] `JdbcWalletRepository` composite 유지 + context별 package-private adapter 분해
+- [x] ArchUnit 레이어 의존 규칙 테스트 추가
+- [x] PostgreSQL scenario가 배포 profile credential fail-fast 정책과 함께 통과하도록 test property 보정
+
+## 검증
+
+```bash
+./gradlew test scenarioTest postgresScenarioTest
+scripts/check-dev-rules.sh
+git diff --check
+```
+
+## 관련 문서
+
+- `docs/adr/0063-application-layer-spring-annotation-policy.md`
+- `docs/adr/0064-jdbc-persistence-adapter-decomposition.md`
+- `docs/progress/0076-jdbc-persistence-adapter-decomposition.md`
+- `docs/releases/unreleased.md`

--- a/issue-drafts/README.md
+++ b/issue-drafts/README.md
@@ -132,6 +132,8 @@
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/124
 - `0073-default-credential-fail-fast.md`: 배포 프로파일(postgres/prod)에서 기본 JWT secret·운영 토큰 fail-fast 작업 초안
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/122
+- `0076-jdbc-persistence-adapter-decomposition.md`: JdbcWalletRepository bounded-context 분해와 ArchUnit 레이어 규칙 작업 초안
+  - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/125
 
 ## GitHub CLI로 생성
 

--- a/src/main/java/com/imwoo/airepo/wallet/infra/JdbcAdminApiAccessAuditRepository.java
+++ b/src/main/java/com/imwoo/airepo/wallet/infra/JdbcAdminApiAccessAuditRepository.java
@@ -1,0 +1,68 @@
+package com.imwoo.airepo.wallet.infra;
+
+import com.imwoo.airepo.wallet.application.AdminApiAccessAuditRepository;
+import com.imwoo.airepo.wallet.domain.AdminApiAccessAudit;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * JDBC adapter for the admin API access audit bounded context: audit id issuance, persistence,
+ * recent history, and retention pruning.
+ */
+final class JdbcAdminApiAccessAuditRepository implements AdminApiAccessAuditRepository {
+
+    private final WalletJdbcSupport support;
+    private final JdbcTemplate jdbcTemplate;
+
+    JdbcAdminApiAccessAuditRepository(WalletJdbcSupport support) {
+        this.support = support;
+        this.jdbcTemplate = support.jdbc();
+    }
+
+    @Override
+    public String nextAdminApiAccessAuditId() {
+        return support.nextId("admin-api-access-audit", "admin_api_access_audit_id_seq");
+    }
+
+    @Override
+    public void saveAdminApiAccessAudit(AdminApiAccessAudit accessAudit) {
+        jdbcTemplate.update(
+                """
+                        insert into admin_api_access_audits (
+                            audit_id, occurred_at, method, path, operator_id, status_code, outcome
+                        )
+                        values (?, ?, ?, ?, ?, ?, ?)
+                        """,
+                accessAudit.auditId(),
+                support.timestamp(accessAudit.occurredAt()),
+                accessAudit.method(),
+                accessAudit.path(),
+                accessAudit.operatorId(),
+                accessAudit.statusCode(),
+                accessAudit.outcome().name()
+        );
+    }
+
+    @Override
+    public List<AdminApiAccessAudit> findRecentAdminApiAccessAudits(int limit) {
+        return jdbcTemplate.query(
+                """
+                        select audit_id, occurred_at, method, path, operator_id, status_code, outcome
+                        from admin_api_access_audits
+                        order by occurred_at desc, audit_id desc
+                        limit ?
+                        """,
+                support.adminApiAccessAuditMapper(),
+                limit
+        );
+    }
+
+    @Override
+    public int deleteAdminApiAccessAuditsOccurredBefore(Instant cutoff) {
+        return jdbcTemplate.update(
+                "delete from admin_api_access_audits where occurred_at < ?",
+                support.timestamp(cutoff)
+        );
+    }
+}

--- a/src/main/java/com/imwoo/airepo/wallet/infra/JdbcOperationalAlertRepository.java
+++ b/src/main/java/com/imwoo/airepo/wallet/infra/JdbcOperationalAlertRepository.java
@@ -1,0 +1,95 @@
+package com.imwoo.airepo.wallet.infra;
+
+import com.imwoo.airepo.wallet.application.OperationalAlertRepository;
+import com.imwoo.airepo.wallet.domain.OperationalAlert;
+import com.imwoo.airepo.wallet.domain.OperationalAlertSeverity;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * JDBC adapter for the operational alert bounded context: alert id issuance, persistence,
+ * suppression-window lookup, recent history, and retention pruning.
+ */
+final class JdbcOperationalAlertRepository implements OperationalAlertRepository {
+
+    private final WalletJdbcSupport support;
+    private final JdbcTemplate jdbcTemplate;
+
+    JdbcOperationalAlertRepository(WalletJdbcSupport support) {
+        this.support = support;
+        this.jdbcTemplate = support.jdbc();
+    }
+
+    @Override
+    public String nextOperationalAlertId() {
+        return support.nextId("operational-alert", "operational_alert_id_seq");
+    }
+
+    @Override
+    public void saveOperationalAlert(OperationalAlert operationalAlert) {
+        jdbcTemplate.update(
+                """
+                        insert into operational_alerts (
+                            alert_id, source, severity, occurred_at, reasons
+                        )
+                        values (?, ?, ?, ?, ?)
+                        """,
+                operationalAlert.alertId(),
+                operationalAlert.source(),
+                operationalAlert.severity().name(),
+                support.timestamp(operationalAlert.occurredAt()),
+                String.join("\n", operationalAlert.reasons())
+        );
+    }
+
+    @Override
+    public boolean existsOperationalAlertBetween(
+            String source,
+            OperationalAlertSeverity severity,
+            List<String> reasons,
+            Instant since,
+            Instant until
+    ) {
+        Integer count = jdbcTemplate.queryForObject(
+                """
+                        select count(*)
+                        from operational_alerts
+                        where source = ?
+                          and severity = ?
+                          and reasons = ?
+                          and occurred_at >= ?
+                          and occurred_at <= ?
+                        """,
+                Integer.class,
+                source,
+                severity.name(),
+                String.join("\n", reasons),
+                support.timestamp(since),
+                support.timestamp(until)
+        );
+        return count != null && count > 0;
+    }
+
+    @Override
+    public List<OperationalAlert> findRecentOperationalAlerts(int limit) {
+        return jdbcTemplate.query(
+                """
+                        select alert_id, source, severity, occurred_at, reasons
+                        from operational_alerts
+                        order by occurred_at desc, alert_id desc
+                        limit ?
+                        """,
+                support.operationalAlertMapper(),
+                limit
+        );
+    }
+
+    @Override
+    public int deleteOperationalAlertsOccurredBefore(Instant cutoff) {
+        return jdbcTemplate.update(
+                "delete from operational_alerts where occurred_at < ?",
+                support.timestamp(cutoff)
+        );
+    }
+}

--- a/src/main/java/com/imwoo/airepo/wallet/infra/JdbcOutboxConsumerRepository.java
+++ b/src/main/java/com/imwoo/airepo/wallet/infra/JdbcOutboxConsumerRepository.java
@@ -1,0 +1,296 @@
+package com.imwoo.airepo.wallet.infra;
+
+import com.imwoo.airepo.wallet.application.OperationOutboxConsumerDeliveryMetricRepository;
+import com.imwoo.airepo.wallet.application.OperationOutboxConsumerIdempotencyRepository;
+import com.imwoo.airepo.wallet.application.OperationOutboxConsumerMetrics;
+import com.imwoo.airepo.wallet.application.OperationOutboxConsumerMonitoringRepository;
+import com.imwoo.airepo.wallet.application.OperationOutboxConsumerPruningRepository;
+import com.imwoo.airepo.wallet.application.OperationOutboxConsumerReceiptRepository;
+import com.imwoo.airepo.wallet.application.OperationOutboxConsumerWindowMetrics;
+import com.imwoo.airepo.wallet.domain.OperationOutboxConsumerProcessedEvent;
+import com.imwoo.airepo.wallet.domain.OperationOutboxConsumerReceipt;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * JDBC adapter for the outbox consumer bounded context: idempotency dedupe, receipt persistence,
+ * delivery-metric time buckets, monitoring aggregates, and retention pruning.
+ */
+final class JdbcOutboxConsumerRepository implements
+        OperationOutboxConsumerIdempotencyRepository,
+        OperationOutboxConsumerReceiptRepository,
+        OperationOutboxConsumerDeliveryMetricRepository,
+        OperationOutboxConsumerMonitoringRepository,
+        OperationOutboxConsumerPruningRepository {
+
+    private final WalletJdbcSupport support;
+    private final JdbcTemplate jdbcTemplate;
+
+    JdbcOutboxConsumerRepository(WalletJdbcSupport support) {
+        this.support = support;
+        this.jdbcTemplate = support.jdbc();
+    }
+
+    @Override
+    public boolean recordProcessedEvent(
+            String idempotencyKey,
+            String outboxEventId,
+            String eventType,
+            Instant processedAt
+    ) {
+        if (support.isPostgresDatabase()) {
+            Boolean inserted = jdbcTemplate.queryForObject(
+                    """
+                            insert into operation_outbox_consumer_processed_events (
+                                idempotency_key, outbox_event_id, event_type, processed_at
+                            )
+                            values (?, ?, ?, ?)
+                            on conflict (idempotency_key) do update
+                            set duplicate_count =
+                                operation_outbox_consumer_processed_events.duplicate_count + 1
+                            returning (xmax = 0) as inserted
+                            """,
+                    Boolean.class,
+                    idempotencyKey,
+                    outboxEventId,
+                    eventType,
+                    support.timestamp(processedAt)
+            );
+            return Boolean.TRUE.equals(inserted);
+        }
+        int duplicateRows = jdbcTemplate.update(
+                """
+                        update operation_outbox_consumer_processed_events
+                        set duplicate_count = duplicate_count + 1
+                        where idempotency_key = ?
+                        """,
+                idempotencyKey
+        );
+        if (duplicateRows == 1) {
+            return false;
+        }
+        try {
+            return jdbcTemplate.update(
+                    """
+                            insert into operation_outbox_consumer_processed_events (
+                                idempotency_key, outbox_event_id, event_type, processed_at
+                            )
+                            values (?, ?, ?, ?)
+                            """,
+                    idempotencyKey,
+                    outboxEventId,
+                    eventType,
+                    support.timestamp(processedAt)
+            ) == 1;
+        } catch (DuplicateKeyException exception) {
+            return false;
+        }
+    }
+
+    @Override
+    public Optional<OperationOutboxConsumerProcessedEvent> findProcessedEvent(String idempotencyKey) {
+        return support.queryOptional(
+                """
+                        select idempotency_key, outbox_event_id, event_type, processed_at, duplicate_count
+                        from operation_outbox_consumer_processed_events
+                        where idempotency_key = ?
+                        """,
+                support.operationOutboxConsumerProcessedEventMapper(),
+                idempotencyKey
+        );
+    }
+
+    @Override
+    public void saveConsumerReceipt(OperationOutboxConsumerReceipt receipt) {
+        jdbcTemplate.update(
+                """
+                        insert into operation_outbox_consumer_receipts (
+                            idempotency_key, outbox_event_id, operation_id, event_type,
+                            aggregate_type, aggregate_id, received_at
+                        )
+                        values (?, ?, ?, ?, ?, ?, ?)
+                        """,
+                receipt.idempotencyKey(),
+                receipt.outboxEventId(),
+                receipt.operationId(),
+                receipt.eventType(),
+                receipt.aggregateType(),
+                receipt.aggregateId(),
+                support.timestamp(receipt.receivedAt())
+        );
+    }
+
+    @Override
+    public Optional<OperationOutboxConsumerReceipt> findConsumerReceipt(String idempotencyKey) {
+        return support.queryOptional(
+                """
+                        select idempotency_key, outbox_event_id, operation_id, event_type,
+                               aggregate_type, aggregate_id, received_at
+                        from operation_outbox_consumer_receipts
+                        where idempotency_key = ?
+                        """,
+                support.operationOutboxConsumerReceiptMapper(),
+                idempotencyKey
+        );
+    }
+
+    @Override
+    public void recordConsumerDeliveryMetric(Instant occurredAt, boolean duplicate) {
+        Instant bucketStartedAt = occurredAt.truncatedTo(ChronoUnit.MINUTES);
+        if (support.isPostgresDatabase()) {
+            jdbcTemplate.update(
+                    """
+                            insert into operation_outbox_consumer_delivery_metrics (
+                                bucket_started_at,
+                                processed_delivery_count,
+                                duplicate_delivery_count,
+                                updated_at
+                            )
+                            values (?, ?, ?, ?)
+                            on conflict (bucket_started_at) do update
+                            set processed_delivery_count =
+                                    operation_outbox_consumer_delivery_metrics.processed_delivery_count + ?,
+                                duplicate_delivery_count =
+                                    operation_outbox_consumer_delivery_metrics.duplicate_delivery_count + ?,
+                                updated_at = ?
+                            """,
+                    support.timestamp(bucketStartedAt),
+                    duplicate ? 0 : 1,
+                    duplicate ? 1 : 0,
+                    support.timestamp(occurredAt),
+                    duplicate ? 0 : 1,
+                    duplicate ? 1 : 0,
+                    support.timestamp(occurredAt)
+            );
+            return;
+        }
+
+        int updatedRows = jdbcTemplate.update(
+                """
+                        update operation_outbox_consumer_delivery_metrics
+                        set processed_delivery_count = processed_delivery_count + ?,
+                            duplicate_delivery_count = duplicate_delivery_count + ?,
+                            updated_at = ?
+                        where bucket_started_at = ?
+                        """,
+                duplicate ? 0 : 1,
+                duplicate ? 1 : 0,
+                support.timestamp(occurredAt),
+                support.timestamp(bucketStartedAt)
+        );
+        if (updatedRows == 1) {
+            return;
+        }
+        try {
+            jdbcTemplate.update(
+                    """
+                            insert into operation_outbox_consumer_delivery_metrics (
+                                bucket_started_at,
+                                processed_delivery_count,
+                                duplicate_delivery_count,
+                                updated_at
+                            )
+                            values (?, ?, ?, ?)
+                            """,
+                    support.timestamp(bucketStartedAt),
+                    duplicate ? 0 : 1,
+                    duplicate ? 1 : 0,
+                    support.timestamp(occurredAt)
+            );
+        } catch (DuplicateKeyException exception) {
+            recordConsumerDeliveryMetric(occurredAt, duplicate);
+        }
+    }
+
+    @Override
+    public OperationOutboxConsumerMetrics getConsumerMetrics() {
+        return jdbcTemplate.queryForObject(
+                """
+                        select
+                            (select count(*) from operation_outbox_consumer_processed_events) as processed_event_count,
+                            (select coalesce(sum(duplicate_count), 0)
+                             from operation_outbox_consumer_processed_events) as duplicate_event_count,
+                            (select count(*) from operation_outbox_consumer_receipts) as receipt_count,
+                            (select max(processed_at)
+                             from operation_outbox_consumer_processed_events) as last_processed_at,
+                            (select max(received_at)
+                             from operation_outbox_consumer_receipts) as last_received_at
+                        """,
+                (resultSet, rowNumber) -> new OperationOutboxConsumerMetrics(
+                        resultSet.getLong("processed_event_count"),
+                        resultSet.getLong("duplicate_event_count"),
+                        resultSet.getLong("receipt_count"),
+                        support.nullableInstant(resultSet, "last_processed_at"),
+                        support.nullableInstant(resultSet, "last_received_at")
+                )
+        );
+    }
+
+    @Override
+    public OperationOutboxConsumerWindowMetrics getConsumerWindowMetrics(
+            Instant windowStartedAt,
+            Instant windowEndedAt
+    ) {
+        return jdbcTemplate.queryForObject(
+                """
+                        select
+                            coalesce(sum(processed_delivery_count), 0) as processed_delivery_count,
+                            coalesce(sum(duplicate_delivery_count), 0) as duplicate_delivery_count
+                        from operation_outbox_consumer_delivery_metrics
+                        where bucket_started_at >= ?
+                          and bucket_started_at < ?
+                        """,
+                (resultSet, rowNumber) -> new OperationOutboxConsumerWindowMetrics(
+                        windowStartedAt,
+                        windowEndedAt,
+                        resultSet.getLong("processed_delivery_count"),
+                        resultSet.getLong("duplicate_delivery_count")
+                ),
+                support.timestamp(windowStartedAt),
+                support.timestamp(windowEndedAt)
+        );
+    }
+
+    @Override
+    public List<OperationOutboxConsumerReceipt> findRecentConsumerReceipts(int limit) {
+        return jdbcTemplate.query(
+                """
+                        select idempotency_key, outbox_event_id, operation_id, event_type,
+                               aggregate_type, aggregate_id, received_at
+                        from operation_outbox_consumer_receipts
+                        order by received_at desc, idempotency_key desc
+                        limit ?
+                        """,
+                support.operationOutboxConsumerReceiptMapper(),
+                limit
+        );
+    }
+
+    @Override
+    public int deleteConsumerProcessedEventsProcessedBefore(Instant cutoff) {
+        return jdbcTemplate.update(
+                "delete from operation_outbox_consumer_processed_events where processed_at < ?",
+                support.timestamp(cutoff)
+        );
+    }
+
+    @Override
+    public int deleteConsumerReceiptsReceivedBefore(Instant cutoff) {
+        return jdbcTemplate.update(
+                "delete from operation_outbox_consumer_receipts where received_at < ?",
+                support.timestamp(cutoff)
+        );
+    }
+
+    @Override
+    public int deleteConsumerDeliveryMetricsBucketStartedBefore(Instant cutoff) {
+        return jdbcTemplate.update(
+                "delete from operation_outbox_consumer_delivery_metrics where bucket_started_at < ?",
+                support.timestamp(cutoff)
+        );
+    }
+}

--- a/src/main/java/com/imwoo/airepo/wallet/infra/JdbcOutboxRelayRepository.java
+++ b/src/main/java/com/imwoo/airepo/wallet/infra/JdbcOutboxRelayRepository.java
@@ -1,0 +1,658 @@
+package com.imwoo.airepo.wallet.infra;
+
+import com.imwoo.airepo.wallet.application.InvalidWalletOperationException;
+import com.imwoo.airepo.wallet.application.OperationOutboxRelayRepository;
+import com.imwoo.airepo.wallet.application.OperationOutboxRelayRunRepository;
+import com.imwoo.airepo.wallet.domain.OperationOutboxEvent;
+import com.imwoo.airepo.wallet.domain.OperationOutboxRelayRun;
+import com.imwoo.airepo.wallet.domain.OperationOutboxRequeueAudit;
+import com.imwoo.airepo.wallet.domain.OperationOutboxRequeueRequestRecord;
+import com.imwoo.airepo.wallet.domain.OperationOutboxRequeueRequestStatus;
+import com.imwoo.airepo.wallet.domain.OperationOutboxStatus;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.jdbc.BadSqlGrammarException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * JDBC adapter for the outbox relay bounded context: pending/claim/publish/fail transitions,
+ * manual-review requeue workflow (direct + request/approve/reject/execute), and relay-run history.
+ */
+final class JdbcOutboxRelayRepository implements OperationOutboxRelayRepository, OperationOutboxRelayRunRepository {
+
+    private final WalletJdbcSupport support;
+    private final JdbcTemplate jdbcTemplate;
+    private final TransactionTemplate transactionTemplate;
+
+    JdbcOutboxRelayRepository(WalletJdbcSupport support) {
+        this.support = support;
+        this.jdbcTemplate = support.jdbc();
+        this.transactionTemplate = support.transaction();
+    }
+
+    @Override
+    public List<OperationOutboxEvent> findPendingOutboxEvents(int limit) {
+        return jdbcTemplate.query(
+                """
+                        select outbox_event_id, operation_id, event_type, aggregate_type,
+                               aggregate_id, payload, status, occurred_at,
+                               attempt_count, next_retry_at, claimed_at, lease_expires_at,
+                               published_at, last_error
+                        from operation_outbox_events
+                        where status = ?
+                        order by occurred_at, outbox_event_id
+                        limit ?
+                        """,
+                support.operationOutboxEventMapper(),
+                OperationOutboxStatus.PENDING.name(),
+                limit
+        );
+    }
+
+    @Override
+    public long countPendingOutboxEvents() {
+        Long count = jdbcTemplate.queryForObject(
+                """
+                        select count(*)
+                        from operation_outbox_events
+                        where status = ?
+                        """,
+                Long.class,
+                OperationOutboxStatus.PENDING.name()
+        );
+        return count == null ? 0L : count;
+    }
+
+    @Override
+    public List<OperationOutboxEvent> findManualReviewOutboxEvents(int limit) {
+        return jdbcTemplate.query(
+                """
+                        select outbox_event_id, operation_id, event_type, aggregate_type,
+                               aggregate_id, payload, status, occurred_at,
+                               attempt_count, next_retry_at, claimed_at, lease_expires_at,
+                               published_at, last_error
+                        from operation_outbox_events
+                        where status = ?
+                        order by occurred_at, outbox_event_id
+                        limit ?
+                        """,
+                support.operationOutboxEventMapper(),
+                OperationOutboxStatus.MANUAL_REVIEW.name(),
+                limit
+        );
+    }
+
+    @Override
+    public List<OperationOutboxRequeueAudit> findOutboxRequeueAudits(String outboxEventId) {
+        return jdbcTemplate.query(
+                """
+                        select audit_id, outbox_event_id, operation_id, requeued_at, operator_name, reason
+                        from operation_outbox_requeue_audits
+                        where outbox_event_id = ?
+                        order by requeued_at, audit_id
+                        """,
+                support.outboxRequeueAuditMapper(),
+                outboxEventId
+        );
+    }
+
+    @Override
+    public List<OperationOutboxRequeueRequestRecord> findOutboxRequeueRequests(String outboxEventId) {
+        return jdbcTemplate.query(
+                """
+                        select request_id, outbox_event_id, operation_id, status, requested_by,
+                               request_reason, requested_at, approved_by, approved_at, approval_reason,
+                               executed_by, executed_at, rejected_by, rejected_at, rejection_reason
+                        from operation_outbox_requeue_requests
+                        where outbox_event_id = ?
+                        order by requested_at, request_id
+                        """,
+                support.outboxRequeueRequestMapper(),
+                outboxEventId
+        );
+    }
+
+    @Override
+    public List<OperationOutboxEvent> claimReadyOutboxEvents(int limit, Instant now, Instant leaseExpiresAt) {
+        return transactionTemplate.execute(status -> {
+            List<String> outboxEventIds = claimReadyOutboxEventIds(limit, now);
+            if (outboxEventIds.isEmpty()) {
+                return List.of();
+            }
+            for (String outboxEventId : outboxEventIds) {
+                jdbcTemplate.update(
+                        """
+                                update operation_outbox_events
+                                set status = ?, next_retry_at = null, claimed_at = ?,
+                                    lease_expires_at = ?, published_at = null, last_error = null
+                                where outbox_event_id = ?
+                                """,
+                        OperationOutboxStatus.PROCESSING.name(),
+                        support.timestamp(now),
+                        support.timestamp(leaseExpiresAt),
+                        outboxEventId
+                );
+            }
+            return jdbcTemplate.query(
+                    """
+                            select outbox_event_id, operation_id, event_type, aggregate_type,
+                                   aggregate_id, payload, status, occurred_at,
+                                   attempt_count, next_retry_at, claimed_at, lease_expires_at,
+                                   published_at, last_error
+                            from operation_outbox_events
+                            where outbox_event_id in (%s)
+                            order by occurred_at, outbox_event_id
+                            """.formatted(support.placeholders(outboxEventIds.size())),
+                    support.operationOutboxEventMapper(),
+                    outboxEventIds.toArray()
+            );
+        });
+    }
+
+    @Override
+    public void markOutboxEventPublished(String outboxEventId, Instant publishedAt) {
+        jdbcTemplate.update(
+                """
+                        update operation_outbox_events
+                        set status = ?, next_retry_at = null, claimed_at = null,
+                            lease_expires_at = null, published_at = ?, last_error = null
+                        where outbox_event_id = ?
+                        """,
+                OperationOutboxStatus.PUBLISHED.name(),
+                support.timestamp(publishedAt),
+                outboxEventId
+        );
+    }
+
+    @Override
+    public void markClaimedOutboxEventPublished(
+            String outboxEventId,
+            Instant claimedAt,
+            Instant leaseExpiresAt,
+            Instant publishedAt
+    ) {
+        support.requireSingleRowUpdate(
+                jdbcTemplate.update(
+                        """
+                                update operation_outbox_events
+                                set status = ?, next_retry_at = null, claimed_at = null,
+                                    lease_expires_at = null, published_at = ?, last_error = null
+                                where outbox_event_id = ?
+                                  and status = ?
+                                  and claimed_at = ?
+                                  and lease_expires_at = ?
+                                """,
+                        OperationOutboxStatus.PUBLISHED.name(),
+                        support.timestamp(publishedAt),
+                        outboxEventId,
+                        OperationOutboxStatus.PROCESSING.name(),
+                        support.timestamp(claimedAt),
+                        support.timestamp(leaseExpiresAt)
+                ),
+                "outbox event claim is no longer active: " + outboxEventId
+        );
+    }
+
+    @Override
+    public void markOutboxEventFailed(String outboxEventId, String lastError, Instant nextRetryAt, int maxAttempts) {
+        jdbcTemplate.update(
+                """
+                        update operation_outbox_events
+                        set status = case
+                                when attempt_count + 1 >= ? then ?
+                                else ?
+                            end,
+                            attempt_count = attempt_count + 1,
+                            next_retry_at = case
+                                when attempt_count + 1 >= ? then null
+                                else cast(? as timestamp)
+                            end,
+                            claimed_at = null, lease_expires_at = null, published_at = null, last_error = ?
+                        where outbox_event_id = ?
+                        """,
+                maxAttempts,
+                OperationOutboxStatus.MANUAL_REVIEW.name(),
+                OperationOutboxStatus.FAILED.name(),
+                maxAttempts,
+                support.timestamp(nextRetryAt),
+                lastError,
+                outboxEventId
+        );
+    }
+
+    @Override
+    public void markClaimedOutboxEventFailed(
+            String outboxEventId,
+            Instant claimedAt,
+            Instant leaseExpiresAt,
+            String lastError,
+            Instant nextRetryAt,
+            int maxAttempts
+    ) {
+        support.requireSingleRowUpdate(
+                jdbcTemplate.update(
+                        """
+                                update operation_outbox_events
+                                set status = case
+                                        when attempt_count + 1 >= ? then ?
+                                        else ?
+                                    end,
+                                    attempt_count = attempt_count + 1,
+                                    next_retry_at = case
+                                        when attempt_count + 1 >= ? then null
+                                        else cast(? as timestamp)
+                                    end,
+                                    claimed_at = null, lease_expires_at = null, published_at = null, last_error = ?
+                                where outbox_event_id = ?
+                                  and status = ?
+                                  and claimed_at = ?
+                                  and lease_expires_at = ?
+                                """,
+                        maxAttempts,
+                        OperationOutboxStatus.MANUAL_REVIEW.name(),
+                        OperationOutboxStatus.FAILED.name(),
+                        maxAttempts,
+                        support.timestamp(nextRetryAt),
+                        lastError,
+                        outboxEventId,
+                        OperationOutboxStatus.PROCESSING.name(),
+                        support.timestamp(claimedAt),
+                        support.timestamp(leaseExpiresAt)
+                ),
+                "outbox event claim is no longer active: " + outboxEventId
+        );
+    }
+
+    @Override
+    public void requeueManualReviewOutboxEvent(
+            String outboxEventId,
+            Instant requeuedAt,
+            String operator,
+            String reason
+    ) {
+        transactionTemplate.executeWithoutResult(status -> {
+            OperationOutboxEvent event = manualReviewOutboxEventForUpdate(outboxEventId);
+
+            support.requireSingleRowUpdate(
+                    jdbcTemplate.update(
+                            """
+                                    update operation_outbox_events
+                                    set status = ?, attempt_count = 0, next_retry_at = null,
+                                        claimed_at = null, lease_expires_at = null, published_at = null, last_error = null
+                                    where outbox_event_id = ?
+                                      and status = ?
+                                    """,
+                            OperationOutboxStatus.PENDING.name(),
+                            outboxEventId,
+                            OperationOutboxStatus.MANUAL_REVIEW.name()
+                    ),
+                    "outbox event must still be MANUAL_REVIEW: " + outboxEventId
+            );
+            jdbcTemplate.update(
+                    """
+                            insert into operation_outbox_requeue_audits (
+                                audit_id, outbox_event_id, operation_id, requeued_at, operator_name, reason
+                            )
+                            values (?, ?, ?, ?, ?, ?)
+                            """,
+                    support.nextId("outbox-requeue-audit", "outbox_requeue_audit_id_seq"),
+                    outboxEventId,
+                    event.operationId(),
+                    support.timestamp(requeuedAt),
+                    operator,
+                    reason
+            );
+        });
+    }
+
+    @Override
+    public OperationOutboxRequeueRequestRecord requestManualReviewRequeue(
+            String outboxEventId,
+            Instant requestedAt,
+            String requestedBy,
+            String reason
+    ) {
+        return transactionTemplate.execute(status -> {
+            OperationOutboxEvent event = manualReviewOutboxEvent(outboxEventId);
+            OperationOutboxRequeueRequestRecord request = new OperationOutboxRequeueRequestRecord(
+                    support.nextId("outbox-requeue-request", "outbox_requeue_request_id_seq"),
+                    outboxEventId,
+                    event.operationId(),
+                    OperationOutboxRequeueRequestStatus.REQUESTED,
+                    requestedBy,
+                    reason,
+                    requestedAt,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+            jdbcTemplate.update(
+                    """
+                            insert into operation_outbox_requeue_requests (
+                                request_id, outbox_event_id, operation_id, status, requested_by,
+                                request_reason, requested_at, approved_by, approved_at, approval_reason,
+                                executed_by, executed_at, rejected_by, rejected_at, rejection_reason
+                            )
+                            values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                            """,
+                    request.requestId(),
+                    request.outboxEventId(),
+                    request.operationId(),
+                    request.status().name(),
+                    request.requestedBy(),
+                    request.requestReason(),
+                    support.timestamp(request.requestedAt()),
+                    request.approvedBy(),
+                    support.timestamp(request.approvedAt()),
+                    request.approvalReason(),
+                    request.executedBy(),
+                    support.timestamp(request.executedAt()),
+                    request.rejectedBy(),
+                    support.timestamp(request.rejectedAt()),
+                    request.rejectionReason()
+            );
+            return request;
+        });
+    }
+
+    @Override
+    public OperationOutboxRequeueRequestRecord approveManualReviewRequeueRequest(
+            String requestId,
+            Instant approvedAt,
+            String approvedBy,
+            String approvalReason
+    ) {
+        return transactionTemplate.execute(status -> {
+            OperationOutboxRequeueRequestRecord request = requeueRequestForUpdate(requestId);
+            if (request.status() != OperationOutboxRequeueRequestStatus.REQUESTED) {
+                throw new InvalidWalletOperationException("requeue request must be REQUESTED: " + requestId);
+            }
+            if (request.requestedBy().equals(approvedBy)) {
+                throw new InvalidWalletOperationException("approver must be different from requester");
+            }
+            support.requireSingleRowUpdate(
+                    jdbcTemplate.update(
+                            """
+                                    update operation_outbox_requeue_requests
+                                    set status = ?, approved_by = ?, approved_at = ?, approval_reason = ?
+                                    where request_id = ?
+                                      and status = ?
+                                    """,
+                            OperationOutboxRequeueRequestStatus.APPROVED.name(),
+                            approvedBy,
+                            support.timestamp(approvedAt),
+                            approvalReason,
+                            requestId,
+                            OperationOutboxRequeueRequestStatus.REQUESTED.name()
+                    ),
+                    "requeue request must still be REQUESTED: " + requestId
+            );
+            return requeueRequest(requestId);
+        });
+    }
+
+    @Override
+    public OperationOutboxRequeueRequestRecord rejectManualReviewRequeueRequest(
+            String requestId,
+            Instant rejectedAt,
+            String rejectedBy,
+            String rejectionReason
+    ) {
+        return transactionTemplate.execute(status -> {
+            OperationOutboxRequeueRequestRecord request = requeueRequestForUpdate(requestId);
+            if (request.status() != OperationOutboxRequeueRequestStatus.REQUESTED) {
+                throw new InvalidWalletOperationException("requeue request must be REQUESTED: " + requestId);
+            }
+            if (request.requestedBy().equals(rejectedBy)) {
+                throw new InvalidWalletOperationException("rejector must be different from requester");
+            }
+            support.requireSingleRowUpdate(
+                    jdbcTemplate.update(
+                            """
+                                    update operation_outbox_requeue_requests
+                                    set status = ?, rejected_by = ?, rejected_at = ?, rejection_reason = ?
+                                    where request_id = ?
+                                      and status = ?
+                                    """,
+                            OperationOutboxRequeueRequestStatus.REJECTED.name(),
+                            rejectedBy,
+                            support.timestamp(rejectedAt),
+                            rejectionReason,
+                            requestId,
+                            OperationOutboxRequeueRequestStatus.REQUESTED.name()
+                    ),
+                    "requeue request must still be REQUESTED: " + requestId
+            );
+            return requeueRequest(requestId);
+        });
+    }
+
+    @Override
+    public OperationOutboxRequeueRequestRecord executeManualReviewRequeueRequest(
+            String requestId,
+            Instant executedAt,
+            String executedBy
+    ) {
+        return transactionTemplate.execute(status -> {
+            OperationOutboxRequeueRequestRecord request = requeueRequestForUpdate(requestId);
+            if (request.status() != OperationOutboxRequeueRequestStatus.APPROVED) {
+                throw new InvalidWalletOperationException("requeue request must be APPROVED: " + requestId);
+            }
+            OperationOutboxEvent event = manualReviewOutboxEventForUpdate(request.outboxEventId());
+            support.requireSingleRowUpdate(
+                    jdbcTemplate.update(
+                            """
+                                    update operation_outbox_events
+                                    set status = ?, attempt_count = 0, next_retry_at = null,
+                                        claimed_at = null, lease_expires_at = null, published_at = null, last_error = null
+                                    where outbox_event_id = ?
+                                      and status = ?
+                                    """,
+                            OperationOutboxStatus.PENDING.name(),
+                            request.outboxEventId(),
+                            OperationOutboxStatus.MANUAL_REVIEW.name()
+                    ),
+                    "outbox event must still be MANUAL_REVIEW: " + request.outboxEventId()
+            );
+            jdbcTemplate.update(
+                    """
+                            insert into operation_outbox_requeue_audits (
+                                audit_id, outbox_event_id, operation_id, requeued_at, operator_name, reason
+                            )
+                            values (?, ?, ?, ?, ?, ?)
+                            """,
+                    support.nextId("outbox-requeue-audit", "outbox_requeue_audit_id_seq"),
+                    request.outboxEventId(),
+                    event.operationId(),
+                    support.timestamp(executedAt),
+                    executedBy,
+                    request.requestReason()
+            );
+            support.requireSingleRowUpdate(
+                    jdbcTemplate.update(
+                            """
+                                    update operation_outbox_requeue_requests
+                                    set status = ?, executed_by = ?, executed_at = ?
+                                    where request_id = ?
+                                      and status = ?
+                                    """,
+                            OperationOutboxRequeueRequestStatus.EXECUTED.name(),
+                            executedBy,
+                            support.timestamp(executedAt),
+                            requestId,
+                            OperationOutboxRequeueRequestStatus.APPROVED.name()
+                    ),
+                    "requeue request must still be APPROVED: " + requestId
+            );
+            return requeueRequest(requestId);
+        });
+    }
+
+    @Override
+    public String nextRelayRunId() {
+        return support.nextId("outbox-relay-run", "outbox_relay_run_id_seq");
+    }
+
+    @Override
+    public void saveOutboxRelayRun(OperationOutboxRelayRun relayRun) {
+        jdbcTemplate.update(
+                """
+                        insert into operation_outbox_relay_runs (
+                            relay_run_id, started_at, completed_at, status, batch_size,
+                            claimed_count, published_count, failed_count, error_message
+                        )
+                        values (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                relayRun.relayRunId(),
+                support.timestamp(relayRun.startedAt()),
+                support.timestamp(relayRun.completedAt()),
+                relayRun.status().name(),
+                relayRun.batchSize(),
+                relayRun.claimedCount(),
+                relayRun.publishedCount(),
+                relayRun.failedCount(),
+                relayRun.errorMessage()
+        );
+    }
+
+    @Override
+    public List<OperationOutboxRelayRun> findRecentOutboxRelayRuns(int limit) {
+        return jdbcTemplate.query(
+                """
+                        select relay_run_id, started_at, completed_at, status, batch_size,
+                               claimed_count, published_count, failed_count, error_message
+                        from operation_outbox_relay_runs
+                        order by completed_at desc, relay_run_id desc
+                        limit ?
+                        """,
+                support.operationOutboxRelayRunMapper(),
+                limit
+        );
+    }
+
+    @Override
+    public int deleteOutboxRelayRunsCompletedBefore(Instant cutoff) {
+        return jdbcTemplate.update(
+                "delete from operation_outbox_relay_runs where completed_at < ?",
+                support.timestamp(cutoff)
+        );
+    }
+
+    private List<String> claimReadyOutboxEventIds(int limit, Instant now) {
+        try {
+            return jdbcTemplate.queryForList(
+                    """
+                            select outbox_event_id
+                            from operation_outbox_events
+                            where status = ?
+                               or (status = ? and (next_retry_at is null or next_retry_at <= ?))
+                               or (status = ? and lease_expires_at <= ?)
+                            order by occurred_at, outbox_event_id
+                            limit ?
+                            for update skip locked
+                            """,
+                    String.class,
+                    OperationOutboxStatus.PENDING.name(),
+                    OperationOutboxStatus.FAILED.name(),
+                    support.timestamp(now),
+                    OperationOutboxStatus.PROCESSING.name(),
+                    support.timestamp(now),
+                    limit
+            );
+        } catch (BadSqlGrammarException exception) {
+            return jdbcTemplate.queryForList(
+                    """
+                            select outbox_event_id
+                            from operation_outbox_events
+                            where status = ?
+                               or (status = ? and (next_retry_at is null or next_retry_at <= ?))
+                               or (status = ? and lease_expires_at <= ?)
+                            order by occurred_at, outbox_event_id
+                            limit ?
+                            for update
+                            """,
+                    String.class,
+                    OperationOutboxStatus.PENDING.name(),
+                    OperationOutboxStatus.FAILED.name(),
+                    support.timestamp(now),
+                    OperationOutboxStatus.PROCESSING.name(),
+                    support.timestamp(now),
+                    limit
+            );
+        }
+    }
+
+    private OperationOutboxEvent manualReviewOutboxEvent(String outboxEventId) {
+        return support.queryOptional(
+                """
+                        select outbox_event_id, operation_id, event_type, aggregate_type,
+                               aggregate_id, payload, status, occurred_at,
+                               attempt_count, next_retry_at, claimed_at, lease_expires_at,
+                               published_at, last_error
+                        from operation_outbox_events
+                        where outbox_event_id = ?
+                          and status = ?
+                        """,
+                support.operationOutboxEventMapper(),
+                outboxEventId,
+                OperationOutboxStatus.MANUAL_REVIEW.name()
+        )
+                .orElseThrow(() -> new InvalidWalletOperationException("manual review outbox event not found: " + outboxEventId));
+    }
+
+    private OperationOutboxEvent manualReviewOutboxEventForUpdate(String outboxEventId) {
+        return support.queryOptional(
+                """
+                        select outbox_event_id, operation_id, event_type, aggregate_type,
+                               aggregate_id, payload, status, occurred_at,
+                               attempt_count, next_retry_at, claimed_at, lease_expires_at,
+                               published_at, last_error
+                        from operation_outbox_events
+                        where outbox_event_id = ?
+                          and status = ?
+                        for update
+                        """,
+                support.operationOutboxEventMapper(),
+                outboxEventId,
+                OperationOutboxStatus.MANUAL_REVIEW.name()
+        )
+                .orElseThrow(() -> new InvalidWalletOperationException("manual review outbox event not found: " + outboxEventId));
+    }
+
+    private OperationOutboxRequeueRequestRecord requeueRequest(String requestId) {
+        return support.queryOptional(
+                """
+                        select request_id, outbox_event_id, operation_id, status, requested_by,
+                               request_reason, requested_at, approved_by, approved_at, approval_reason,
+                               executed_by, executed_at, rejected_by, rejected_at, rejection_reason
+                        from operation_outbox_requeue_requests
+                        where request_id = ?
+                        """,
+                support.outboxRequeueRequestMapper(),
+                requestId
+        )
+                .orElseThrow(() -> new InvalidWalletOperationException("requeue request not found: " + requestId));
+    }
+
+    private OperationOutboxRequeueRequestRecord requeueRequestForUpdate(String requestId) {
+        return support.queryOptional(
+                """
+                        select request_id, outbox_event_id, operation_id, status, requested_by,
+                               request_reason, requested_at, approved_by, approved_at, approval_reason,
+                               executed_by, executed_at, rejected_by, rejected_at, rejection_reason
+                        from operation_outbox_requeue_requests
+                        where request_id = ?
+                        for update
+                        """,
+                support.outboxRequeueRequestMapper(),
+                requestId
+        )
+                .orElseThrow(() -> new InvalidWalletOperationException("requeue request not found: " + requestId));
+    }
+}

--- a/src/main/java/com/imwoo/airepo/wallet/infra/JdbcWalletLedgerRepository.java
+++ b/src/main/java/com/imwoo/airepo/wallet/infra/JdbcWalletLedgerRepository.java
@@ -1,0 +1,705 @@
+package com.imwoo.airepo.wallet.infra;
+
+import com.imwoo.airepo.wallet.application.InsufficientBalanceException;
+import com.imwoo.airepo.wallet.application.WalletCommandRepository;
+import com.imwoo.airepo.wallet.application.WalletConcurrencyException;
+import com.imwoo.airepo.wallet.application.WalletLedgerQueryRepository;
+import com.imwoo.airepo.wallet.application.WalletNotFoundException;
+import com.imwoo.airepo.wallet.application.WalletOperationRecord;
+import com.imwoo.airepo.wallet.application.WalletOperationResult;
+import com.imwoo.airepo.wallet.domain.AuditEvent;
+import com.imwoo.airepo.wallet.domain.AuditEventType;
+import com.imwoo.airepo.wallet.domain.LedgerEntry;
+import com.imwoo.airepo.wallet.domain.Member;
+import com.imwoo.airepo.wallet.domain.Money;
+import com.imwoo.airepo.wallet.domain.OperationOutboxEvent;
+import com.imwoo.airepo.wallet.domain.OperationOutboxStatus;
+import com.imwoo.airepo.wallet.domain.OperationStep;
+import com.imwoo.airepo.wallet.domain.OperationStepLog;
+import com.imwoo.airepo.wallet.domain.TransactionDirection;
+import com.imwoo.airepo.wallet.domain.TransactionHistoryItem;
+import com.imwoo.airepo.wallet.domain.TransactionStatus;
+import com.imwoo.airepo.wallet.domain.TransactionType;
+import com.imwoo.airepo.wallet.domain.WalletAccount;
+import com.imwoo.airepo.wallet.domain.WalletBalance;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.BadSqlGrammarException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * JDBC adapter for the wallet + ledger bounded context: member/account/balance queries,
+ * transaction/ledger/audit history, and the charge/transfer command flows (balance locking,
+ * step logs, operation persistence, outbox emission).
+ */
+final class JdbcWalletLedgerRepository implements WalletCommandRepository, WalletLedgerQueryRepository {
+
+    private static final int LOCK_TIMEOUT_MILLIS = 1000;
+    private static final String BUSY_BALANCE_MESSAGE = "Wallet balance is busy. Please retry.";
+
+    private final WalletJdbcSupport support;
+    private final JdbcTemplate jdbcTemplate;
+    private final TransactionTemplate transactionTemplate;
+
+    JdbcWalletLedgerRepository(WalletJdbcSupport support) {
+        this.support = support;
+        this.jdbcTemplate = support.jdbc();
+        this.transactionTemplate = support.transaction();
+    }
+
+    @Override
+    public Optional<Member> findMember(String memberId) {
+        return support.queryOptional(
+                "select member_id, status, created_at from members where member_id = ?",
+                support.memberMapper(),
+                memberId
+        );
+    }
+
+    @Override
+    public Optional<WalletAccount> findWalletAccount(String walletId) {
+        return support.queryOptional(
+                "select wallet_id, member_id, status, created_at from wallet_accounts where wallet_id = ?",
+                support.walletAccountMapper(),
+                walletId
+        );
+    }
+
+    @Override
+    public Optional<WalletBalance> findBalance(String walletId) {
+        return support.queryOptional(
+                "select wallet_id, amount, currency, as_of from wallet_balances where wallet_id = ?",
+                support.walletBalanceMapper(),
+                walletId
+        );
+    }
+
+    @Override
+    public List<TransactionHistoryItem> findTransactions(String walletId) {
+        return jdbcTemplate.query(
+                """
+                        select transaction_id, wallet_id, occurred_at, type, status, direction, amount, currency, description
+                        from transaction_history
+                        where wallet_id = ?
+                        """,
+                support.transactionHistoryMapper(),
+                walletId
+        );
+    }
+
+    @Override
+    public List<LedgerEntry> findLedgerEntries(String walletId) {
+        return jdbcTemplate.query(
+                """
+                        select ledger_entry_id, operation_id, wallet_id, occurred_at, type, direction,
+                               amount, currency, balance_after_amount, balance_after_currency, description
+                        from ledger_entries
+                        where wallet_id = ?
+                        """,
+                support.ledgerEntryMapper(),
+                walletId
+        );
+    }
+
+    @Override
+    public List<AuditEvent> findAuditEvents() {
+        return jdbcTemplate.query(
+                "select audit_event_id, operation_id, type, occurred_at, detail from audit_events",
+                support.auditEventMapper()
+        );
+    }
+
+    @Override
+    public List<AuditEvent> findAuditEventsByWallet(String walletId) {
+        return jdbcTemplate.query(
+                """
+                        select ae.audit_event_id, ae.operation_id, ae.type, ae.occurred_at, ae.detail
+                        from audit_events ae
+                        where ae.audit_event_id in (
+                            select audit_event_id from audit_event_wallets where wallet_id = ?
+                        )
+                        """,
+                support.auditEventMapper(),
+                walletId
+        );
+    }
+
+    @Override
+    public List<OperationStepLog> findOperationStepLogs(String operationId) {
+        return jdbcTemplate.query(
+                """
+                        select operation_step_log_id, operation_id, step, status, occurred_at, detail
+                        from operation_step_logs
+                        where operation_id = ?
+                        """,
+                support.operationStepLogMapper(),
+                operationId
+        );
+    }
+
+    @Override
+    public List<OperationOutboxEvent> findOperationOutboxEvents(String operationId) {
+        return jdbcTemplate.query(
+                """
+                        select outbox_event_id, operation_id, event_type, aggregate_type,
+                               aggregate_id, payload, status, occurred_at,
+                               attempt_count, next_retry_at, claimed_at, lease_expires_at,
+                               published_at, last_error
+                        from operation_outbox_events
+                        where operation_id = ?
+                        """,
+                support.operationOutboxEventMapper(),
+                operationId
+        );
+    }
+
+    @Override
+    public boolean existsOperationId(String operationId) {
+        Integer count = jdbcTemplate.queryForObject(
+                "select count(*) from wallet_operations where operation_id = ?",
+                Integer.class,
+                operationId
+        );
+        return count != null && count > 0;
+    }
+
+    @Override
+    public Optional<WalletOperationRecord> findOperation(String idempotencyKey) {
+        return support.queryOptional(
+                """
+                        select idempotency_key, fingerprint, operation_id, transaction_id, wallet_id,
+                               counterparty_wallet_id, occurred_at, type, status, direction, amount, currency,
+                               balance_wallet_id, balance_amount, balance_currency, balance_as_of, description
+                        from wallet_operations
+                        where idempotency_key = ?
+                        """,
+                support.operationRecordMapper(),
+                idempotencyKey
+        );
+    }
+
+    @Override
+    public WalletOperationRecord applyCharge(
+            String idempotencyKey,
+            String fingerprint,
+            String walletId,
+            Money money,
+            String description,
+            Instant occurredAt
+    ) {
+        return executeWithLockTimeout(() -> {
+            WalletBalance currentBalance = findBalanceForUpdate(walletId);
+            WalletBalance updatedBalance = new WalletBalance(walletId, currentBalance.money().add(money), occurredAt);
+            String operationId = support.nextId("op", "operation_id_seq");
+            insertOperationStepLog(
+                    operationId,
+                    OperationStep.BALANCE_LOCKED,
+                    occurredAt,
+                    "Balance locked for wallet " + walletId
+            );
+            updateBalance(updatedBalance);
+            insertOperationStepLog(
+                    operationId,
+                    OperationStep.BALANCE_UPDATED,
+                    occurredAt,
+                    "Balance updated for wallet " + walletId
+            );
+
+            String transactionId = support.nextId("txn", "transaction_id_seq");
+            insertTransaction(
+                    transactionId,
+                    walletId,
+                    occurredAt,
+                    TransactionType.CHARGE,
+                    TransactionStatus.COMPLETED,
+                    TransactionDirection.CREDIT,
+                    money,
+                    description
+            );
+            insertOperationStepLog(
+                    operationId,
+                    OperationStep.TRANSACTION_RECORDED,
+                    occurredAt,
+                    "Transaction history recorded for wallet " + walletId
+            );
+            insertLedgerEntry(
+                    support.nextId("ledger", "ledger_entry_id_seq"),
+                    operationId,
+                    walletId,
+                    occurredAt,
+                    TransactionType.CHARGE,
+                    TransactionDirection.CREDIT,
+                    money,
+                    updatedBalance.money(),
+                    description
+            );
+            insertOperationStepLog(
+                    operationId,
+                    OperationStep.LEDGER_RECORDED,
+                    occurredAt,
+                    "Ledger entry recorded for wallet " + walletId
+            );
+            insertAuditEvent(
+                    support.nextId("audit", "audit_event_id_seq"),
+                    operationId,
+                    AuditEventType.CHARGE_COMPLETED,
+                    occurredAt,
+                    "Charge completed for wallet " + walletId,
+                    List.of(walletId)
+            );
+            insertOperationStepLog(
+                    operationId,
+                    OperationStep.AUDIT_RECORDED,
+                    occurredAt,
+                    "Audit event recorded for operation " + operationId
+            );
+
+            WalletOperationResult result = new WalletOperationResult(
+                    operationId,
+                    transactionId,
+                    walletId,
+                    null,
+                    occurredAt,
+                    TransactionType.CHARGE,
+                    TransactionStatus.COMPLETED,
+                    TransactionDirection.CREDIT,
+                    money,
+                    updatedBalance,
+                    description
+            );
+            WalletOperationRecord record = new WalletOperationRecord(idempotencyKey, fingerprint, result);
+            insertOperation(record);
+            insertOperationStepLog(
+                    operationId,
+                    OperationStep.IDEMPOTENCY_RECORDED,
+                    occurredAt,
+                    "Idempotency record stored for operation " + operationId
+            );
+            insertOutboxEvent(result);
+            return record;
+        });
+    }
+
+    @Override
+    public WalletOperationRecord applyTransfer(
+            String idempotencyKey,
+            String fingerprint,
+            String sourceWalletId,
+            String targetWalletId,
+            Money money,
+            String description,
+            Instant occurredAt
+    ) {
+        return executeWithLockTimeout(() -> {
+            List<WalletBalance> lockedBalances = findTransferBalancesForUpdate(sourceWalletId, targetWalletId);
+            WalletBalance sourceBalance = findLockedBalance(lockedBalances, sourceWalletId);
+            WalletBalance targetBalance = findLockedBalance(lockedBalances, targetWalletId);
+            if (sourceBalance.money().lessThan(money)) {
+                throw new InsufficientBalanceException(sourceWalletId);
+            }
+
+            String operationId = support.nextId("op", "operation_id_seq");
+            insertOperationStepLog(
+                    operationId,
+                    OperationStep.BALANCE_LOCKED,
+                    occurredAt,
+                    "Balances locked for transfer " + sourceWalletId + " to " + targetWalletId
+            );
+            WalletBalance updatedSourceBalance = new WalletBalance(
+                    sourceWalletId,
+                    sourceBalance.money().subtract(money),
+                    occurredAt
+            );
+            WalletBalance updatedTargetBalance = new WalletBalance(
+                    targetWalletId,
+                    targetBalance.money().add(money),
+                    occurredAt
+            );
+            updateBalance(updatedSourceBalance);
+            updateBalance(updatedTargetBalance);
+            insertOperationStepLog(
+                    operationId,
+                    OperationStep.BALANCE_UPDATED,
+                    occurredAt,
+                    "Balances updated for transfer " + sourceWalletId + " to " + targetWalletId
+            );
+
+            String sourceTransactionId = support.nextId("txn", "transaction_id_seq");
+            insertTransaction(
+                    sourceTransactionId,
+                    sourceWalletId,
+                    occurredAt,
+                    TransactionType.TRANSFER,
+                    TransactionStatus.COMPLETED,
+                    TransactionDirection.DEBIT,
+                    money,
+                    description
+            );
+            insertTransaction(
+                    support.nextId("txn", "transaction_id_seq"),
+                    targetWalletId,
+                    occurredAt,
+                    TransactionType.TRANSFER,
+                    TransactionStatus.COMPLETED,
+                    TransactionDirection.CREDIT,
+                    money,
+                    description
+            );
+            insertOperationStepLog(
+                    operationId,
+                    OperationStep.TRANSACTION_RECORDED,
+                    occurredAt,
+                    "Transaction history recorded for transfer " + sourceWalletId + " to " + targetWalletId
+            );
+            insertLedgerEntry(
+                    support.nextId("ledger", "ledger_entry_id_seq"),
+                    operationId,
+                    sourceWalletId,
+                    occurredAt,
+                    TransactionType.TRANSFER,
+                    TransactionDirection.DEBIT,
+                    money,
+                    updatedSourceBalance.money(),
+                    description
+            );
+            insertLedgerEntry(
+                    support.nextId("ledger", "ledger_entry_id_seq"),
+                    operationId,
+                    targetWalletId,
+                    occurredAt,
+                    TransactionType.TRANSFER,
+                    TransactionDirection.CREDIT,
+                    money,
+                    updatedTargetBalance.money(),
+                    description
+            );
+            insertOperationStepLog(
+                    operationId,
+                    OperationStep.LEDGER_RECORDED,
+                    occurredAt,
+                    "Ledger entries recorded for transfer " + sourceWalletId + " to " + targetWalletId
+            );
+            insertAuditEvent(
+                    support.nextId("audit", "audit_event_id_seq"),
+                    operationId,
+                    AuditEventType.TRANSFER_COMPLETED,
+                    occurredAt,
+                    "Transfer completed from " + sourceWalletId + " to " + targetWalletId,
+                    List.of(sourceWalletId, targetWalletId)
+            );
+            insertOperationStepLog(
+                    operationId,
+                    OperationStep.AUDIT_RECORDED,
+                    occurredAt,
+                    "Audit event recorded for operation " + operationId
+            );
+
+            WalletOperationResult result = new WalletOperationResult(
+                    operationId,
+                    sourceTransactionId,
+                    sourceWalletId,
+                    targetWalletId,
+                    occurredAt,
+                    TransactionType.TRANSFER,
+                    TransactionStatus.COMPLETED,
+                    TransactionDirection.DEBIT,
+                    money,
+                    updatedSourceBalance,
+                    description
+            );
+            WalletOperationRecord record = new WalletOperationRecord(idempotencyKey, fingerprint, result);
+            insertOperation(record);
+            insertOperationStepLog(
+                    operationId,
+                    OperationStep.IDEMPOTENCY_RECORDED,
+                    occurredAt,
+                    "Idempotency record stored for operation " + operationId
+            );
+            insertOutboxEvent(result);
+            return record;
+        });
+    }
+
+    private WalletOperationRecord executeWithLockTimeout(Supplier<WalletOperationRecord> operation) {
+        try {
+            return transactionTemplate.execute(status -> {
+                applyLockTimeout();
+                return operation.get();
+            });
+        } catch (DataAccessException exception) {
+            if (!causedByLockTimeout(exception)) {
+                throw exception;
+            }
+            throw new WalletConcurrencyException(BUSY_BALANCE_MESSAGE, exception);
+        }
+    }
+
+    private boolean causedByLockTimeout(DataAccessException exception) {
+        if (exception instanceof CannotAcquireLockException) {
+            return true;
+        }
+
+        Throwable cause = exception;
+        while (cause != null) {
+            if (cause instanceof SQLException sqlException && "55P03".equals(sqlException.getSQLState())) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+
+        return false;
+    }
+
+    private void applyLockTimeout() {
+        try {
+            jdbcTemplate.execute("set local lock_timeout = '" + LOCK_TIMEOUT_MILLIS + "ms'");
+        } catch (BadSqlGrammarException exception) {
+            jdbcTemplate.execute("set lock_timeout " + LOCK_TIMEOUT_MILLIS);
+        }
+    }
+
+    private WalletBalance findBalanceForUpdate(String walletId) {
+        return support.queryOptional(
+                "select wallet_id, amount, currency, as_of from wallet_balances where wallet_id = ? for update",
+                support.walletBalanceMapper(),
+                walletId
+        )
+                .orElseThrow(() -> new WalletNotFoundException(walletId));
+    }
+
+    private List<WalletBalance> findTransferBalancesForUpdate(String sourceWalletId, String targetWalletId) {
+        List<String> walletIds = List.of(sourceWalletId, targetWalletId).stream()
+                .sorted()
+                .toList();
+
+        return jdbcTemplate.query(
+                """
+                        select wallet_id, amount, currency, as_of
+                        from wallet_balances
+                        where wallet_id in (?, ?)
+                        order by wallet_id
+                        for update
+                        """,
+                support.walletBalanceMapper(),
+                walletIds.get(0),
+                walletIds.get(1)
+        );
+    }
+
+    private WalletBalance findLockedBalance(List<WalletBalance> lockedBalances, String walletId) {
+        return lockedBalances.stream()
+                .filter(walletBalance -> walletBalance.walletId().equals(walletId))
+                .findFirst()
+                .orElseThrow(() -> new WalletNotFoundException(walletId));
+    }
+
+    private void updateBalance(WalletBalance walletBalance) {
+        jdbcTemplate.update(
+                "update wallet_balances set amount = ?, currency = ?, as_of = ? where wallet_id = ?",
+                walletBalance.money().amount(),
+                walletBalance.money().currency(),
+                support.timestamp(walletBalance.asOf()),
+                walletBalance.walletId()
+        );
+    }
+
+    private void insertTransaction(
+            String transactionId,
+            String walletId,
+            Instant occurredAt,
+            TransactionType type,
+            TransactionStatus status,
+            TransactionDirection direction,
+            Money money,
+            String description
+    ) {
+        jdbcTemplate.update(
+                """
+                        insert into transaction_history (
+                            transaction_id, wallet_id, occurred_at, type, status, direction, amount, currency, description
+                        )
+                        values (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                transactionId,
+                walletId,
+                support.timestamp(occurredAt),
+                type.name(),
+                status.name(),
+                direction.name(),
+                money.amount(),
+                money.currency(),
+                description
+        );
+    }
+
+    private void insertLedgerEntry(
+            String ledgerEntryId,
+            String operationId,
+            String walletId,
+            Instant occurredAt,
+            TransactionType type,
+            TransactionDirection direction,
+            Money money,
+            Money balanceAfter,
+            String description
+    ) {
+        jdbcTemplate.update(
+                """
+                        insert into ledger_entries (
+                            ledger_entry_id, operation_id, wallet_id, occurred_at, type, direction,
+                            amount, currency, balance_after_amount, balance_after_currency, description
+                        )
+                        values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                ledgerEntryId,
+                operationId,
+                walletId,
+                support.timestamp(occurredAt),
+                type.name(),
+                direction.name(),
+                money.amount(),
+                money.currency(),
+                balanceAfter.amount(),
+                balanceAfter.currency(),
+                description
+        );
+    }
+
+    private void insertAuditEvent(
+            String auditEventId,
+            String operationId,
+            AuditEventType type,
+            Instant occurredAt,
+            String detail,
+            List<String> walletIds
+    ) {
+        jdbcTemplate.update(
+                """
+                        insert into audit_events (audit_event_id, operation_id, type, occurred_at, detail)
+                        values (?, ?, ?, ?, ?)
+                        """,
+                auditEventId,
+                operationId,
+                type.name(),
+                support.timestamp(occurredAt),
+                detail
+        );
+        for (String walletId : walletIds) {
+            jdbcTemplate.update(
+                    """
+                            insert into audit_event_wallets (audit_event_id, wallet_id)
+                            values (?, ?)
+                            """,
+                    auditEventId,
+                    walletId
+            );
+        }
+    }
+
+    private void insertOperation(WalletOperationRecord record) {
+        WalletOperationResult result = record.result();
+        jdbcTemplate.update(
+                """
+                        insert into wallet_operations (
+                            idempotency_key, fingerprint, operation_id, transaction_id, wallet_id, counterparty_wallet_id,
+                            occurred_at, type, status, direction, amount, currency, balance_wallet_id,
+                            balance_amount, balance_currency, balance_as_of, description
+                        )
+                        values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                record.idempotencyKey(),
+                record.fingerprint(),
+                result.operationId(),
+                result.transactionId(),
+                result.walletId(),
+                result.counterpartyWalletId(),
+                support.timestamp(result.occurredAt()),
+                result.type().name(),
+                result.status().name(),
+                result.direction().name(),
+                result.money().amount(),
+                result.money().currency(),
+                result.balance().walletId(),
+                result.balance().money().amount(),
+                result.balance().money().currency(),
+                support.timestamp(result.balance().asOf()),
+                result.description()
+        );
+    }
+
+    private void insertOperationStepLog(
+            String operationId,
+            OperationStep step,
+            Instant occurredAt,
+            String detail
+    ) {
+        jdbcTemplate.update(
+                """
+                        insert into operation_step_logs (
+                            operation_step_log_id, operation_id, step, status, occurred_at, detail
+                        )
+                        values (?, ?, ?, ?, ?, ?)
+                        """,
+                support.nextId("step", "operation_step_log_id_seq"),
+                operationId,
+                step.name(),
+                TransactionStatus.COMPLETED.name(),
+                support.timestamp(occurredAt),
+                detail
+        );
+    }
+
+    private void insertOutboxEvent(WalletOperationResult result) {
+        jdbcTemplate.update(
+                """
+                        insert into operation_outbox_events (
+                            outbox_event_id, operation_id, event_type, aggregate_type,
+                            aggregate_id, payload, status, occurred_at,
+                            attempt_count, next_retry_at, claimed_at, lease_expires_at,
+                            published_at, last_error
+                        )
+                        values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                support.nextId("outbox", "outbox_event_id_seq"),
+                result.operationId(),
+                result.type().name() + "_COMPLETED",
+                "WALLET_OPERATION",
+                result.operationId(),
+                outboxPayload(result),
+                OperationOutboxStatus.PENDING.name(),
+                support.timestamp(result.occurredAt()),
+                0,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    private String outboxPayload(WalletOperationResult result) {
+        return """
+                {"operationId":"%s","walletId":"%s","counterpartyWalletId":%s,"type":"%s","amount":"%s","currency":"%s"}
+                """.formatted(
+                result.operationId(),
+                result.walletId(),
+                nullableJsonString(result.counterpartyWalletId()),
+                result.type().name(),
+                result.money().amount().stripTrailingZeros().toPlainString(),
+                result.money().currency()
+        ).trim();
+    }
+
+    private String nullableJsonString(String value) {
+        if (value == null) {
+            return "null";
+        }
+        return "\"" + value + "\"";
+    }
+}

--- a/src/main/java/com/imwoo/airepo/wallet/infra/JdbcWalletRepository.java
+++ b/src/main/java/com/imwoo/airepo/wallet/infra/JdbcWalletRepository.java
@@ -1,8 +1,6 @@
 package com.imwoo.airepo.wallet.infra;
 
 import com.imwoo.airepo.wallet.application.AdminApiAccessAuditRepository;
-import com.imwoo.airepo.wallet.application.InsufficientBalanceException;
-import com.imwoo.airepo.wallet.application.InvalidWalletOperationException;
 import com.imwoo.airepo.wallet.application.OperationOutboxConsumerDeliveryMetricRepository;
 import com.imwoo.airepo.wallet.application.OperationOutboxConsumerIdempotencyRepository;
 import com.imwoo.airepo.wallet.application.OperationOutboxConsumerMetrics;
@@ -14,61 +12,46 @@ import com.imwoo.airepo.wallet.application.OperationOutboxRelayRepository;
 import com.imwoo.airepo.wallet.application.OperationOutboxRelayRunRepository;
 import com.imwoo.airepo.wallet.application.OperationalAlertRepository;
 import com.imwoo.airepo.wallet.application.WalletCommandRepository;
-import com.imwoo.airepo.wallet.application.WalletConcurrencyException;
 import com.imwoo.airepo.wallet.application.WalletLedgerQueryRepository;
 import com.imwoo.airepo.wallet.application.WalletOperationRecord;
-import com.imwoo.airepo.wallet.application.WalletOperationResult;
-import com.imwoo.airepo.wallet.application.WalletNotFoundException;
 import com.imwoo.airepo.wallet.domain.AdminApiAccessAudit;
-import com.imwoo.airepo.wallet.domain.AdminApiAccessOutcome;
 import com.imwoo.airepo.wallet.domain.AuditEvent;
-import com.imwoo.airepo.wallet.domain.AuditEventType;
 import com.imwoo.airepo.wallet.domain.LedgerEntry;
 import com.imwoo.airepo.wallet.domain.Member;
-import com.imwoo.airepo.wallet.domain.MemberStatus;
 import com.imwoo.airepo.wallet.domain.Money;
 import com.imwoo.airepo.wallet.domain.OperationOutboxConsumerProcessedEvent;
 import com.imwoo.airepo.wallet.domain.OperationOutboxConsumerReceipt;
 import com.imwoo.airepo.wallet.domain.OperationOutboxEvent;
 import com.imwoo.airepo.wallet.domain.OperationOutboxRequeueAudit;
 import com.imwoo.airepo.wallet.domain.OperationOutboxRequeueRequestRecord;
-import com.imwoo.airepo.wallet.domain.OperationOutboxRequeueRequestStatus;
 import com.imwoo.airepo.wallet.domain.OperationOutboxRelayRun;
-import com.imwoo.airepo.wallet.domain.OperationOutboxRelayRunStatus;
-import com.imwoo.airepo.wallet.domain.OperationOutboxStatus;
-import com.imwoo.airepo.wallet.domain.OperationStep;
 import com.imwoo.airepo.wallet.domain.OperationStepLog;
 import com.imwoo.airepo.wallet.domain.OperationalAlert;
 import com.imwoo.airepo.wallet.domain.OperationalAlertSeverity;
-import com.imwoo.airepo.wallet.domain.TransactionDirection;
 import com.imwoo.airepo.wallet.domain.TransactionHistoryItem;
-import com.imwoo.airepo.wallet.domain.TransactionStatus;
-import com.imwoo.airepo.wallet.domain.TransactionType;
 import com.imwoo.airepo.wallet.domain.WalletAccount;
-import com.imwoo.airepo.wallet.domain.WalletAccountStatus;
 import com.imwoo.airepo.wallet.domain.WalletBalance;
-import java.math.BigDecimal;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Timestamp;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Supplier;
 import org.springframework.context.annotation.Profile;
-import org.springframework.dao.CannotAcquireLockException;
-import org.springframework.dao.DataAccessException;
-import org.springframework.dao.DuplicateKeyException;
-import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.jdbc.BadSqlGrammarException;
-import org.springframework.jdbc.core.ConnectionCallback;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.support.TransactionTemplate;
 
+/**
+ * PostgreSQL-backed composite of the wallet persistence ports.
+ *
+ * <p>This class no longer contains any SQL: it composes the bounded-context adapters
+ * ({@link JdbcWalletLedgerRepository}, {@link JdbcOutboxRelayRepository},
+ * {@link JdbcOutboxConsumerRepository}, {@link JdbcOperationalAlertRepository},
+ * {@link JdbcAdminApiAccessAuditRepository}) over a shared {@link WalletJdbcSupport} and delegates
+ * every port method. Retaining the aggregate bean under {@code @Profile("postgres")} keeps the
+ * Spring wiring and the {@code (JdbcTemplate, TransactionTemplate)} construction contract identical
+ * for callers and tests, while the SQL lives in focused, single-context adapters.
+ *
+ * <p>See ADR-0064 for the decomposition strategy and rationale.
+ */
 @Repository
 @Profile("postgres")
 public class JdbcWalletRepository implements
@@ -84,1080 +67,76 @@ public class JdbcWalletRepository implements
         OperationalAlertRepository,
         AdminApiAccessAuditRepository {
 
-    private static final int LOCK_TIMEOUT_MILLIS = 1000;
-    private static final String BUSY_BALANCE_MESSAGE = "Wallet balance is busy. Please retry.";
-
-    private final JdbcTemplate jdbcTemplate;
-    private final TransactionTemplate transactionTemplate;
+    private final JdbcWalletLedgerRepository walletLedger;
+    private final JdbcOutboxRelayRepository outboxRelay;
+    private final JdbcOutboxConsumerRepository outboxConsumer;
+    private final JdbcOperationalAlertRepository operationalAlert;
+    private final JdbcAdminApiAccessAuditRepository adminApiAccessAudit;
 
     public JdbcWalletRepository(JdbcTemplate jdbcTemplate, TransactionTemplate transactionTemplate) {
-        this.jdbcTemplate = jdbcTemplate;
-        this.transactionTemplate = transactionTemplate;
+        WalletJdbcSupport support = new WalletJdbcSupport(jdbcTemplate, transactionTemplate);
+        this.walletLedger = new JdbcWalletLedgerRepository(support);
+        this.outboxRelay = new JdbcOutboxRelayRepository(support);
+        this.outboxConsumer = new JdbcOutboxConsumerRepository(support);
+        this.operationalAlert = new JdbcOperationalAlertRepository(support);
+        this.adminApiAccessAudit = new JdbcAdminApiAccessAuditRepository(support);
     }
+
+    // --- WalletQueryRepository / WalletLedgerQueryRepository / WalletCommandRepository ---
 
     @Override
     public Optional<Member> findMember(String memberId) {
-        return queryOptional(
-                "select member_id, status, created_at from members where member_id = ?",
-                memberMapper(),
-                memberId
-        );
+        return walletLedger.findMember(memberId);
     }
 
     @Override
     public Optional<WalletAccount> findWalletAccount(String walletId) {
-        return queryOptional(
-                "select wallet_id, member_id, status, created_at from wallet_accounts where wallet_id = ?",
-                walletAccountMapper(),
-                walletId
-        );
+        return walletLedger.findWalletAccount(walletId);
     }
 
     @Override
     public Optional<WalletBalance> findBalance(String walletId) {
-        return queryOptional(
-                "select wallet_id, amount, currency, as_of from wallet_balances where wallet_id = ?",
-                walletBalanceMapper(),
-                walletId
-        );
+        return walletLedger.findBalance(walletId);
     }
 
     @Override
     public List<TransactionHistoryItem> findTransactions(String walletId) {
-        return jdbcTemplate.query(
-                """
-                        select transaction_id, wallet_id, occurred_at, type, status, direction, amount, currency, description
-                        from transaction_history
-                        where wallet_id = ?
-                        """,
-                transactionHistoryMapper(),
-                walletId
-        );
+        return walletLedger.findTransactions(walletId);
     }
 
     @Override
     public List<LedgerEntry> findLedgerEntries(String walletId) {
-        return jdbcTemplate.query(
-                """
-                        select ledger_entry_id, operation_id, wallet_id, occurred_at, type, direction,
-                               amount, currency, balance_after_amount, balance_after_currency, description
-                        from ledger_entries
-                        where wallet_id = ?
-                        """,
-                ledgerEntryMapper(),
-                walletId
-        );
+        return walletLedger.findLedgerEntries(walletId);
     }
 
     @Override
     public List<AuditEvent> findAuditEvents() {
-        return jdbcTemplate.query(
-                "select audit_event_id, operation_id, type, occurred_at, detail from audit_events",
-                auditEventMapper()
-        );
+        return walletLedger.findAuditEvents();
     }
 
     @Override
     public List<AuditEvent> findAuditEventsByWallet(String walletId) {
-        return jdbcTemplate.query(
-                """
-                        select ae.audit_event_id, ae.operation_id, ae.type, ae.occurred_at, ae.detail
-                        from audit_events ae
-                        where ae.audit_event_id in (
-                            select audit_event_id from audit_event_wallets where wallet_id = ?
-                        )
-                        """,
-                auditEventMapper(),
-                walletId
-        );
+        return walletLedger.findAuditEventsByWallet(walletId);
     }
 
     @Override
     public List<OperationStepLog> findOperationStepLogs(String operationId) {
-        return jdbcTemplate.query(
-                """
-                        select operation_step_log_id, operation_id, step, status, occurred_at, detail
-                        from operation_step_logs
-                        where operation_id = ?
-                        """,
-                operationStepLogMapper(),
-                operationId
-        );
+        return walletLedger.findOperationStepLogs(operationId);
     }
 
     @Override
     public List<OperationOutboxEvent> findOperationOutboxEvents(String operationId) {
-        return jdbcTemplate.query(
-                """
-                        select outbox_event_id, operation_id, event_type, aggregate_type,
-                               aggregate_id, payload, status, occurred_at,
-                               attempt_count, next_retry_at, claimed_at, lease_expires_at,
-                               published_at, last_error
-                        from operation_outbox_events
-                        where operation_id = ?
-                        """,
-                operationOutboxEventMapper(),
-                operationId
-        );
+        return walletLedger.findOperationOutboxEvents(operationId);
     }
 
     @Override
     public boolean existsOperationId(String operationId) {
-        Integer count = jdbcTemplate.queryForObject(
-                "select count(*) from wallet_operations where operation_id = ?",
-                Integer.class,
-                operationId
-        );
-        return count != null && count > 0;
-    }
-
-    @Override
-    public List<OperationOutboxEvent> findPendingOutboxEvents(int limit) {
-        return jdbcTemplate.query(
-                """
-                        select outbox_event_id, operation_id, event_type, aggregate_type,
-                               aggregate_id, payload, status, occurred_at,
-                               attempt_count, next_retry_at, claimed_at, lease_expires_at,
-                               published_at, last_error
-                        from operation_outbox_events
-                        where status = ?
-                        order by occurred_at, outbox_event_id
-                        limit ?
-                        """,
-                operationOutboxEventMapper(),
-                OperationOutboxStatus.PENDING.name(),
-                limit
-        );
-    }
-
-    @Override
-    public long countPendingOutboxEvents() {
-        Long count = jdbcTemplate.queryForObject(
-                """
-                        select count(*)
-                        from operation_outbox_events
-                        where status = ?
-                        """,
-                Long.class,
-                OperationOutboxStatus.PENDING.name()
-        );
-        return count == null ? 0L : count;
-    }
-
-    @Override
-    public List<OperationOutboxEvent> findManualReviewOutboxEvents(int limit) {
-        return jdbcTemplate.query(
-                """
-                        select outbox_event_id, operation_id, event_type, aggregate_type,
-                               aggregate_id, payload, status, occurred_at,
-                               attempt_count, next_retry_at, claimed_at, lease_expires_at,
-                               published_at, last_error
-                        from operation_outbox_events
-                        where status = ?
-                        order by occurred_at, outbox_event_id
-                        limit ?
-                        """,
-                operationOutboxEventMapper(),
-                OperationOutboxStatus.MANUAL_REVIEW.name(),
-                limit
-        );
-    }
-
-    @Override
-    public List<OperationOutboxRequeueAudit> findOutboxRequeueAudits(String outboxEventId) {
-        return jdbcTemplate.query(
-                """
-                        select audit_id, outbox_event_id, operation_id, requeued_at, operator_name, reason
-                        from operation_outbox_requeue_audits
-                        where outbox_event_id = ?
-                        order by requeued_at, audit_id
-                        """,
-                outboxRequeueAuditMapper(),
-                outboxEventId
-        );
-    }
-
-    @Override
-    public List<OperationOutboxRequeueRequestRecord> findOutboxRequeueRequests(String outboxEventId) {
-        return jdbcTemplate.query(
-                """
-                        select request_id, outbox_event_id, operation_id, status, requested_by,
-                               request_reason, requested_at, approved_by, approved_at, approval_reason,
-                               executed_by, executed_at, rejected_by, rejected_at, rejection_reason
-                        from operation_outbox_requeue_requests
-                        where outbox_event_id = ?
-                        order by requested_at, request_id
-                        """,
-                outboxRequeueRequestMapper(),
-                outboxEventId
-        );
-    }
-
-    @Override
-    public List<OperationOutboxEvent> claimReadyOutboxEvents(int limit, Instant now, Instant leaseExpiresAt) {
-        return transactionTemplate.execute(status -> {
-            List<String> outboxEventIds = claimReadyOutboxEventIds(limit, now);
-            if (outboxEventIds.isEmpty()) {
-                return List.of();
-            }
-            for (String outboxEventId : outboxEventIds) {
-                jdbcTemplate.update(
-                        """
-                                update operation_outbox_events
-                                set status = ?, next_retry_at = null, claimed_at = ?,
-                                    lease_expires_at = ?, published_at = null, last_error = null
-                                where outbox_event_id = ?
-                                """,
-                        OperationOutboxStatus.PROCESSING.name(),
-                        timestamp(now),
-                        timestamp(leaseExpiresAt),
-                        outboxEventId
-                );
-            }
-            return jdbcTemplate.query(
-                    """
-                            select outbox_event_id, operation_id, event_type, aggregate_type,
-                                   aggregate_id, payload, status, occurred_at,
-                                   attempt_count, next_retry_at, claimed_at, lease_expires_at,
-                                   published_at, last_error
-                            from operation_outbox_events
-                            where outbox_event_id in (%s)
-                            order by occurred_at, outbox_event_id
-                            """.formatted(placeholders(outboxEventIds.size())),
-                    operationOutboxEventMapper(),
-                    outboxEventIds.toArray()
-            );
-        });
-    }
-
-    @Override
-    public void markOutboxEventPublished(String outboxEventId, Instant publishedAt) {
-        jdbcTemplate.update(
-                """
-                        update operation_outbox_events
-                        set status = ?, next_retry_at = null, claimed_at = null,
-                            lease_expires_at = null, published_at = ?, last_error = null
-                        where outbox_event_id = ?
-                        """,
-                OperationOutboxStatus.PUBLISHED.name(),
-                timestamp(publishedAt),
-                outboxEventId
-        );
-    }
-
-    @Override
-    public void markClaimedOutboxEventPublished(
-            String outboxEventId,
-            Instant claimedAt,
-            Instant leaseExpiresAt,
-            Instant publishedAt
-    ) {
-        requireSingleRowUpdate(
-                jdbcTemplate.update(
-                        """
-                                update operation_outbox_events
-                                set status = ?, next_retry_at = null, claimed_at = null,
-                                    lease_expires_at = null, published_at = ?, last_error = null
-                                where outbox_event_id = ?
-                                  and status = ?
-                                  and claimed_at = ?
-                                  and lease_expires_at = ?
-                                """,
-                        OperationOutboxStatus.PUBLISHED.name(),
-                        timestamp(publishedAt),
-                        outboxEventId,
-                        OperationOutboxStatus.PROCESSING.name(),
-                        timestamp(claimedAt),
-                        timestamp(leaseExpiresAt)
-                ),
-                "outbox event claim is no longer active: " + outboxEventId
-        );
-    }
-
-    @Override
-    public void markOutboxEventFailed(String outboxEventId, String lastError, Instant nextRetryAt, int maxAttempts) {
-        jdbcTemplate.update(
-                """
-                        update operation_outbox_events
-                        set status = case
-                                when attempt_count + 1 >= ? then ?
-                                else ?
-                            end,
-                            attempt_count = attempt_count + 1,
-                            next_retry_at = case
-                                when attempt_count + 1 >= ? then null
-                                else cast(? as timestamp)
-                            end,
-                            claimed_at = null, lease_expires_at = null, published_at = null, last_error = ?
-                        where outbox_event_id = ?
-                        """,
-                maxAttempts,
-                OperationOutboxStatus.MANUAL_REVIEW.name(),
-                OperationOutboxStatus.FAILED.name(),
-                maxAttempts,
-                timestamp(nextRetryAt),
-                lastError,
-                outboxEventId
-        );
-    }
-
-    @Override
-    public void markClaimedOutboxEventFailed(
-            String outboxEventId,
-            Instant claimedAt,
-            Instant leaseExpiresAt,
-            String lastError,
-            Instant nextRetryAt,
-            int maxAttempts
-    ) {
-        requireSingleRowUpdate(
-                jdbcTemplate.update(
-                        """
-                                update operation_outbox_events
-                                set status = case
-                                        when attempt_count + 1 >= ? then ?
-                                        else ?
-                                    end,
-                                    attempt_count = attempt_count + 1,
-                                    next_retry_at = case
-                                        when attempt_count + 1 >= ? then null
-                                        else cast(? as timestamp)
-                                    end,
-                                    claimed_at = null, lease_expires_at = null, published_at = null, last_error = ?
-                                where outbox_event_id = ?
-                                  and status = ?
-                                  and claimed_at = ?
-                                  and lease_expires_at = ?
-                                """,
-                        maxAttempts,
-                        OperationOutboxStatus.MANUAL_REVIEW.name(),
-                        OperationOutboxStatus.FAILED.name(),
-                        maxAttempts,
-                        timestamp(nextRetryAt),
-                        lastError,
-                        outboxEventId,
-                        OperationOutboxStatus.PROCESSING.name(),
-                        timestamp(claimedAt),
-                        timestamp(leaseExpiresAt)
-                ),
-                "outbox event claim is no longer active: " + outboxEventId
-        );
-    }
-
-    @Override
-    public void requeueManualReviewOutboxEvent(
-            String outboxEventId,
-            Instant requeuedAt,
-            String operator,
-            String reason
-    ) {
-        transactionTemplate.executeWithoutResult(status -> {
-            OperationOutboxEvent event = manualReviewOutboxEventForUpdate(outboxEventId);
-
-            requireSingleRowUpdate(
-                    jdbcTemplate.update(
-                            """
-                                    update operation_outbox_events
-                                    set status = ?, attempt_count = 0, next_retry_at = null,
-                                        claimed_at = null, lease_expires_at = null, published_at = null, last_error = null
-                                    where outbox_event_id = ?
-                                      and status = ?
-                                    """,
-                            OperationOutboxStatus.PENDING.name(),
-                            outboxEventId,
-                            OperationOutboxStatus.MANUAL_REVIEW.name()
-                    ),
-                    "outbox event must still be MANUAL_REVIEW: " + outboxEventId
-            );
-            jdbcTemplate.update(
-                    """
-                            insert into operation_outbox_requeue_audits (
-                                audit_id, outbox_event_id, operation_id, requeued_at, operator_name, reason
-                            )
-                            values (?, ?, ?, ?, ?, ?)
-                            """,
-                    nextId("outbox-requeue-audit", "outbox_requeue_audit_id_seq"),
-                    outboxEventId,
-                    event.operationId(),
-                    timestamp(requeuedAt),
-                    operator,
-                    reason
-            );
-        });
-    }
-
-    @Override
-    public OperationOutboxRequeueRequestRecord requestManualReviewRequeue(
-            String outboxEventId,
-            Instant requestedAt,
-            String requestedBy,
-            String reason
-    ) {
-        return transactionTemplate.execute(status -> {
-            OperationOutboxEvent event = manualReviewOutboxEvent(outboxEventId);
-            OperationOutboxRequeueRequestRecord request = new OperationOutboxRequeueRequestRecord(
-                    nextId("outbox-requeue-request", "outbox_requeue_request_id_seq"),
-                    outboxEventId,
-                    event.operationId(),
-                    OperationOutboxRequeueRequestStatus.REQUESTED,
-                    requestedBy,
-                    reason,
-                    requestedAt,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-            );
-            jdbcTemplate.update(
-                    """
-                            insert into operation_outbox_requeue_requests (
-                                request_id, outbox_event_id, operation_id, status, requested_by,
-                                request_reason, requested_at, approved_by, approved_at, approval_reason,
-                                executed_by, executed_at, rejected_by, rejected_at, rejection_reason
-                            )
-                            values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                            """,
-                    request.requestId(),
-                    request.outboxEventId(),
-                    request.operationId(),
-                    request.status().name(),
-                    request.requestedBy(),
-                    request.requestReason(),
-                    timestamp(request.requestedAt()),
-                    request.approvedBy(),
-                    timestamp(request.approvedAt()),
-                    request.approvalReason(),
-                    request.executedBy(),
-                    timestamp(request.executedAt()),
-                    request.rejectedBy(),
-                    timestamp(request.rejectedAt()),
-                    request.rejectionReason()
-            );
-            return request;
-        });
-    }
-
-    @Override
-    public OperationOutboxRequeueRequestRecord approveManualReviewRequeueRequest(
-            String requestId,
-            Instant approvedAt,
-            String approvedBy,
-            String approvalReason
-    ) {
-        return transactionTemplate.execute(status -> {
-            OperationOutboxRequeueRequestRecord request = requeueRequestForUpdate(requestId);
-            if (request.status() != OperationOutboxRequeueRequestStatus.REQUESTED) {
-                throw new InvalidWalletOperationException("requeue request must be REQUESTED: " + requestId);
-            }
-            if (request.requestedBy().equals(approvedBy)) {
-                throw new InvalidWalletOperationException("approver must be different from requester");
-            }
-            requireSingleRowUpdate(
-                    jdbcTemplate.update(
-                            """
-                                    update operation_outbox_requeue_requests
-                                    set status = ?, approved_by = ?, approved_at = ?, approval_reason = ?
-                                    where request_id = ?
-                                      and status = ?
-                                    """,
-                            OperationOutboxRequeueRequestStatus.APPROVED.name(),
-                            approvedBy,
-                            timestamp(approvedAt),
-                            approvalReason,
-                            requestId,
-                            OperationOutboxRequeueRequestStatus.REQUESTED.name()
-                    ),
-                    "requeue request must still be REQUESTED: " + requestId
-            );
-            return requeueRequest(requestId);
-        });
-    }
-
-    @Override
-    public OperationOutboxRequeueRequestRecord rejectManualReviewRequeueRequest(
-            String requestId,
-            Instant rejectedAt,
-            String rejectedBy,
-            String rejectionReason
-    ) {
-        return transactionTemplate.execute(status -> {
-            OperationOutboxRequeueRequestRecord request = requeueRequestForUpdate(requestId);
-            if (request.status() != OperationOutboxRequeueRequestStatus.REQUESTED) {
-                throw new InvalidWalletOperationException("requeue request must be REQUESTED: " + requestId);
-            }
-            if (request.requestedBy().equals(rejectedBy)) {
-                throw new InvalidWalletOperationException("rejector must be different from requester");
-            }
-            requireSingleRowUpdate(
-                    jdbcTemplate.update(
-                            """
-                                    update operation_outbox_requeue_requests
-                                    set status = ?, rejected_by = ?, rejected_at = ?, rejection_reason = ?
-                                    where request_id = ?
-                                      and status = ?
-                                    """,
-                            OperationOutboxRequeueRequestStatus.REJECTED.name(),
-                            rejectedBy,
-                            timestamp(rejectedAt),
-                            rejectionReason,
-                            requestId,
-                            OperationOutboxRequeueRequestStatus.REQUESTED.name()
-                    ),
-                    "requeue request must still be REQUESTED: " + requestId
-            );
-            return requeueRequest(requestId);
-        });
-    }
-
-    @Override
-    public OperationOutboxRequeueRequestRecord executeManualReviewRequeueRequest(
-            String requestId,
-            Instant executedAt,
-            String executedBy
-    ) {
-        return transactionTemplate.execute(status -> {
-            OperationOutboxRequeueRequestRecord request = requeueRequestForUpdate(requestId);
-            if (request.status() != OperationOutboxRequeueRequestStatus.APPROVED) {
-                throw new InvalidWalletOperationException("requeue request must be APPROVED: " + requestId);
-            }
-            OperationOutboxEvent event = manualReviewOutboxEventForUpdate(request.outboxEventId());
-            requireSingleRowUpdate(
-                    jdbcTemplate.update(
-                            """
-                                    update operation_outbox_events
-                                    set status = ?, attempt_count = 0, next_retry_at = null,
-                                        claimed_at = null, lease_expires_at = null, published_at = null, last_error = null
-                                    where outbox_event_id = ?
-                                      and status = ?
-                                    """,
-                            OperationOutboxStatus.PENDING.name(),
-                            request.outboxEventId(),
-                            OperationOutboxStatus.MANUAL_REVIEW.name()
-                    ),
-                    "outbox event must still be MANUAL_REVIEW: " + request.outboxEventId()
-            );
-            jdbcTemplate.update(
-                    """
-                            insert into operation_outbox_requeue_audits (
-                                audit_id, outbox_event_id, operation_id, requeued_at, operator_name, reason
-                            )
-                            values (?, ?, ?, ?, ?, ?)
-                            """,
-                    nextId("outbox-requeue-audit", "outbox_requeue_audit_id_seq"),
-                    request.outboxEventId(),
-                    event.operationId(),
-                    timestamp(executedAt),
-                    executedBy,
-                    request.requestReason()
-            );
-            requireSingleRowUpdate(
-                    jdbcTemplate.update(
-                            """
-                                    update operation_outbox_requeue_requests
-                                    set status = ?, executed_by = ?, executed_at = ?
-                                    where request_id = ?
-                                      and status = ?
-                                    """,
-                            OperationOutboxRequeueRequestStatus.EXECUTED.name(),
-                            executedBy,
-                            timestamp(executedAt),
-                            requestId,
-                            OperationOutboxRequeueRequestStatus.APPROVED.name()
-                    ),
-                    "requeue request must still be APPROVED: " + requestId
-            );
-            return requeueRequest(requestId);
-        });
-    }
-
-    @Override
-    public String nextRelayRunId() {
-        return nextId("outbox-relay-run", "outbox_relay_run_id_seq");
-    }
-
-    @Override
-    public void saveOutboxRelayRun(OperationOutboxRelayRun relayRun) {
-        jdbcTemplate.update(
-                """
-                        insert into operation_outbox_relay_runs (
-                            relay_run_id, started_at, completed_at, status, batch_size,
-                            claimed_count, published_count, failed_count, error_message
-                        )
-                        values (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                        """,
-                relayRun.relayRunId(),
-                timestamp(relayRun.startedAt()),
-                timestamp(relayRun.completedAt()),
-                relayRun.status().name(),
-                relayRun.batchSize(),
-                relayRun.claimedCount(),
-                relayRun.publishedCount(),
-                relayRun.failedCount(),
-                relayRun.errorMessage()
-        );
-    }
-
-    @Override
-    public List<OperationOutboxRelayRun> findRecentOutboxRelayRuns(int limit) {
-        return jdbcTemplate.query(
-                """
-                        select relay_run_id, started_at, completed_at, status, batch_size,
-                               claimed_count, published_count, failed_count, error_message
-                        from operation_outbox_relay_runs
-                        order by completed_at desc, relay_run_id desc
-                        limit ?
-                        """,
-                operationOutboxRelayRunMapper(),
-                limit
-        );
-    }
-
-    @Override
-    public int deleteOutboxRelayRunsCompletedBefore(Instant cutoff) {
-        return jdbcTemplate.update(
-                "delete from operation_outbox_relay_runs where completed_at < ?",
-                timestamp(cutoff)
-        );
-    }
-
-    @Override
-    public String nextAdminApiAccessAuditId() {
-        return nextId("admin-api-access-audit", "admin_api_access_audit_id_seq");
-    }
-
-    @Override
-    public void saveAdminApiAccessAudit(AdminApiAccessAudit accessAudit) {
-        jdbcTemplate.update(
-                """
-                        insert into admin_api_access_audits (
-                            audit_id, occurred_at, method, path, operator_id, status_code, outcome
-                        )
-                        values (?, ?, ?, ?, ?, ?, ?)
-                        """,
-                accessAudit.auditId(),
-                timestamp(accessAudit.occurredAt()),
-                accessAudit.method(),
-                accessAudit.path(),
-                accessAudit.operatorId(),
-                accessAudit.statusCode(),
-                accessAudit.outcome().name()
-        );
-    }
-
-    @Override
-    public List<AdminApiAccessAudit> findRecentAdminApiAccessAudits(int limit) {
-        return jdbcTemplate.query(
-                """
-                        select audit_id, occurred_at, method, path, operator_id, status_code, outcome
-                        from admin_api_access_audits
-                        order by occurred_at desc, audit_id desc
-                        limit ?
-                        """,
-                adminApiAccessAuditMapper(),
-                limit
-        );
-    }
-
-    @Override
-    public String nextOperationalAlertId() {
-        return nextId("operational-alert", "operational_alert_id_seq");
-    }
-
-    @Override
-    public void saveOperationalAlert(OperationalAlert operationalAlert) {
-        jdbcTemplate.update(
-                """
-                        insert into operational_alerts (
-                            alert_id, source, severity, occurred_at, reasons
-                        )
-                        values (?, ?, ?, ?, ?)
-                        """,
-                operationalAlert.alertId(),
-                operationalAlert.source(),
-                operationalAlert.severity().name(),
-                timestamp(operationalAlert.occurredAt()),
-                String.join("\n", operationalAlert.reasons())
-        );
-    }
-
-    @Override
-    public boolean existsOperationalAlertBetween(
-            String source,
-            OperationalAlertSeverity severity,
-            List<String> reasons,
-            Instant since,
-            Instant until
-    ) {
-        Integer count = jdbcTemplate.queryForObject(
-                """
-                        select count(*)
-                        from operational_alerts
-                        where source = ?
-                          and severity = ?
-                          and reasons = ?
-                          and occurred_at >= ?
-                          and occurred_at <= ?
-                        """,
-                Integer.class,
-                source,
-                severity.name(),
-                String.join("\n", reasons),
-                timestamp(since),
-                timestamp(until)
-        );
-        return count != null && count > 0;
-    }
-
-    @Override
-    public List<OperationalAlert> findRecentOperationalAlerts(int limit) {
-        return jdbcTemplate.query(
-                """
-                        select alert_id, source, severity, occurred_at, reasons
-                        from operational_alerts
-                        order by occurred_at desc, alert_id desc
-                        limit ?
-                        """,
-                operationalAlertMapper(),
-                limit
-        );
-    }
-
-    @Override
-    public int deleteOperationalAlertsOccurredBefore(Instant cutoff) {
-        return jdbcTemplate.update(
-                "delete from operational_alerts where occurred_at < ?",
-                timestamp(cutoff)
-        );
-    }
-
-    @Override
-    public int deleteAdminApiAccessAuditsOccurredBefore(Instant cutoff) {
-        return jdbcTemplate.update(
-                "delete from admin_api_access_audits where occurred_at < ?",
-                timestamp(cutoff)
-        );
-    }
-
-    @Override
-    public boolean recordProcessedEvent(
-            String idempotencyKey,
-            String outboxEventId,
-            String eventType,
-            Instant processedAt
-    ) {
-        if (isPostgresDatabase()) {
-            Boolean inserted = jdbcTemplate.queryForObject(
-                    """
-                            insert into operation_outbox_consumer_processed_events (
-                                idempotency_key, outbox_event_id, event_type, processed_at
-                            )
-                            values (?, ?, ?, ?)
-                            on conflict (idempotency_key) do update
-                            set duplicate_count =
-                                operation_outbox_consumer_processed_events.duplicate_count + 1
-                            returning (xmax = 0) as inserted
-                            """,
-                    Boolean.class,
-                    idempotencyKey,
-                    outboxEventId,
-                    eventType,
-                    timestamp(processedAt)
-            );
-            return Boolean.TRUE.equals(inserted);
-        }
-        int duplicateRows = jdbcTemplate.update(
-                """
-                        update operation_outbox_consumer_processed_events
-                        set duplicate_count = duplicate_count + 1
-                        where idempotency_key = ?
-                        """,
-                idempotencyKey
-        );
-        if (duplicateRows == 1) {
-            return false;
-        }
-        try {
-            return jdbcTemplate.update(
-                    """
-                            insert into operation_outbox_consumer_processed_events (
-                                idempotency_key, outbox_event_id, event_type, processed_at
-                            )
-                            values (?, ?, ?, ?)
-                            """,
-                    idempotencyKey,
-                    outboxEventId,
-                    eventType,
-                    timestamp(processedAt)
-            ) == 1;
-        } catch (DuplicateKeyException exception) {
-            return false;
-        }
-    }
-
-    @Override
-    public Optional<OperationOutboxConsumerProcessedEvent> findProcessedEvent(String idempotencyKey) {
-        return queryOptional(
-                """
-                        select idempotency_key, outbox_event_id, event_type, processed_at, duplicate_count
-                        from operation_outbox_consumer_processed_events
-                        where idempotency_key = ?
-                        """,
-                operationOutboxConsumerProcessedEventMapper(),
-                idempotencyKey
-        );
-    }
-
-    @Override
-    public void saveConsumerReceipt(OperationOutboxConsumerReceipt receipt) {
-        jdbcTemplate.update(
-                """
-                        insert into operation_outbox_consumer_receipts (
-                            idempotency_key, outbox_event_id, operation_id, event_type,
-                            aggregate_type, aggregate_id, received_at
-                        )
-                        values (?, ?, ?, ?, ?, ?, ?)
-                        """,
-                receipt.idempotencyKey(),
-                receipt.outboxEventId(),
-                receipt.operationId(),
-                receipt.eventType(),
-                receipt.aggregateType(),
-                receipt.aggregateId(),
-                timestamp(receipt.receivedAt())
-        );
-    }
-
-    @Override
-    public Optional<OperationOutboxConsumerReceipt> findConsumerReceipt(String idempotencyKey) {
-        return queryOptional(
-                """
-                        select idempotency_key, outbox_event_id, operation_id, event_type,
-                               aggregate_type, aggregate_id, received_at
-                        from operation_outbox_consumer_receipts
-                        where idempotency_key = ?
-                        """,
-                operationOutboxConsumerReceiptMapper(),
-                idempotencyKey
-        );
-    }
-
-    @Override
-    public void recordConsumerDeliveryMetric(Instant occurredAt, boolean duplicate) {
-        Instant bucketStartedAt = occurredAt.truncatedTo(ChronoUnit.MINUTES);
-        if (isPostgresDatabase()) {
-            jdbcTemplate.update(
-                    """
-                            insert into operation_outbox_consumer_delivery_metrics (
-                                bucket_started_at,
-                                processed_delivery_count,
-                                duplicate_delivery_count,
-                                updated_at
-                            )
-                            values (?, ?, ?, ?)
-                            on conflict (bucket_started_at) do update
-                            set processed_delivery_count =
-                                    operation_outbox_consumer_delivery_metrics.processed_delivery_count + ?,
-                                duplicate_delivery_count =
-                                    operation_outbox_consumer_delivery_metrics.duplicate_delivery_count + ?,
-                                updated_at = ?
-                            """,
-                    timestamp(bucketStartedAt),
-                    duplicate ? 0 : 1,
-                    duplicate ? 1 : 0,
-                    timestamp(occurredAt),
-                    duplicate ? 0 : 1,
-                    duplicate ? 1 : 0,
-                    timestamp(occurredAt)
-            );
-            return;
-        }
-
-        int updatedRows = jdbcTemplate.update(
-                """
-                        update operation_outbox_consumer_delivery_metrics
-                        set processed_delivery_count = processed_delivery_count + ?,
-                            duplicate_delivery_count = duplicate_delivery_count + ?,
-                            updated_at = ?
-                        where bucket_started_at = ?
-                        """,
-                duplicate ? 0 : 1,
-                duplicate ? 1 : 0,
-                timestamp(occurredAt),
-                timestamp(bucketStartedAt)
-        );
-        if (updatedRows == 1) {
-            return;
-        }
-        try {
-            jdbcTemplate.update(
-                    """
-                            insert into operation_outbox_consumer_delivery_metrics (
-                                bucket_started_at,
-                                processed_delivery_count,
-                                duplicate_delivery_count,
-                                updated_at
-                            )
-                            values (?, ?, ?, ?)
-                            """,
-                    timestamp(bucketStartedAt),
-                    duplicate ? 0 : 1,
-                    duplicate ? 1 : 0,
-                    timestamp(occurredAt)
-            );
-        } catch (DuplicateKeyException exception) {
-            recordConsumerDeliveryMetric(occurredAt, duplicate);
-        }
-    }
-
-    @Override
-    public OperationOutboxConsumerMetrics getConsumerMetrics() {
-        return jdbcTemplate.queryForObject(
-                """
-                        select
-                            (select count(*) from operation_outbox_consumer_processed_events) as processed_event_count,
-                            (select coalesce(sum(duplicate_count), 0)
-                             from operation_outbox_consumer_processed_events) as duplicate_event_count,
-                            (select count(*) from operation_outbox_consumer_receipts) as receipt_count,
-                            (select max(processed_at)
-                             from operation_outbox_consumer_processed_events) as last_processed_at,
-                            (select max(received_at)
-                             from operation_outbox_consumer_receipts) as last_received_at
-                        """,
-                (resultSet, rowNumber) -> new OperationOutboxConsumerMetrics(
-                        resultSet.getLong("processed_event_count"),
-                        resultSet.getLong("duplicate_event_count"),
-                        resultSet.getLong("receipt_count"),
-                        nullableInstant(resultSet, "last_processed_at"),
-                        nullableInstant(resultSet, "last_received_at")
-                )
-        );
-    }
-
-    @Override
-    public OperationOutboxConsumerWindowMetrics getConsumerWindowMetrics(
-            Instant windowStartedAt,
-            Instant windowEndedAt
-    ) {
-        return jdbcTemplate.queryForObject(
-                """
-                        select
-                            coalesce(sum(processed_delivery_count), 0) as processed_delivery_count,
-                            coalesce(sum(duplicate_delivery_count), 0) as duplicate_delivery_count
-                        from operation_outbox_consumer_delivery_metrics
-                        where bucket_started_at >= ?
-                          and bucket_started_at < ?
-                        """,
-                (resultSet, rowNumber) -> new OperationOutboxConsumerWindowMetrics(
-                        windowStartedAt,
-                        windowEndedAt,
-                        resultSet.getLong("processed_delivery_count"),
-                        resultSet.getLong("duplicate_delivery_count")
-                ),
-                timestamp(windowStartedAt),
-                timestamp(windowEndedAt)
-        );
-    }
-
-    @Override
-    public List<OperationOutboxConsumerReceipt> findRecentConsumerReceipts(int limit) {
-        return jdbcTemplate.query(
-                """
-                        select idempotency_key, outbox_event_id, operation_id, event_type,
-                               aggregate_type, aggregate_id, received_at
-                        from operation_outbox_consumer_receipts
-                        order by received_at desc, idempotency_key desc
-                        limit ?
-                        """,
-                operationOutboxConsumerReceiptMapper(),
-                limit
-        );
-    }
-
-    @Override
-    public int deleteConsumerProcessedEventsProcessedBefore(Instant cutoff) {
-        return jdbcTemplate.update(
-                "delete from operation_outbox_consumer_processed_events where processed_at < ?",
-                timestamp(cutoff)
-        );
-    }
-
-    @Override
-    public int deleteConsumerReceiptsReceivedBefore(Instant cutoff) {
-        return jdbcTemplate.update(
-                "delete from operation_outbox_consumer_receipts where received_at < ?",
-                timestamp(cutoff)
-        );
-    }
-
-    @Override
-    public int deleteConsumerDeliveryMetricsBucketStartedBefore(Instant cutoff) {
-        return jdbcTemplate.update(
-                "delete from operation_outbox_consumer_delivery_metrics where bucket_started_at < ?",
-                timestamp(cutoff)
-        );
-    }
-
-    private List<String> claimReadyOutboxEventIds(int limit, Instant now) {
-        try {
-            return jdbcTemplate.queryForList(
-                    """
-                            select outbox_event_id
-                            from operation_outbox_events
-                            where status = ?
-                               or (status = ? and (next_retry_at is null or next_retry_at <= ?))
-                               or (status = ? and lease_expires_at <= ?)
-                            order by occurred_at, outbox_event_id
-                            limit ?
-                            for update skip locked
-                            """,
-                    String.class,
-                    OperationOutboxStatus.PENDING.name(),
-                    OperationOutboxStatus.FAILED.name(),
-                    timestamp(now),
-                    OperationOutboxStatus.PROCESSING.name(),
-                    timestamp(now),
-                    limit
-            );
-        } catch (BadSqlGrammarException exception) {
-            return jdbcTemplate.queryForList(
-                    """
-                            select outbox_event_id
-                            from operation_outbox_events
-                            where status = ?
-                               or (status = ? and (next_retry_at is null or next_retry_at <= ?))
-                               or (status = ? and lease_expires_at <= ?)
-                            order by occurred_at, outbox_event_id
-                            limit ?
-                            for update
-                            """,
-                    String.class,
-                    OperationOutboxStatus.PENDING.name(),
-                    OperationOutboxStatus.FAILED.name(),
-                    timestamp(now),
-                    OperationOutboxStatus.PROCESSING.name(),
-                    timestamp(now),
-                    limit
-            );
-        }
+        return walletLedger.existsOperationId(operationId);
     }
 
     @Override
     public Optional<WalletOperationRecord> findOperation(String idempotencyKey) {
-        return queryOptional(
-                """
-                        select idempotency_key, fingerprint, operation_id, transaction_id, wallet_id,
-                               counterparty_wallet_id, occurred_at, type, status, direction, amount, currency,
-                               balance_wallet_id, balance_amount, balance_currency, balance_as_of, description
-                        from wallet_operations
-                        where idempotency_key = ?
-                        """,
-                operationRecordMapper(),
-                idempotencyKey
-        );
+        return walletLedger.findOperation(idempotencyKey);
     }
 
     @Override
@@ -1169,97 +148,7 @@ public class JdbcWalletRepository implements
             String description,
             Instant occurredAt
     ) {
-        return executeWithLockTimeout(() -> {
-            WalletBalance currentBalance = findBalanceForUpdate(walletId);
-            WalletBalance updatedBalance = new WalletBalance(walletId, currentBalance.money().add(money), occurredAt);
-            String operationId = nextId("op", "operation_id_seq");
-            insertOperationStepLog(
-                    operationId,
-                    OperationStep.BALANCE_LOCKED,
-                    occurredAt,
-                    "Balance locked for wallet " + walletId
-            );
-            updateBalance(updatedBalance);
-            insertOperationStepLog(
-                    operationId,
-                    OperationStep.BALANCE_UPDATED,
-                    occurredAt,
-                    "Balance updated for wallet " + walletId
-            );
-
-            String transactionId = nextId("txn", "transaction_id_seq");
-            insertTransaction(
-                    transactionId,
-                    walletId,
-                    occurredAt,
-                    TransactionType.CHARGE,
-                    TransactionStatus.COMPLETED,
-                    TransactionDirection.CREDIT,
-                    money,
-                    description
-            );
-            insertOperationStepLog(
-                    operationId,
-                    OperationStep.TRANSACTION_RECORDED,
-                    occurredAt,
-                    "Transaction history recorded for wallet " + walletId
-            );
-            insertLedgerEntry(
-                    nextId("ledger", "ledger_entry_id_seq"),
-                    operationId,
-                    walletId,
-                    occurredAt,
-                    TransactionType.CHARGE,
-                    TransactionDirection.CREDIT,
-                    money,
-                    updatedBalance.money(),
-                    description
-            );
-            insertOperationStepLog(
-                    operationId,
-                    OperationStep.LEDGER_RECORDED,
-                    occurredAt,
-                    "Ledger entry recorded for wallet " + walletId
-            );
-            insertAuditEvent(
-                    nextId("audit", "audit_event_id_seq"),
-                    operationId,
-                    AuditEventType.CHARGE_COMPLETED,
-                    occurredAt,
-                    "Charge completed for wallet " + walletId,
-                    List.of(walletId)
-            );
-            insertOperationStepLog(
-                    operationId,
-                    OperationStep.AUDIT_RECORDED,
-                    occurredAt,
-                    "Audit event recorded for operation " + operationId
-            );
-
-            WalletOperationResult result = new WalletOperationResult(
-                    operationId,
-                    transactionId,
-                    walletId,
-                    null,
-                    occurredAt,
-                    TransactionType.CHARGE,
-                    TransactionStatus.COMPLETED,
-                    TransactionDirection.CREDIT,
-                    money,
-                    updatedBalance,
-                    description
-            );
-            WalletOperationRecord record = new WalletOperationRecord(idempotencyKey, fingerprint, result);
-            insertOperation(record);
-            insertOperationStepLog(
-                    operationId,
-                    OperationStep.IDEMPOTENCY_RECORDED,
-                    occurredAt,
-                    "Idempotency record stored for operation " + operationId
-            );
-            insertOutboxEvent(result);
-            return record;
-        });
+        return walletLedger.applyCharge(idempotencyKey, fingerprint, walletId, money, description, occurredAt);
     }
 
     @Override
@@ -1272,736 +161,261 @@ public class JdbcWalletRepository implements
             String description,
             Instant occurredAt
     ) {
-        return executeWithLockTimeout(() -> {
-            List<WalletBalance> lockedBalances = findTransferBalancesForUpdate(sourceWalletId, targetWalletId);
-            WalletBalance sourceBalance = findLockedBalance(lockedBalances, sourceWalletId);
-            WalletBalance targetBalance = findLockedBalance(lockedBalances, targetWalletId);
-            if (sourceBalance.money().lessThan(money)) {
-                throw new InsufficientBalanceException(sourceWalletId);
-            }
-
-            String operationId = nextId("op", "operation_id_seq");
-            insertOperationStepLog(
-                    operationId,
-                    OperationStep.BALANCE_LOCKED,
-                    occurredAt,
-                    "Balances locked for transfer " + sourceWalletId + " to " + targetWalletId
-            );
-            WalletBalance updatedSourceBalance = new WalletBalance(
-                    sourceWalletId,
-                    sourceBalance.money().subtract(money),
-                    occurredAt
-            );
-            WalletBalance updatedTargetBalance = new WalletBalance(
-                    targetWalletId,
-                    targetBalance.money().add(money),
-                    occurredAt
-            );
-            updateBalance(updatedSourceBalance);
-            updateBalance(updatedTargetBalance);
-            insertOperationStepLog(
-                    operationId,
-                    OperationStep.BALANCE_UPDATED,
-                    occurredAt,
-                    "Balances updated for transfer " + sourceWalletId + " to " + targetWalletId
-            );
-
-            String sourceTransactionId = nextId("txn", "transaction_id_seq");
-            insertTransaction(
-                    sourceTransactionId,
-                    sourceWalletId,
-                    occurredAt,
-                    TransactionType.TRANSFER,
-                    TransactionStatus.COMPLETED,
-                    TransactionDirection.DEBIT,
-                    money,
-                    description
-            );
-            insertTransaction(
-                    nextId("txn", "transaction_id_seq"),
-                    targetWalletId,
-                    occurredAt,
-                    TransactionType.TRANSFER,
-                    TransactionStatus.COMPLETED,
-                    TransactionDirection.CREDIT,
-                    money,
-                    description
-            );
-            insertOperationStepLog(
-                    operationId,
-                    OperationStep.TRANSACTION_RECORDED,
-                    occurredAt,
-                    "Transaction history recorded for transfer " + sourceWalletId + " to " + targetWalletId
-            );
-            insertLedgerEntry(
-                    nextId("ledger", "ledger_entry_id_seq"),
-                    operationId,
-                    sourceWalletId,
-                    occurredAt,
-                    TransactionType.TRANSFER,
-                    TransactionDirection.DEBIT,
-                    money,
-                    updatedSourceBalance.money(),
-                    description
-            );
-            insertLedgerEntry(
-                    nextId("ledger", "ledger_entry_id_seq"),
-                    operationId,
-                    targetWalletId,
-                    occurredAt,
-                    TransactionType.TRANSFER,
-                    TransactionDirection.CREDIT,
-                    money,
-                    updatedTargetBalance.money(),
-                    description
-            );
-            insertOperationStepLog(
-                    operationId,
-                    OperationStep.LEDGER_RECORDED,
-                    occurredAt,
-                    "Ledger entries recorded for transfer " + sourceWalletId + " to " + targetWalletId
-            );
-            insertAuditEvent(
-                    nextId("audit", "audit_event_id_seq"),
-                    operationId,
-                    AuditEventType.TRANSFER_COMPLETED,
-                    occurredAt,
-                    "Transfer completed from " + sourceWalletId + " to " + targetWalletId,
-                    List.of(sourceWalletId, targetWalletId)
-            );
-            insertOperationStepLog(
-                    operationId,
-                    OperationStep.AUDIT_RECORDED,
-                    occurredAt,
-                    "Audit event recorded for operation " + operationId
-            );
-
-            WalletOperationResult result = new WalletOperationResult(
-                    operationId,
-                    sourceTransactionId,
-                    sourceWalletId,
-                    targetWalletId,
-                    occurredAt,
-                    TransactionType.TRANSFER,
-                    TransactionStatus.COMPLETED,
-                    TransactionDirection.DEBIT,
-                    money,
-                    updatedSourceBalance,
-                    description
-            );
-            WalletOperationRecord record = new WalletOperationRecord(idempotencyKey, fingerprint, result);
-            insertOperation(record);
-            insertOperationStepLog(
-                    operationId,
-                    OperationStep.IDEMPOTENCY_RECORDED,
-                    occurredAt,
-                    "Idempotency record stored for operation " + operationId
-            );
-            insertOutboxEvent(result);
-            return record;
-        });
+        return walletLedger.applyTransfer(
+                idempotencyKey, fingerprint, sourceWalletId, targetWalletId, money, description, occurredAt);
     }
 
-    private WalletOperationRecord executeWithLockTimeout(Supplier<WalletOperationRecord> operation) {
-        try {
-            return transactionTemplate.execute(status -> {
-                applyLockTimeout();
-                return operation.get();
-            });
-        } catch (DataAccessException exception) {
-            if (!causedByLockTimeout(exception)) {
-                throw exception;
-            }
-            throw new WalletConcurrencyException(BUSY_BALANCE_MESSAGE, exception);
-        }
+    // --- OperationOutboxRelayRepository / OperationOutboxRelayRunRepository ---
+
+    @Override
+    public List<OperationOutboxEvent> findPendingOutboxEvents(int limit) {
+        return outboxRelay.findPendingOutboxEvents(limit);
     }
 
-    private boolean causedByLockTimeout(DataAccessException exception) {
-        if (exception instanceof CannotAcquireLockException) {
-            return true;
-        }
-
-        Throwable cause = exception;
-        while (cause != null) {
-            if (cause instanceof SQLException sqlException && "55P03".equals(sqlException.getSQLState())) {
-                return true;
-            }
-            cause = cause.getCause();
-        }
-
-        return false;
+    @Override
+    public long countPendingOutboxEvents() {
+        return outboxRelay.countPendingOutboxEvents();
     }
 
-    private void applyLockTimeout() {
-        try {
-            jdbcTemplate.execute("set local lock_timeout = '" + LOCK_TIMEOUT_MILLIS + "ms'");
-        } catch (BadSqlGrammarException exception) {
-            jdbcTemplate.execute("set lock_timeout " + LOCK_TIMEOUT_MILLIS);
-        }
+    @Override
+    public List<OperationOutboxEvent> findManualReviewOutboxEvents(int limit) {
+        return outboxRelay.findManualReviewOutboxEvents(limit);
     }
 
-    private WalletBalance findBalanceForUpdate(String walletId) {
-        return queryOptional(
-                "select wallet_id, amount, currency, as_of from wallet_balances where wallet_id = ? for update",
-                walletBalanceMapper(),
-                walletId
-        )
-                .orElseThrow(() -> new WalletNotFoundException(walletId));
+    @Override
+    public List<OperationOutboxRequeueAudit> findOutboxRequeueAudits(String outboxEventId) {
+        return outboxRelay.findOutboxRequeueAudits(outboxEventId);
     }
 
-    private List<WalletBalance> findTransferBalancesForUpdate(String sourceWalletId, String targetWalletId) {
-        List<String> walletIds = List.of(sourceWalletId, targetWalletId).stream()
-                .sorted()
-                .toList();
-
-        return jdbcTemplate.query(
-                """
-                        select wallet_id, amount, currency, as_of
-                        from wallet_balances
-                        where wallet_id in (?, ?)
-                        order by wallet_id
-                        for update
-                        """,
-                walletBalanceMapper(),
-                walletIds.get(0),
-                walletIds.get(1)
-        );
+    @Override
+    public List<OperationOutboxRequeueRequestRecord> findOutboxRequeueRequests(String outboxEventId) {
+        return outboxRelay.findOutboxRequeueRequests(outboxEventId);
     }
 
-    private WalletBalance findLockedBalance(List<WalletBalance> lockedBalances, String walletId) {
-        return lockedBalances.stream()
-                .filter(walletBalance -> walletBalance.walletId().equals(walletId))
-                .findFirst()
-                .orElseThrow(() -> new WalletNotFoundException(walletId));
+    @Override
+    public List<OperationOutboxEvent> claimReadyOutboxEvents(int limit, Instant now, Instant leaseExpiresAt) {
+        return outboxRelay.claimReadyOutboxEvents(limit, now, leaseExpiresAt);
     }
 
-    private void updateBalance(WalletBalance walletBalance) {
-        jdbcTemplate.update(
-                "update wallet_balances set amount = ?, currency = ?, as_of = ? where wallet_id = ?",
-                walletBalance.money().amount(),
-                walletBalance.money().currency(),
-                timestamp(walletBalance.asOf()),
-                walletBalance.walletId()
-        );
+    @Override
+    public void markOutboxEventPublished(String outboxEventId, Instant publishedAt) {
+        outboxRelay.markOutboxEventPublished(outboxEventId, publishedAt);
     }
 
-    private void insertTransaction(
-            String transactionId,
-            String walletId,
-            Instant occurredAt,
-            TransactionType type,
-            TransactionStatus status,
-            TransactionDirection direction,
-            Money money,
-            String description
+    @Override
+    public void markClaimedOutboxEventPublished(
+            String outboxEventId,
+            Instant claimedAt,
+            Instant leaseExpiresAt,
+            Instant publishedAt
     ) {
-        jdbcTemplate.update(
-                """
-                        insert into transaction_history (
-                            transaction_id, wallet_id, occurred_at, type, status, direction, amount, currency, description
-                        )
-                        values (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                        """,
-                transactionId,
-                walletId,
-                timestamp(occurredAt),
-                type.name(),
-                status.name(),
-                direction.name(),
-                money.amount(),
-                money.currency(),
-                description
-        );
+        outboxRelay.markClaimedOutboxEventPublished(outboxEventId, claimedAt, leaseExpiresAt, publishedAt);
     }
 
-    private void insertLedgerEntry(
-            String ledgerEntryId,
-            String operationId,
-            String walletId,
-            Instant occurredAt,
-            TransactionType type,
-            TransactionDirection direction,
-            Money money,
-            Money balanceAfter,
-            String description
+    @Override
+    public void markOutboxEventFailed(String outboxEventId, String lastError, Instant nextRetryAt, int maxAttempts) {
+        outboxRelay.markOutboxEventFailed(outboxEventId, lastError, nextRetryAt, maxAttempts);
+    }
+
+    @Override
+    public void markClaimedOutboxEventFailed(
+            String outboxEventId,
+            Instant claimedAt,
+            Instant leaseExpiresAt,
+            String lastError,
+            Instant nextRetryAt,
+            int maxAttempts
     ) {
-        jdbcTemplate.update(
-                """
-                        insert into ledger_entries (
-                            ledger_entry_id, operation_id, wallet_id, occurred_at, type, direction,
-                            amount, currency, balance_after_amount, balance_after_currency, description
-                        )
-                        values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                        """,
-                ledgerEntryId,
-                operationId,
-                walletId,
-                timestamp(occurredAt),
-                type.name(),
-                direction.name(),
-                money.amount(),
-                money.currency(),
-                balanceAfter.amount(),
-                balanceAfter.currency(),
-                description
-        );
+        outboxRelay.markClaimedOutboxEventFailed(
+                outboxEventId, claimedAt, leaseExpiresAt, lastError, nextRetryAt, maxAttempts);
     }
 
-    private void insertAuditEvent(
-            String auditEventId,
-            String operationId,
-            AuditEventType type,
-            Instant occurredAt,
-            String detail,
-            List<String> walletIds
+    @Override
+    public void requeueManualReviewOutboxEvent(
+            String outboxEventId,
+            Instant requeuedAt,
+            String operator,
+            String reason
     ) {
-        jdbcTemplate.update(
-                """
-                        insert into audit_events (audit_event_id, operation_id, type, occurred_at, detail)
-                        values (?, ?, ?, ?, ?)
-                        """,
-                auditEventId,
-                operationId,
-                type.name(),
-                timestamp(occurredAt),
-                detail
-        );
-        for (String walletId : walletIds) {
-            jdbcTemplate.update(
-                    """
-                            insert into audit_event_wallets (audit_event_id, wallet_id)
-                            values (?, ?)
-                            """,
-                    auditEventId,
-                    walletId
-            );
-        }
+        outboxRelay.requeueManualReviewOutboxEvent(outboxEventId, requeuedAt, operator, reason);
     }
 
-    private void insertOperation(WalletOperationRecord record) {
-        WalletOperationResult result = record.result();
-        jdbcTemplate.update(
-                """
-                        insert into wallet_operations (
-                            idempotency_key, fingerprint, operation_id, transaction_id, wallet_id, counterparty_wallet_id,
-                            occurred_at, type, status, direction, amount, currency, balance_wallet_id,
-                            balance_amount, balance_currency, balance_as_of, description
-                        )
-                        values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                        """,
-                record.idempotencyKey(),
-                record.fingerprint(),
-                result.operationId(),
-                result.transactionId(),
-                result.walletId(),
-                result.counterpartyWalletId(),
-                timestamp(result.occurredAt()),
-                result.type().name(),
-                result.status().name(),
-                result.direction().name(),
-                result.money().amount(),
-                result.money().currency(),
-                result.balance().walletId(),
-                result.balance().money().amount(),
-                result.balance().money().currency(),
-                timestamp(result.balance().asOf()),
-                result.description()
-        );
-    }
-
-    private void insertOperationStepLog(
-            String operationId,
-            OperationStep step,
-            Instant occurredAt,
-            String detail
+    @Override
+    public OperationOutboxRequeueRequestRecord requestManualReviewRequeue(
+            String outboxEventId,
+            Instant requestedAt,
+            String requestedBy,
+            String reason
     ) {
-        jdbcTemplate.update(
-                """
-                        insert into operation_step_logs (
-                            operation_step_log_id, operation_id, step, status, occurred_at, detail
-                        )
-                        values (?, ?, ?, ?, ?, ?)
-                        """,
-                nextId("step", "operation_step_log_id_seq"),
-                operationId,
-                step.name(),
-                TransactionStatus.COMPLETED.name(),
-                timestamp(occurredAt),
-                detail
-        );
+        return outboxRelay.requestManualReviewRequeue(outboxEventId, requestedAt, requestedBy, reason);
     }
 
-    private void insertOutboxEvent(WalletOperationResult result) {
-        jdbcTemplate.update(
-                """
-                        insert into operation_outbox_events (
-                            outbox_event_id, operation_id, event_type, aggregate_type,
-                            aggregate_id, payload, status, occurred_at,
-                            attempt_count, next_retry_at, claimed_at, lease_expires_at,
-                            published_at, last_error
-                        )
-                        values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                        """,
-                nextId("outbox", "outbox_event_id_seq"),
-                result.operationId(),
-                result.type().name() + "_COMPLETED",
-                "WALLET_OPERATION",
-                result.operationId(),
-                outboxPayload(result),
-                OperationOutboxStatus.PENDING.name(),
-                timestamp(result.occurredAt()),
-                0,
-                null,
-                null,
-                null,
-                null,
-                null
-        );
+    @Override
+    public OperationOutboxRequeueRequestRecord approveManualReviewRequeueRequest(
+            String requestId,
+            Instant approvedAt,
+            String approvedBy,
+            String approvalReason
+    ) {
+        return outboxRelay.approveManualReviewRequeueRequest(requestId, approvedAt, approvedBy, approvalReason);
     }
 
-    private String outboxPayload(WalletOperationResult result) {
-        return """
-                {"operationId":"%s","walletId":"%s","counterpartyWalletId":%s,"type":"%s","amount":"%s","currency":"%s"}
-                """.formatted(
-                result.operationId(),
-                result.walletId(),
-                nullableJsonString(result.counterpartyWalletId()),
-                result.type().name(),
-                result.money().amount().stripTrailingZeros().toPlainString(),
-                result.money().currency()
-        ).trim();
+    @Override
+    public OperationOutboxRequeueRequestRecord rejectManualReviewRequeueRequest(
+            String requestId,
+            Instant rejectedAt,
+            String rejectedBy,
+            String rejectionReason
+    ) {
+        return outboxRelay.rejectManualReviewRequeueRequest(requestId, rejectedAt, rejectedBy, rejectionReason);
     }
 
-    private String nullableJsonString(String value) {
-        if (value == null) {
-            return "null";
-        }
-        return "\"" + value + "\"";
+    @Override
+    public OperationOutboxRequeueRequestRecord executeManualReviewRequeueRequest(
+            String requestId,
+            Instant executedAt,
+            String executedBy
+    ) {
+        return outboxRelay.executeManualReviewRequeueRequest(requestId, executedAt, executedBy);
     }
 
-    private String nextId(String prefix, String sequenceName) {
-        Long nextValue = jdbcTemplate.queryForObject("select nextval('" + sequenceName + "')", Long.class);
-        return "%s-%03d".formatted(prefix, nextValue);
+    @Override
+    public String nextRelayRunId() {
+        return outboxRelay.nextRelayRunId();
     }
 
-    private String placeholders(int count) {
-        return String.join(", ", Collections.nCopies(count, "?"));
+    @Override
+    public void saveOutboxRelayRun(OperationOutboxRelayRun relayRun) {
+        outboxRelay.saveOutboxRelayRun(relayRun);
     }
 
-    private <T> Optional<T> queryOptional(String sql, RowMapper<T> rowMapper, Object... args) {
-        try {
-            return Optional.ofNullable(jdbcTemplate.queryForObject(sql, rowMapper, args));
-        } catch (EmptyResultDataAccessException exception) {
-            return Optional.empty();
-        }
+    @Override
+    public List<OperationOutboxRelayRun> findRecentOutboxRelayRuns(int limit) {
+        return outboxRelay.findRecentOutboxRelayRuns(limit);
     }
 
-    private OperationOutboxEvent manualReviewOutboxEvent(String outboxEventId) {
-        return queryOptional(
-                """
-                        select outbox_event_id, operation_id, event_type, aggregate_type,
-                               aggregate_id, payload, status, occurred_at,
-                               attempt_count, next_retry_at, claimed_at, lease_expires_at,
-                               published_at, last_error
-                        from operation_outbox_events
-                        where outbox_event_id = ?
-                          and status = ?
-                        """,
-                operationOutboxEventMapper(),
-                outboxEventId,
-                OperationOutboxStatus.MANUAL_REVIEW.name()
-        )
-                .orElseThrow(() -> new InvalidWalletOperationException("manual review outbox event not found: " + outboxEventId));
+    @Override
+    public int deleteOutboxRelayRunsCompletedBefore(Instant cutoff) {
+        return outboxRelay.deleteOutboxRelayRunsCompletedBefore(cutoff);
     }
 
-    private OperationOutboxEvent manualReviewOutboxEventForUpdate(String outboxEventId) {
-        return queryOptional(
-                """
-                        select outbox_event_id, operation_id, event_type, aggregate_type,
-                               aggregate_id, payload, status, occurred_at,
-                               attempt_count, next_retry_at, claimed_at, lease_expires_at,
-                               published_at, last_error
-                        from operation_outbox_events
-                        where outbox_event_id = ?
-                          and status = ?
-                        for update
-                        """,
-                operationOutboxEventMapper(),
-                outboxEventId,
-                OperationOutboxStatus.MANUAL_REVIEW.name()
-        )
-                .orElseThrow(() -> new InvalidWalletOperationException("manual review outbox event not found: " + outboxEventId));
+    // --- Outbox consumer (idempotency / receipt / delivery metric / monitoring / pruning) ---
+
+    @Override
+    public boolean recordProcessedEvent(
+            String idempotencyKey,
+            String outboxEventId,
+            String eventType,
+            Instant processedAt
+    ) {
+        return outboxConsumer.recordProcessedEvent(idempotencyKey, outboxEventId, eventType, processedAt);
     }
 
-    private OperationOutboxRequeueRequestRecord requeueRequest(String requestId) {
-        return queryOptional(
-                """
-                        select request_id, outbox_event_id, operation_id, status, requested_by,
-                               request_reason, requested_at, approved_by, approved_at, approval_reason,
-                               executed_by, executed_at, rejected_by, rejected_at, rejection_reason
-                        from operation_outbox_requeue_requests
-                        where request_id = ?
-                        """,
-                outboxRequeueRequestMapper(),
-                requestId
-        )
-                .orElseThrow(() -> new InvalidWalletOperationException("requeue request not found: " + requestId));
+    @Override
+    public Optional<OperationOutboxConsumerProcessedEvent> findProcessedEvent(String idempotencyKey) {
+        return outboxConsumer.findProcessedEvent(idempotencyKey);
     }
 
-    private OperationOutboxRequeueRequestRecord requeueRequestForUpdate(String requestId) {
-        return queryOptional(
-                """
-                        select request_id, outbox_event_id, operation_id, status, requested_by,
-                               request_reason, requested_at, approved_by, approved_at, approval_reason,
-                               executed_by, executed_at, rejected_by, rejected_at, rejection_reason
-                        from operation_outbox_requeue_requests
-                        where request_id = ?
-                        for update
-                        """,
-                outboxRequeueRequestMapper(),
-                requestId
-        )
-                .orElseThrow(() -> new InvalidWalletOperationException("requeue request not found: " + requestId));
+    @Override
+    public void saveConsumerReceipt(OperationOutboxConsumerReceipt receipt) {
+        outboxConsumer.saveConsumerReceipt(receipt);
     }
 
-    private void requireSingleRowUpdate(int updatedRows, String message) {
-        if (updatedRows != 1) {
-            throw new InvalidWalletOperationException(message);
-        }
+    @Override
+    public Optional<OperationOutboxConsumerReceipt> findConsumerReceipt(String idempotencyKey) {
+        return outboxConsumer.findConsumerReceipt(idempotencyKey);
     }
 
-    private RowMapper<Member> memberMapper() {
-        return (resultSet, rowNumber) -> new Member(
-                resultSet.getString("member_id"),
-                MemberStatus.valueOf(resultSet.getString("status")),
-                instant(resultSet, "created_at")
-        );
+    @Override
+    public void recordConsumerDeliveryMetric(Instant occurredAt, boolean duplicate) {
+        outboxConsumer.recordConsumerDeliveryMetric(occurredAt, duplicate);
     }
 
-    private RowMapper<WalletAccount> walletAccountMapper() {
-        return (resultSet, rowNumber) -> new WalletAccount(
-                resultSet.getString("wallet_id"),
-                resultSet.getString("member_id"),
-                WalletAccountStatus.valueOf(resultSet.getString("status")),
-                instant(resultSet, "created_at")
-        );
+    @Override
+    public OperationOutboxConsumerMetrics getConsumerMetrics() {
+        return outboxConsumer.getConsumerMetrics();
     }
 
-    private RowMapper<WalletBalance> walletBalanceMapper() {
-        return (resultSet, rowNumber) -> new WalletBalance(
-                resultSet.getString("wallet_id"),
-                money(resultSet, "amount", "currency"),
-                instant(resultSet, "as_of")
-        );
+    @Override
+    public OperationOutboxConsumerWindowMetrics getConsumerWindowMetrics(
+            Instant windowStartedAt,
+            Instant windowEndedAt
+    ) {
+        return outboxConsumer.getConsumerWindowMetrics(windowStartedAt, windowEndedAt);
     }
 
-    private RowMapper<TransactionHistoryItem> transactionHistoryMapper() {
-        return (resultSet, rowNumber) -> new TransactionHistoryItem(
-                resultSet.getString("transaction_id"),
-                resultSet.getString("wallet_id"),
-                instant(resultSet, "occurred_at"),
-                TransactionType.valueOf(resultSet.getString("type")),
-                TransactionStatus.valueOf(resultSet.getString("status")),
-                TransactionDirection.valueOf(resultSet.getString("direction")),
-                money(resultSet, "amount", "currency"),
-                resultSet.getString("description")
-        );
+    @Override
+    public List<OperationOutboxConsumerReceipt> findRecentConsumerReceipts(int limit) {
+        return outboxConsumer.findRecentConsumerReceipts(limit);
     }
 
-    private RowMapper<LedgerEntry> ledgerEntryMapper() {
-        return (resultSet, rowNumber) -> new LedgerEntry(
-                resultSet.getString("ledger_entry_id"),
-                resultSet.getString("operation_id"),
-                resultSet.getString("wallet_id"),
-                instant(resultSet, "occurred_at"),
-                TransactionType.valueOf(resultSet.getString("type")),
-                TransactionDirection.valueOf(resultSet.getString("direction")),
-                money(resultSet, "amount", "currency"),
-                money(resultSet, "balance_after_amount", "balance_after_currency"),
-                resultSet.getString("description")
-        );
+    @Override
+    public int deleteConsumerProcessedEventsProcessedBefore(Instant cutoff) {
+        return outboxConsumer.deleteConsumerProcessedEventsProcessedBefore(cutoff);
     }
 
-    private RowMapper<AuditEvent> auditEventMapper() {
-        return (resultSet, rowNumber) -> new AuditEvent(
-                resultSet.getString("audit_event_id"),
-                resultSet.getString("operation_id"),
-                AuditEventType.valueOf(resultSet.getString("type")),
-                instant(resultSet, "occurred_at"),
-                resultSet.getString("detail")
-        );
+    @Override
+    public int deleteConsumerReceiptsReceivedBefore(Instant cutoff) {
+        return outboxConsumer.deleteConsumerReceiptsReceivedBefore(cutoff);
     }
 
-    private RowMapper<OperationStepLog> operationStepLogMapper() {
-        return (resultSet, rowNumber) -> new OperationStepLog(
-                resultSet.getString("operation_step_log_id"),
-                resultSet.getString("operation_id"),
-                OperationStep.valueOf(resultSet.getString("step")),
-                TransactionStatus.valueOf(resultSet.getString("status")),
-                instant(resultSet, "occurred_at"),
-                resultSet.getString("detail")
-        );
+    @Override
+    public int deleteConsumerDeliveryMetricsBucketStartedBefore(Instant cutoff) {
+        return outboxConsumer.deleteConsumerDeliveryMetricsBucketStartedBefore(cutoff);
     }
 
-    private RowMapper<OperationOutboxEvent> operationOutboxEventMapper() {
-        return (resultSet, rowNumber) -> new OperationOutboxEvent(
-                resultSet.getString("outbox_event_id"),
-                resultSet.getString("operation_id"),
-                resultSet.getString("event_type"),
-                resultSet.getString("aggregate_type"),
-                resultSet.getString("aggregate_id"),
-                resultSet.getString("payload"),
-                OperationOutboxStatus.valueOf(resultSet.getString("status")),
-                instant(resultSet, "occurred_at"),
-                resultSet.getInt("attempt_count"),
-                nullableInstant(resultSet, "next_retry_at"),
-                nullableInstant(resultSet, "claimed_at"),
-                nullableInstant(resultSet, "lease_expires_at"),
-                nullableInstant(resultSet, "published_at"),
-                resultSet.getString("last_error")
-        );
+    // --- OperationalAlertRepository ---
+
+    @Override
+    public String nextOperationalAlertId() {
+        return operationalAlert.nextOperationalAlertId();
     }
 
-    private RowMapper<OperationOutboxRequeueAudit> outboxRequeueAuditMapper() {
-        return (resultSet, rowNumber) -> new OperationOutboxRequeueAudit(
-                resultSet.getString("audit_id"),
-                resultSet.getString("outbox_event_id"),
-                resultSet.getString("operation_id"),
-                instant(resultSet, "requeued_at"),
-                resultSet.getString("operator_name"),
-                resultSet.getString("reason")
-        );
+    @Override
+    public void saveOperationalAlert(OperationalAlert operationalAlertRecord) {
+        operationalAlert.saveOperationalAlert(operationalAlertRecord);
     }
 
-    private RowMapper<OperationOutboxRequeueRequestRecord> outboxRequeueRequestMapper() {
-        return (resultSet, rowNumber) -> new OperationOutboxRequeueRequestRecord(
-                resultSet.getString("request_id"),
-                resultSet.getString("outbox_event_id"),
-                resultSet.getString("operation_id"),
-                OperationOutboxRequeueRequestStatus.valueOf(resultSet.getString("status")),
-                resultSet.getString("requested_by"),
-                resultSet.getString("request_reason"),
-                instant(resultSet, "requested_at"),
-                resultSet.getString("approved_by"),
-                nullableInstant(resultSet, "approved_at"),
-                resultSet.getString("approval_reason"),
-                resultSet.getString("executed_by"),
-                nullableInstant(resultSet, "executed_at"),
-                resultSet.getString("rejected_by"),
-                nullableInstant(resultSet, "rejected_at"),
-                resultSet.getString("rejection_reason")
-        );
+    @Override
+    public boolean existsOperationalAlertBetween(
+            String source,
+            OperationalAlertSeverity severity,
+            List<String> reasons,
+            Instant since,
+            Instant until
+    ) {
+        return operationalAlert.existsOperationalAlertBetween(source, severity, reasons, since, until);
     }
 
-    private RowMapper<OperationOutboxRelayRun> operationOutboxRelayRunMapper() {
-        return (resultSet, rowNumber) -> new OperationOutboxRelayRun(
-                resultSet.getString("relay_run_id"),
-                instant(resultSet, "started_at"),
-                instant(resultSet, "completed_at"),
-                OperationOutboxRelayRunStatus.valueOf(resultSet.getString("status")),
-                resultSet.getInt("batch_size"),
-                resultSet.getInt("claimed_count"),
-                resultSet.getInt("published_count"),
-                resultSet.getInt("failed_count"),
-                resultSet.getString("error_message")
-        );
+    @Override
+    public List<OperationalAlert> findRecentOperationalAlerts(int limit) {
+        return operationalAlert.findRecentOperationalAlerts(limit);
     }
 
-    private RowMapper<AdminApiAccessAudit> adminApiAccessAuditMapper() {
-        return (resultSet, rowNumber) -> new AdminApiAccessAudit(
-                resultSet.getString("audit_id"),
-                instant(resultSet, "occurred_at"),
-                resultSet.getString("method"),
-                resultSet.getString("path"),
-                resultSet.getString("operator_id"),
-                resultSet.getInt("status_code"),
-                AdminApiAccessOutcome.valueOf(resultSet.getString("outcome"))
-        );
+    @Override
+    public int deleteOperationalAlertsOccurredBefore(Instant cutoff) {
+        return operationalAlert.deleteOperationalAlertsOccurredBefore(cutoff);
     }
 
-    private RowMapper<OperationalAlert> operationalAlertMapper() {
-        return (resultSet, rowNumber) -> new OperationalAlert(
-                resultSet.getString("alert_id"),
-                resultSet.getString("source"),
-                OperationalAlertSeverity.valueOf(resultSet.getString("severity")),
-                instant(resultSet, "occurred_at"),
-                List.of(resultSet.getString("reasons").split("\\n"))
-        );
+    // --- AdminApiAccessAuditRepository ---
+
+    @Override
+    public String nextAdminApiAccessAuditId() {
+        return adminApiAccessAudit.nextAdminApiAccessAuditId();
     }
 
-    private RowMapper<OperationOutboxConsumerProcessedEvent> operationOutboxConsumerProcessedEventMapper() {
-        return (resultSet, rowNumber) -> new OperationOutboxConsumerProcessedEvent(
-                resultSet.getString("idempotency_key"),
-                resultSet.getString("outbox_event_id"),
-                resultSet.getString("event_type"),
-                instant(resultSet, "processed_at"),
-                resultSet.getInt("duplicate_count")
-        );
+    @Override
+    public void saveAdminApiAccessAudit(AdminApiAccessAudit accessAudit) {
+        adminApiAccessAudit.saveAdminApiAccessAudit(accessAudit);
     }
 
-    private RowMapper<OperationOutboxConsumerReceipt> operationOutboxConsumerReceiptMapper() {
-        return (resultSet, rowNumber) -> new OperationOutboxConsumerReceipt(
-                resultSet.getString("idempotency_key"),
-                resultSet.getString("outbox_event_id"),
-                resultSet.getString("operation_id"),
-                resultSet.getString("event_type"),
-                resultSet.getString("aggregate_type"),
-                resultSet.getString("aggregate_id"),
-                instant(resultSet, "received_at")
-        );
+    @Override
+    public List<AdminApiAccessAudit> findRecentAdminApiAccessAudits(int limit) {
+        return adminApiAccessAudit.findRecentAdminApiAccessAudits(limit);
     }
 
-    private RowMapper<WalletOperationRecord> operationRecordMapper() {
-        return (resultSet, rowNumber) -> new WalletOperationRecord(
-                resultSet.getString("idempotency_key"),
-                resultSet.getString("fingerprint"),
-                new WalletOperationResult(
-                        resultSet.getString("operation_id"),
-                        resultSet.getString("transaction_id"),
-                        resultSet.getString("wallet_id"),
-                        resultSet.getString("counterparty_wallet_id"),
-                        instant(resultSet, "occurred_at"),
-                        TransactionType.valueOf(resultSet.getString("type")),
-                        TransactionStatus.valueOf(resultSet.getString("status")),
-                        TransactionDirection.valueOf(resultSet.getString("direction")),
-                        money(resultSet, "amount", "currency"),
-                        new WalletBalance(
-                                resultSet.getString("balance_wallet_id"),
-                                money(resultSet, "balance_amount", "balance_currency"),
-                                instant(resultSet, "balance_as_of")
-                        ),
-                        resultSet.getString("description")
-                )
-        );
-    }
-
-    private Money money(ResultSet resultSet, String amountColumn, String currencyColumn) throws SQLException {
-        BigDecimal amount = resultSet.getBigDecimal(amountColumn);
-        String currency = resultSet.getString(currencyColumn);
-        return new Money(amount, currency);
-    }
-
-    private Timestamp timestamp(Instant instant) {
-        if (instant == null) {
-            return null;
-        }
-        return Timestamp.from(instant);
-    }
-
-    private boolean isPostgresDatabase() {
-        return Boolean.TRUE.equals(jdbcTemplate.execute((ConnectionCallback<Boolean>) connection ->
-                "PostgreSQL".equals(connection.getMetaData().getDatabaseProductName())));
-    }
-
-    private Instant instant(ResultSet resultSet, String columnName) throws SQLException {
-        return resultSet.getTimestamp(columnName).toInstant();
-    }
-
-    private Instant nullableInstant(ResultSet resultSet, String columnName) throws SQLException {
-        Timestamp timestamp = resultSet.getTimestamp(columnName);
-        if (timestamp == null) {
-            return null;
-        }
-        return timestamp.toInstant();
+    @Override
+    public int deleteAdminApiAccessAuditsOccurredBefore(Instant cutoff) {
+        return adminApiAccessAudit.deleteAdminApiAccessAuditsOccurredBefore(cutoff);
     }
 }

--- a/src/main/java/com/imwoo/airepo/wallet/infra/WalletJdbcSupport.java
+++ b/src/main/java/com/imwoo/airepo/wallet/infra/WalletJdbcSupport.java
@@ -1,0 +1,330 @@
+package com.imwoo.airepo.wallet.infra;
+
+import com.imwoo.airepo.wallet.application.InvalidWalletOperationException;
+import com.imwoo.airepo.wallet.domain.AdminApiAccessAudit;
+import com.imwoo.airepo.wallet.domain.AdminApiAccessOutcome;
+import com.imwoo.airepo.wallet.domain.AuditEvent;
+import com.imwoo.airepo.wallet.domain.AuditEventType;
+import com.imwoo.airepo.wallet.domain.LedgerEntry;
+import com.imwoo.airepo.wallet.domain.Member;
+import com.imwoo.airepo.wallet.domain.MemberStatus;
+import com.imwoo.airepo.wallet.domain.Money;
+import com.imwoo.airepo.wallet.domain.OperationOutboxConsumerProcessedEvent;
+import com.imwoo.airepo.wallet.domain.OperationOutboxConsumerReceipt;
+import com.imwoo.airepo.wallet.domain.OperationOutboxEvent;
+import com.imwoo.airepo.wallet.domain.OperationOutboxRequeueAudit;
+import com.imwoo.airepo.wallet.domain.OperationOutboxRequeueRequestRecord;
+import com.imwoo.airepo.wallet.domain.OperationOutboxRequeueRequestStatus;
+import com.imwoo.airepo.wallet.domain.OperationOutboxRelayRun;
+import com.imwoo.airepo.wallet.domain.OperationOutboxRelayRunStatus;
+import com.imwoo.airepo.wallet.domain.OperationOutboxStatus;
+import com.imwoo.airepo.wallet.domain.OperationStep;
+import com.imwoo.airepo.wallet.domain.OperationStepLog;
+import com.imwoo.airepo.wallet.domain.OperationalAlert;
+import com.imwoo.airepo.wallet.domain.OperationalAlertSeverity;
+import com.imwoo.airepo.wallet.domain.TransactionDirection;
+import com.imwoo.airepo.wallet.domain.TransactionHistoryItem;
+import com.imwoo.airepo.wallet.domain.TransactionStatus;
+import com.imwoo.airepo.wallet.domain.TransactionType;
+import com.imwoo.airepo.wallet.domain.WalletAccount;
+import com.imwoo.airepo.wallet.domain.WalletAccountStatus;
+import com.imwoo.airepo.wallet.domain.WalletBalance;
+import com.imwoo.airepo.wallet.application.WalletOperationRecord;
+import com.imwoo.airepo.wallet.application.WalletOperationResult;
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Optional;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.ConnectionCallback;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Shared JDBC infrastructure for the wallet persistence adapters.
+ *
+ * <p>Holds the {@link JdbcTemplate}/{@link TransactionTemplate} and centralises the
+ * {@link RowMapper}s, id/timestamp helpers, and transaction patterns that each bounded-context
+ * adapter reuses. Package-private on purpose: it is an implementation detail of the
+ * {@code infra} package and never leaves it.
+ */
+final class WalletJdbcSupport {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final TransactionTemplate transactionTemplate;
+
+    WalletJdbcSupport(JdbcTemplate jdbcTemplate, TransactionTemplate transactionTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.transactionTemplate = transactionTemplate;
+    }
+
+    JdbcTemplate jdbc() {
+        return jdbcTemplate;
+    }
+
+    TransactionTemplate transaction() {
+        return transactionTemplate;
+    }
+
+    String nextId(String prefix, String sequenceName) {
+        Long nextValue = jdbcTemplate.queryForObject("select nextval('" + sequenceName + "')", Long.class);
+        return "%s-%03d".formatted(prefix, nextValue);
+    }
+
+    String placeholders(int count) {
+        return String.join(", ", Collections.nCopies(count, "?"));
+    }
+
+    <T> Optional<T> queryOptional(String sql, RowMapper<T> rowMapper, Object... args) {
+        try {
+            return Optional.ofNullable(jdbcTemplate.queryForObject(sql, rowMapper, args));
+        } catch (EmptyResultDataAccessException exception) {
+            return Optional.empty();
+        }
+    }
+
+    void requireSingleRowUpdate(int updatedRows, String message) {
+        if (updatedRows != 1) {
+            throw new InvalidWalletOperationException(message);
+        }
+    }
+
+    Timestamp timestamp(Instant instant) {
+        if (instant == null) {
+            return null;
+        }
+        return Timestamp.from(instant);
+    }
+
+    boolean isPostgresDatabase() {
+        return Boolean.TRUE.equals(jdbcTemplate.execute((ConnectionCallback<Boolean>) connection ->
+                "PostgreSQL".equals(connection.getMetaData().getDatabaseProductName())));
+    }
+
+    Money money(ResultSet resultSet, String amountColumn, String currencyColumn) throws SQLException {
+        BigDecimal amount = resultSet.getBigDecimal(amountColumn);
+        String currency = resultSet.getString(currencyColumn);
+        return new Money(amount, currency);
+    }
+
+    Instant instant(ResultSet resultSet, String columnName) throws SQLException {
+        return resultSet.getTimestamp(columnName).toInstant();
+    }
+
+    Instant nullableInstant(ResultSet resultSet, String columnName) throws SQLException {
+        Timestamp timestamp = resultSet.getTimestamp(columnName);
+        if (timestamp == null) {
+            return null;
+        }
+        return timestamp.toInstant();
+    }
+
+    RowMapper<Member> memberMapper() {
+        return (resultSet, rowNumber) -> new Member(
+                resultSet.getString("member_id"),
+                MemberStatus.valueOf(resultSet.getString("status")),
+                instant(resultSet, "created_at")
+        );
+    }
+
+    RowMapper<WalletAccount> walletAccountMapper() {
+        return (resultSet, rowNumber) -> new WalletAccount(
+                resultSet.getString("wallet_id"),
+                resultSet.getString("member_id"),
+                WalletAccountStatus.valueOf(resultSet.getString("status")),
+                instant(resultSet, "created_at")
+        );
+    }
+
+    RowMapper<WalletBalance> walletBalanceMapper() {
+        return (resultSet, rowNumber) -> new WalletBalance(
+                resultSet.getString("wallet_id"),
+                money(resultSet, "amount", "currency"),
+                instant(resultSet, "as_of")
+        );
+    }
+
+    RowMapper<TransactionHistoryItem> transactionHistoryMapper() {
+        return (resultSet, rowNumber) -> new TransactionHistoryItem(
+                resultSet.getString("transaction_id"),
+                resultSet.getString("wallet_id"),
+                instant(resultSet, "occurred_at"),
+                TransactionType.valueOf(resultSet.getString("type")),
+                TransactionStatus.valueOf(resultSet.getString("status")),
+                TransactionDirection.valueOf(resultSet.getString("direction")),
+                money(resultSet, "amount", "currency"),
+                resultSet.getString("description")
+        );
+    }
+
+    RowMapper<LedgerEntry> ledgerEntryMapper() {
+        return (resultSet, rowNumber) -> new LedgerEntry(
+                resultSet.getString("ledger_entry_id"),
+                resultSet.getString("operation_id"),
+                resultSet.getString("wallet_id"),
+                instant(resultSet, "occurred_at"),
+                TransactionType.valueOf(resultSet.getString("type")),
+                TransactionDirection.valueOf(resultSet.getString("direction")),
+                money(resultSet, "amount", "currency"),
+                money(resultSet, "balance_after_amount", "balance_after_currency"),
+                resultSet.getString("description")
+        );
+    }
+
+    RowMapper<AuditEvent> auditEventMapper() {
+        return (resultSet, rowNumber) -> new AuditEvent(
+                resultSet.getString("audit_event_id"),
+                resultSet.getString("operation_id"),
+                AuditEventType.valueOf(resultSet.getString("type")),
+                instant(resultSet, "occurred_at"),
+                resultSet.getString("detail")
+        );
+    }
+
+    RowMapper<OperationStepLog> operationStepLogMapper() {
+        return (resultSet, rowNumber) -> new OperationStepLog(
+                resultSet.getString("operation_step_log_id"),
+                resultSet.getString("operation_id"),
+                OperationStep.valueOf(resultSet.getString("step")),
+                TransactionStatus.valueOf(resultSet.getString("status")),
+                instant(resultSet, "occurred_at"),
+                resultSet.getString("detail")
+        );
+    }
+
+    RowMapper<OperationOutboxEvent> operationOutboxEventMapper() {
+        return (resultSet, rowNumber) -> new OperationOutboxEvent(
+                resultSet.getString("outbox_event_id"),
+                resultSet.getString("operation_id"),
+                resultSet.getString("event_type"),
+                resultSet.getString("aggregate_type"),
+                resultSet.getString("aggregate_id"),
+                resultSet.getString("payload"),
+                OperationOutboxStatus.valueOf(resultSet.getString("status")),
+                instant(resultSet, "occurred_at"),
+                resultSet.getInt("attempt_count"),
+                nullableInstant(resultSet, "next_retry_at"),
+                nullableInstant(resultSet, "claimed_at"),
+                nullableInstant(resultSet, "lease_expires_at"),
+                nullableInstant(resultSet, "published_at"),
+                resultSet.getString("last_error")
+        );
+    }
+
+    RowMapper<OperationOutboxRequeueAudit> outboxRequeueAuditMapper() {
+        return (resultSet, rowNumber) -> new OperationOutboxRequeueAudit(
+                resultSet.getString("audit_id"),
+                resultSet.getString("outbox_event_id"),
+                resultSet.getString("operation_id"),
+                instant(resultSet, "requeued_at"),
+                resultSet.getString("operator_name"),
+                resultSet.getString("reason")
+        );
+    }
+
+    RowMapper<OperationOutboxRequeueRequestRecord> outboxRequeueRequestMapper() {
+        return (resultSet, rowNumber) -> new OperationOutboxRequeueRequestRecord(
+                resultSet.getString("request_id"),
+                resultSet.getString("outbox_event_id"),
+                resultSet.getString("operation_id"),
+                OperationOutboxRequeueRequestStatus.valueOf(resultSet.getString("status")),
+                resultSet.getString("requested_by"),
+                resultSet.getString("request_reason"),
+                instant(resultSet, "requested_at"),
+                resultSet.getString("approved_by"),
+                nullableInstant(resultSet, "approved_at"),
+                resultSet.getString("approval_reason"),
+                resultSet.getString("executed_by"),
+                nullableInstant(resultSet, "executed_at"),
+                resultSet.getString("rejected_by"),
+                nullableInstant(resultSet, "rejected_at"),
+                resultSet.getString("rejection_reason")
+        );
+    }
+
+    RowMapper<OperationOutboxRelayRun> operationOutboxRelayRunMapper() {
+        return (resultSet, rowNumber) -> new OperationOutboxRelayRun(
+                resultSet.getString("relay_run_id"),
+                instant(resultSet, "started_at"),
+                instant(resultSet, "completed_at"),
+                OperationOutboxRelayRunStatus.valueOf(resultSet.getString("status")),
+                resultSet.getInt("batch_size"),
+                resultSet.getInt("claimed_count"),
+                resultSet.getInt("published_count"),
+                resultSet.getInt("failed_count"),
+                resultSet.getString("error_message")
+        );
+    }
+
+    RowMapper<AdminApiAccessAudit> adminApiAccessAuditMapper() {
+        return (resultSet, rowNumber) -> new AdminApiAccessAudit(
+                resultSet.getString("audit_id"),
+                instant(resultSet, "occurred_at"),
+                resultSet.getString("method"),
+                resultSet.getString("path"),
+                resultSet.getString("operator_id"),
+                resultSet.getInt("status_code"),
+                AdminApiAccessOutcome.valueOf(resultSet.getString("outcome"))
+        );
+    }
+
+    RowMapper<OperationalAlert> operationalAlertMapper() {
+        return (resultSet, rowNumber) -> new OperationalAlert(
+                resultSet.getString("alert_id"),
+                resultSet.getString("source"),
+                OperationalAlertSeverity.valueOf(resultSet.getString("severity")),
+                instant(resultSet, "occurred_at"),
+                java.util.List.of(resultSet.getString("reasons").split("\\n"))
+        );
+    }
+
+    RowMapper<OperationOutboxConsumerProcessedEvent> operationOutboxConsumerProcessedEventMapper() {
+        return (resultSet, rowNumber) -> new OperationOutboxConsumerProcessedEvent(
+                resultSet.getString("idempotency_key"),
+                resultSet.getString("outbox_event_id"),
+                resultSet.getString("event_type"),
+                instant(resultSet, "processed_at"),
+                resultSet.getInt("duplicate_count")
+        );
+    }
+
+    RowMapper<OperationOutboxConsumerReceipt> operationOutboxConsumerReceiptMapper() {
+        return (resultSet, rowNumber) -> new OperationOutboxConsumerReceipt(
+                resultSet.getString("idempotency_key"),
+                resultSet.getString("outbox_event_id"),
+                resultSet.getString("operation_id"),
+                resultSet.getString("event_type"),
+                resultSet.getString("aggregate_type"),
+                resultSet.getString("aggregate_id"),
+                instant(resultSet, "received_at")
+        );
+    }
+
+    RowMapper<WalletOperationRecord> operationRecordMapper() {
+        return (resultSet, rowNumber) -> new WalletOperationRecord(
+                resultSet.getString("idempotency_key"),
+                resultSet.getString("fingerprint"),
+                new WalletOperationResult(
+                        resultSet.getString("operation_id"),
+                        resultSet.getString("transaction_id"),
+                        resultSet.getString("wallet_id"),
+                        resultSet.getString("counterparty_wallet_id"),
+                        instant(resultSet, "occurred_at"),
+                        TransactionType.valueOf(resultSet.getString("type")),
+                        TransactionStatus.valueOf(resultSet.getString("status")),
+                        TransactionDirection.valueOf(resultSet.getString("direction")),
+                        money(resultSet, "amount", "currency"),
+                        new WalletBalance(
+                                resultSet.getString("balance_wallet_id"),
+                                money(resultSet, "balance_amount", "balance_currency"),
+                                instant(resultSet, "balance_as_of")
+                        ),
+                        resultSet.getString("description")
+                )
+        );
+    }
+}

--- a/src/test/java/com/imwoo/airepo/wallet/architecture/LayerDependencyTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/architecture/LayerDependencyTest.java
@@ -1,0 +1,57 @@
+package com.imwoo.airepo.wallet.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+@AnalyzeClasses(packages = "com.imwoo.airepo.wallet", importOptions = ImportOption.DoNotIncludeTests.class)
+class LayerDependencyTest {
+
+    @ArchTest
+    static final ArchRule domain_does_not_depend_on_outer_layers = noClasses()
+            .that()
+            .resideInAPackage("..domain..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAnyPackage(
+                    "com.imwoo.airepo.wallet.api..",
+                    "com.imwoo.airepo.wallet.application..",
+                    "com.imwoo.airepo.wallet.infra..",
+                    "com.imwoo.airepo.wallet.config..",
+                    "org.springframework.."
+            );
+
+    @ArchTest
+    static final ArchRule application_does_not_depend_on_adapters = noClasses()
+            .that()
+            .resideInAPackage("..application..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAnyPackage(
+                    "com.imwoo.airepo.wallet.api..",
+                    "com.imwoo.airepo.wallet.infra..",
+                    "com.imwoo.airepo.wallet.config..",
+                    "org.springframework.web..",
+                    "org.springframework.jdbc..",
+                    "org.springframework.security.."
+            );
+
+    @ArchTest
+    static final ArchRule api_does_not_depend_on_infra_or_config = noClasses()
+            .that()
+            .resideInAPackage("..api..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAnyPackage("com.imwoo.airepo.wallet.infra..", "com.imwoo.airepo.wallet.config..");
+
+    @ArchTest
+    static final ArchRule infra_does_not_depend_on_api = noClasses()
+            .that()
+            .resideInAPackage("..infra..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage("com.imwoo.airepo.wallet.api..");
+}

--- a/src/test/java/com/imwoo/airepo/wallet/scenario/PostgresWalletScenarioFlowTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/scenario/PostgresWalletScenarioFlowTest.java
@@ -39,6 +39,10 @@ import org.testcontainers.utility.DockerImageName;
 @AutoConfigureMockMvc
 class PostgresWalletScenarioFlowTest {
 
+    private static final String TEST_JWT_SECRET = "postgres-scenario-jwt-secret-32b!!";
+    private static final String TEST_ADMIN_TOKEN = "postgres-scenario-admin-token";
+    private static final String TEST_OPERATOR_TOKEN = "postgres-scenario-operator-token";
+
     @Container
     private static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>(
             DockerImageName.parse("postgres:17-alpine")
@@ -74,6 +78,9 @@ class PostgresWalletScenarioFlowTest {
         registry.add("spring.datasource.driver-class-name", POSTGRES::getDriverClassName);
         registry.add("spring.flyway.enabled", () -> "true");
         registry.add("spring.flyway.locations", () -> "classpath:db/migration");
+        registry.add("ai-repo.auth.jwt.secret", () -> TEST_JWT_SECRET);
+        registry.add("ai-repo.ops.admin-token", () -> TEST_ADMIN_TOKEN);
+        registry.add("ai-repo.ops.operator-token", () -> TEST_OPERATOR_TOKEN);
     }
 
     @Test
@@ -134,17 +141,17 @@ class PostgresWalletScenarioFlowTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", hasSize(2)));
         mockMvc.perform(get("/api/v1/audit-events")
-                        .header("X-Operator-Token", "local-operator-token")
+                        .header("X-Operator-Token", TEST_OPERATOR_TOKEN)
                         .header("X-Operator-Id", "postgres-ops"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", hasSize(2)));
         mockMvc.perform(get("/api/v1/operations/op-001/step-logs")
-                        .header("X-Operator-Token", "local-operator-token")
+                        .header("X-Operator-Token", TEST_OPERATOR_TOKEN)
                         .header("X-Operator-Id", "postgres-ops"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", hasSize(6)));
         mockMvc.perform(get("/api/v1/operations/op-002/outbox-events")
-                        .header("X-Operator-Token", "local-operator-token")
+                        .header("X-Operator-Token", TEST_OPERATOR_TOKEN)
                         .header("X-Operator-Id", "postgres-ops"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", hasSize(1)))
@@ -158,12 +165,12 @@ class PostgresWalletScenarioFlowTest {
                 });
 
         mockMvc.perform(get("/api/v1/operations/op-001/outbox-events")
-                        .header("X-Operator-Token", "local-operator-token")
+                        .header("X-Operator-Token", TEST_OPERATOR_TOKEN)
                         .header("X-Operator-Id", "postgres-ops"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].status").value("PUBLISHED"));
         mockMvc.perform(get("/api/v1/operations/op-002/outbox-events")
-                        .header("X-Operator-Token", "local-operator-token")
+                        .header("X-Operator-Token", TEST_OPERATOR_TOKEN)
                         .header("X-Operator-Id", "postgres-ops"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].status").value("PUBLISHED"));

--- a/wiki-drafts/Architecture-Decisions.md
+++ b/wiki-drafts/Architecture-Decisions.md
@@ -80,6 +80,9 @@
    - ADR-0055 Admin API Path Matching Hardening
    - ADR-0056 End-User JWT Auth and Wallet Ownership
    - ADR-0057 End-User Login and Bearer Refresh
+8. 구조 경계와 persistence adapter 분해
+   - ADR-0063 Application Layer Spring Annotation Policy
+   - ADR-0064 JDBC Persistence Adapter Decomposition
 
 ## 중요한 트레이드오프
 
@@ -111,6 +114,8 @@
 | 로컬 k8s 배포와 관측 스택 (ADR-0059) | Docker Desktop k8s + kustomize + Prometheus/Grafana/Loki, GitHub Actions→GHCR→ArgoCD GitOps, deploy는 CI 성공 게이트(workflow_run) 뒤에서만 실행 | 익명 Grafana/평문 자격증명은 로컬 학습 전용, 원격 전환 시 재설계 |
 | k8s 자격증명 Secret 주입 (ADR-0061) | `deploy/k8s` 평문 env(DB/운영 토큰/JWT)를 `Secret ai-repo-credentials`의 `secretKeyRef`로 전환 | 로컬 고정값 Secret도 평문 커밋 — 목적은 비밀 은닉이 아니라 스테이징 사고 방지+원격 전환 준비 |
 | 배포 프로파일 기본 자격증명 fail-fast (ADR-0062) | `postgres`/`prod`에서 공개된 기본 JWT secret·운영 토큰이면 기동 실패, `deploy/k8s/app.yaml`에 명시 값 주입 | 배포 프로파일 목록 하드코딩과 `app.yaml` 평문 값(Secret 주입은 #121에서 완결) |
+| Application layer Spring annotation policy (ADR-0063) | `@Service`, policy/properties `@Component`/`@Value`, 필요한 `@Transactional`을 제한적으로 허용하고 adapter 의존은 금지 | framework-free usecase 분리는 후속 전환 ADR 필요 |
+| JDBC persistence adapter decomposition (ADR-0064) | `JdbcWalletRepository`는 Spring composite bean으로 유지하고 SQL은 wallet/ledger, outbox relay, outbox consumer, operational alert, admin audit adapter로 분리 | composite가 여러 port를 계속 구현하는 절충은 유지 |
 
 ## 다음 구조 후보
 
@@ -120,3 +125,4 @@
 - pruning 실행 이력 저장과 조회 API
 - Slack 발행 실패 record와 재시도 정책
 - 실제 운영자 identity와 role scope 분리
+- context별 JDBC adapter slice test 분리

--- a/wiki-drafts/QA-Scenarios.md
+++ b/wiki-drafts/QA-Scenarios.md
@@ -33,6 +33,8 @@
 | Consumer pruning API | 오래된 processed-event, receipt, delivery metric bucket만 admin 권한으로 삭제한다 | API test, service test, JDBC test |
 | Relay/pruning 운영 화면 | relay health, relay run, pruning 결과를 운영자 화면에서 확인한다 | Frontend unit, E2E |
 | PostgreSQL runtime | `postgres` profile에서 Flyway migration과 대표 흐름이 동작한다 | PostgreSQL scenario CI |
+| 레이어 의존 규칙 | domain/application/api/infra의 핵심 의존 방향이 유지된다 | ArchUnit test |
+| JDBC adapter 분해 회귀 | context별 JDBC adapter로 분해해도 기존 repository contract와 rollback 경계가 유지된다 | JDBC test, PostgreSQL scenario CI |
 
 ## 수동 시연 순서
 
@@ -56,6 +58,7 @@
 - `./gradlew check`
 - `./gradlew scenarioTest`
 - `./gradlew postgresScenarioTest`
+- `./gradlew test --tests '*LayerDependencyTest'`
 - `npm --prefix frontend run test`
 - `npm --prefix frontend run build`
 - `npm --prefix frontend run e2e`

--- a/wiki-drafts/Release-Notes.md
+++ b/wiki-drafts/Release-Notes.md
@@ -44,6 +44,7 @@
 - GitHub Actions → GHCR({version}-{sha8}) → GitOps → ArgoCD 배포 파이프라인
 - Deploy 파이프라인 CI 성공 게이트(workflow_run)
 - k8s 로컬 스크립트 하드닝(loki/alloy rollout 대기 + Loki ready 스모크, ArgoCD 설치 버전 고정 v3.4.4)
+- JDBC persistence adapter 분해와 ArchUnit 레이어 규칙
 
 ## 릴리스 후보 검증
 
@@ -52,6 +53,7 @@
 - `./gradlew check`
 - `./gradlew scenarioTest`
 - `./gradlew postgresScenarioTest`
+- `./gradlew test --tests '*LayerDependencyTest'`
 - `npm --prefix frontend run test`
 - `npm --prefix frontend run build`
 - `npm --prefix frontend run e2e`
@@ -75,3 +77,4 @@
 - pruning 실행 이력 저장과 조회 API
 - Slack 발행 실패 record와 재시도 정책
 - 운영 alert 화면 연결
+- context별 JDBC adapter slice test 분리


### PR DESCRIPTION
## Summary
- Decompose JdbcWalletRepository into bounded-context JDBC adapters while preserving the postgres composite bean contract.
- Add ADR-0063/0064, progress 0076, issue/wiki/release documentation, and Codex review notes.
- Add ArchUnit layer dependency tests and update PostgreSQL scenario test credentials for deployed-profile fail-fast guards.

## Verification
- ./gradlew test scenarioTest postgresScenarioTest
- scripts/check-dev-rules.sh
- git diff --check

Closes #125