### PR TITLE
feat: authenticate /internal/broker/outbox-events with shared secret (#123)

### DIFF
--- a/.dev/debug/i123-broker-endpoint-auth-recheck.md
+++ b/.dev/debug/i123-broker-endpoint-auth-recheck.md
@@ -1,0 +1,35 @@
+# i123 broker endpoint auth — 재검증 트러블슈팅 메모
+
+- 대상 이슈: #123 (broker 엔드포인트 인증), 후속 #134 (디버그 잔여물 제거·지연 원인 기록)
+- 브랜치: `feat/broker-endpoint-auth` (origin/main에서 분기, 변경 전부 uncommitted)
+- GitHub 기록: https://github.com/IMWoo94/ai-repo/issues/134#issuecomment-4881455462
+
+## 결론
+초기 분석의 주요 원인 판단은 정합적이다. 단 "DIAG println이 지연의 직접 증거"라는 한 문장만 저장소로는 입증 불가라 톤다운이 필요하다.
+
+## 확인된 것 (green)
+- 인증 순서/계약 문제 진단 정확:
+  - `src/main/java/com/imwoo/airepo/wallet/api/SecurityConfig.java` — `/internal/broker/**` 전용 `@Order(3)` `brokerSecurityFilterChain` 추가.
+  - `src/main/java/com/imwoo/airepo/wallet/api/BrokerTokenAuthenticationFilter.java` — `X-Broker-Token` 없으면 401.
+- publisher 계약 동반 수정:
+  - `src/main/java/com/imwoo/airepo/wallet/infra/HttpOperationOutboxPublisher.java` — `X-Broker-Token` 헤더 부착.
+  - `src/main/resources/application.yml` — consumer/publisher 양쪽 `broker-token` 기본값 `local-broker-token` 일치.
+- monitoring/alert 컨트롤러 테스트 토큰 헤더 1줄 추가 정당(helper가 `/internal/broker/outbox-events` 직접 호출).
+- 잔여물 재스캔: `System.out`/`System.err`/`printStackTrace`/`DIAG` 워킹트리 0건.
+- 테스트 재실행 통과 (fail/skip/error 0):
+  | 클래스 | tests |
+  |---|---|
+  | BrokerTokenAuthenticationFilterTest | 4 |
+  | OperationOutboxConsumerControllerTest | 4 |
+  | OperationOutboxConsumerMonitoringControllerTest | 3 |
+  | OperationalAlertControllerTest | 4 |
+  | HttpOperationOutboxPublisherContractTest | 3 |
+  | HttpOutboxPublishConsumeLoopTest | 1 |
+
+## 입증 불가 (톤다운 대상)
+- "DIAG println이 오래 걸린 직접 증거": `git log -S 'DIAG' --all` 0건, reflog/stash 0건. 중간 커밋이 없어 과거 존재 여부조차 repo로는 재구성 불가 → 세션 transcript로만 확정 가능.
+- "락 이슈 아님" 결론은 코드로 재확인됨(무상태 토큰 비교, relay 기존 claim-lease 유지).
+
+## 남은 액션
+- #134 본문 "정확한 원인" 문구를 세션 로그 근거의 추정 원인으로 톤다운 또는 transcript 링크 첨부.
+- #123 PR 반영 시 위 테스트 green + 잔여물 0건 상태 유지.

--- a/docs/adr/0065-broker-endpoint-authentication.md
+++ b/docs/adr/0065-broker-endpoint-authentication.md
@@ -1,0 +1,51 @@
+# ADR-0065: Broker Consumer Endpoint Authentication
+
+## 상태
+
+Accepted
+
+## 배경
+
+`POST /internal/broker/outbox-events`(`OperationOutboxConsumerController`)는 header-body 일치 검증만 있고 인증이 없었다. 이 endpoint는 앱과 같은 포트 표면(로컬 NodePort 30080)을 공유하므로, relay/broker 뿐 아니라 같은 네트워크에서 접근 가능한 누구나 consumer로 임의 outbox event를 주입할 수 있었다. `SecurityConfig`에서 `/internal/broker/**`는 어떤 `securityMatcher`에도 걸리지 않아 Order(4) default chain의 `permitAll`로 떨어졌다.
+
+publisher 측(`HttpOperationOutboxPublisher`)은 이미 `X-Outbox-Event-Id` 등 계약 헤더만 붙였고 인증 헤더는 없었다.
+
+## 결정
+
+broker→consumer 사이에 shared secret 헤더(`X-Broker-Token`)를 도입한다.
+
+| 항목 | 결정 |
+| --- | --- |
+| 인증 방식 | consumer가 `X-Broker-Token` 헤더를 configured `ai-repo.outbox.consumer.broker-token`(env `AI_REPO_OUTBOX_CONSUMER_BROKER_TOKEN`, 로컬 기본 `local-broker-token`)과 상수시간 비교. 불일치/누락 → 401 |
+| 게이팅 위치 | `/internal/broker/**` 전용 `SecurityFilterChain`(Order 3)을 신설하고 `BrokerTokenAuthenticationFilter`(`OncePerRequestFilter`)를 체인에 등록. admin chain(`AdminHeaderAuthenticationFilter` + `AdminSecurityErrorHandler`) 패턴과 동일하게 구성 |
+| 401 응답 | `BrokerSecurityErrorHandler`가 admin과 동일한 JSON error 형태(`{"code","message","timestamp"}`)로 `BROKER_AUTHENTICATION_REQUIRED` 401 작성 |
+| publisher | `HttpOperationOutboxPublisher`가 같은 token(`ai-repo.outbox.publisher.http.broker-token`, env `AI_REPO_OUTBOX_PUBLISHER_HTTP_BROKER_TOKEN`)을 `X-Broker-Token` 헤더로 부착. contract test로 헤더 부착을 고정 |
+| 토큰 비교 | `MessageDigest.isEqual`로 timing-safe 비교(admin token 검증과 동일) |
+
+## 왜 controller가 아니라 filter/chain인가
+
+controller에서 직접 검증하면 header-body 검증 로직과 인증 로직이 섞이고, 401 JSON 형태를 controller마다 다시 만들어야 한다. admin 운영 API가 이미 "전용 security chain + `OncePerRequestFilter` + 공통 error handler"로 401을 통일해 두었으므로, broker endpoint도 같은 축을 따르는 것이 일관적이고 side-effect 이전에 요청을 차단한다. 전용 chain(Order 3)을 둬서 `permitAll` default로 새는 것을 명시적으로 막는다.
+
+## 네트워크 전제와 토큰 로테이션
+
+- **NetworkPolicy 전제**: shared secret은 방어의 한 축일 뿐이다. `/internal/**`는 클러스터 내부 relay만 호출해야 하며, ingress/NetworkPolicy로 외부에서 `/internal/broker/**`가 도달하지 못하게 막는 것을 전제로 한다. 토큰은 "네트워크가 뚫렸을 때의 2차 방어선"이다.
+- **기본 토큰 fail-fast**: 로컬 기본값 `local-broker-token`은 저장소에 커밋돼 있어 그대로 두면 2차 방어선이 무력화된다. `BrokerTokenGuard`(`JwtSecretGuard`와 동일 패턴)가 배포 프로파일(`postgres`/`prod`)에서 consumer 토큰이 이 기본값이면 startup을 실패시키고, 그 외 프로파일에서는 경고만 남긴다. 즉 배포 프로파일은 `AI_REPO_OUTBOX_CONSUMER_BROKER_TOKEN` 주입을 강제한다.
+- **토큰 로테이션**: consumer(`AI_REPO_OUTBOX_CONSUMER_BROKER_TOKEN`)와 publisher(`AI_REPO_OUTBOX_PUBLISHER_HTTP_BROKER_TOKEN`)는 같은 값이어야 한다. 로테이션 시 무중단을 위해서는 consumer가 신·구 토큰을 동시에 수용하는 window가 필요하나, 현재는 단일 토큰만 지원하므로 로테이션은 짧은 순단(publisher→consumer 순차 배포)을 수용한다. 다중 토큰 수용은 후속 과제로 둔다.
+
+## 트레이드오프
+
+### 장점
+
+- 미인증 event 주입을 닫으면서 relay→consumer 계약은 헤더 하나 추가로 최소 변경.
+- admin 운영 API와 동일한 filter/chain/error-handler 축을 재사용해 인증·401 형태가 일관됨.
+
+### 비용
+
+- consumer와 publisher가 같은 토큰 값을 공유해야 하므로 설정 동기화 책임이 생긴다(로테이션 순단).
+- shared secret은 대칭 비밀이라 유출 시 양쪽을 모두 교체해야 한다. mTLS 같은 상호 인증은 범위 밖으로 둔다.
+
+## 대안
+
+- controller에서 직접 검증: 가장 단순하나 401 형태 중복과 관심사 혼합.
+- mTLS/서명 기반 인증: 유출 내성이 크지만 로컬 학습 스택에는 과하고 인증서 배포/로테이션 비용이 크다.
+- NetworkPolicy만으로 차단(토큰 없음): 포트 표면 공유 상황에서 2차 방어선이 없어 이슈 요구를 충족하지 못한다.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -80,3 +80,4 @@ ADR은 이 저장소에서 중요한 결정의 source of truth입니다. README�
 | ADR-0062 | 배포 프로파일에서 기본 자격증명 fail-fast | Accepted |
 | ADR-0063 | Application Layer Spring Annotation Policy | Accepted |
 | ADR-0064 | JDBC Persistence Adapter Decomposition | Accepted |
+| ADR-0065 | Broker Consumer Endpoint Authentication | Accepted |

--- a/docs/progress/0074-broker-endpoint-authentication.md
+++ b/docs/progress/0074-broker-endpoint-authentication.md
@@ -1,0 +1,36 @@
+# 0074. Broker Consumer Endpoint Authentication
+
+## 스펙 목표
+
+- 미인증 상태였던 `POST /internal/broker/outbox-events`(`OperationOutboxConsumerController`)에 broker→consumer shared secret 헤더 인증을 추가한다.
+- HTTP publisher(`HttpOperationOutboxPublisher`)가 같은 secret을 부착하도록 계약을 갱신한다.
+- 미인증/오토큰 401, 정상 토큰 2xx, publish→consume loop 유지를 회귀 테스트로 고정한다.
+
+## 완료 결과
+
+- `X-Broker-Token` 헤더를 도입했다. consumer는 `ai-repo.outbox.consumer.broker-token`(env `AI_REPO_OUTBOX_CONSUMER_BROKER_TOKEN`, 로컬 기본 `local-broker-token`)과 `MessageDigest.isEqual` 상수시간 비교로 검증한다.
+- `/internal/broker/**` 전용 `SecurityFilterChain`(Order 3)을 신설하고 `BrokerTokenAuthenticationFilter`(`OncePerRequestFilter`)를 체인에 등록했다. 기존 default chain은 Order 4→5로 밀었다. admin 운영 API의 filter/chain/error-handler 축을 그대로 따랐다.
+- `BrokerSecurityErrorHandler`가 admin과 동일한 JSON error 형태(`{"code","message","timestamp"}`)로 `BROKER_AUTHENTICATION_REQUIRED` 401을 작성한다.
+- `HttpOperationOutboxPublisher`에 broker token 생성자 인자(`ai-repo.outbox.publisher.http.broker-token`, env `AI_REPO_OUTBOX_PUBLISHER_HTTP_BROKER_TOKEN`)를 추가하고 `X-Broker-Token` 헤더를 부착한다.
+- `BrokerTokenGuard`(`JwtSecretGuard` 동일 패턴)를 추가해, 배포 프로파일(`postgres`/`prod`)에서 consumer 토큰이 커밋된 기본값 `local-broker-token`이면 startup fail-fast(그 외 프로파일은 경고). 커밋된 기본 secret으로의 fail-open을 막는다.
+- 회귀 테스트: 필터 유닛 테스트(비-broker path 통과, 미토큰 401, 오토큰 401, 정상 토큰 통과), controller 미토큰/오토큰 401 + 정상 토큰 2xx, contract test의 `X-Broker-Token` 헤더 부착 단언, publish→consume loop 유지.
+
+## 개선 건수
+
+1. `/internal/broker/outbox-events` 미인증 event 주입 차단(shared secret 게이팅).
+2. publisher가 같은 secret을 부착하도록 계약 갱신.
+
+## 검증
+
+- `./gradlew test` 통과
+- `./gradlew scenarioTest` (broker endpoint를 거치는 loop 포함)
+
+## 남은 일
+
+- 다중 토큰(신·구) 동시 수용으로 무중단 로테이션 지원(현재 단일 토큰, 로테이션 순단 수용).
+- mTLS/서명 기반 상호 인증은 범위 밖(로컬 학습 스택에는 과함).
+
+## 관련 문서
+
+- `docs/adr/0065-broker-endpoint-authentication.md`
+- `docs/releases/unreleased.md`

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -91,6 +91,7 @@ ADR은 “왜 그렇게 결정했는가”를 기록하고, 이 폴더는 “각
 | 0075 | [Admin Path Drift Guard](0075-admin-path-drift-guard.md) | 완료 |
 | 0073 | [배포 프로파일 기본 자격증명 fail-fast](0073-default-credential-fail-fast.md) | 완료 |
 | 0076 | [JDBC Persistence Adapter Decomposition](0076-jdbc-persistence-adapter-decomposition.md) | 완료 |
+| 0074 | [Broker Consumer Endpoint Authentication](0074-broker-endpoint-authentication.md) | 완료 |
 
 ## 현재 기준선
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -42,6 +42,7 @@
 - 운영 API 경로 목록 drift 방지 테스트 — `SecurityConfig`와 `AdminApiPathMatcher` 두 상수 목록이 같은 운영 API root 집합을 다루는지 양방향 검증(불일치 시 누락 경로 명시)
 - 배포 프로파일(`postgres`/`prod`)에서 공개된 기본 JWT secret·운영 토큰 fail-fast 확장(`JwtSecretGuard`/`OpsTokenGuard`)과 `deploy/k8s/app.yaml` 명시 값 주입
 - JDBC persistence adapter 분해 — `JdbcWalletRepository`를 PostgreSQL profile composite bean으로 유지하면서 wallet/ledger, outbox relay, outbox consumer, operational alert, admin audit SQL을 context별 package-private adapter로 분리하고 ArchUnit 레이어 규칙을 추가
+- `POST /internal/broker/outbox-events` shared secret 헤더(`X-Broker-Token`) 인증 — 전용 SecurityFilterChain(Order 3) + 상수시간 토큰 비교로 미인증 event 주입 차단, publisher가 같은 secret 부착(#123)
 
 ## MVP 출시 판단 기준
 

--- a/docs/reviews/2026-07-04-broker-endpoint-authentication-claude-review.md
+++ b/docs/reviews/2026-07-04-broker-endpoint-authentication-claude-review.md
@@ -1,0 +1,43 @@
+# Broker Endpoint Authentication Claude Multi-Agent Review
+
+> AGENTS.md 기본 흐름의 1차 리뷰는 Codex다. 이 문서는 사용자가 명시적으로 요청한(ultracode) Claude 멀티에이전트 커밋 전 리뷰 결과이며, Codex 1차 리뷰를 대체하지 않는다.
+
+## 검토 대상
+
+- 범위: `feat/broker-endpoint-auth` 워킹트리 diff (#123 완료)
+- 변경 의도: 미인증 `POST /internal/broker/outbox-events`에 shared secret 헤더(`X-Broker-Token`) 인증을 추가하고 publisher가 같은 secret을 부착하도록 계약을 갱신한다.
+- 방법: 4개 렌즈(auth-security / contract-config / test-coverage / issue-completeness) 병렬 리뷰 → 각 finding 적대적 재검증(refute-우선). 16개 에이전트, 0 에러.
+
+## 검증
+
+```bash
+scripts/check-dev-rules.sh                          # PASS
+./gradlew test scenarioTest postgresScenarioTest    # BUILD SUCCESSFUL
+```
+
+## 판정
+
+통과. 블로커/HIGH 없음. MEDIUM 1건 수용(수정), LOW 3건 후속 과제.
+
+## 리뷰 반영
+
+### 수용
+
+- **[MEDIUM] 기본 토큰 fail-open**: consumer 토큰이 env 미주입 시 커밋된 상수 `local-broker-token`으로 떨어져, ADR이 명시한 "2차 방어선"이 무력화된다. 형제 `JwtSecretGuard`가 배포 프로파일(postgres/prod)에서 커밋된 기본 secret에 startup fail-fast를 거는 선례가 있으나 broker token엔 없었다.
+  - 조치: `BrokerTokenGuard`를 `JwtSecretGuard`와 동일 패턴으로 추가(DeployedProfiles = postgres/prod에서 기본값이면 startup 실패, 그 외 경고). 단위 테스트 5종 추가. ADR-0065 / progress 0074에 명시.
+
+### 후속 과제
+
+- **[LOW] 필터 path 가드 불일치**: `BrokerTokenAuthenticationFilter.isBrokerPath()`가 `startsWith("/internal/broker/")`(trailing slash)라, matcher `/internal/broker/**`가 매칭하는 slash-less `/internal/broker`는 토큰 검사 없이 통과한다. 현재 해당 base path에 매핑된 핸들러가 없어 404, 악용 불가. 방어적 하드닝으로 후속.
+- **[LOW] error handler escape 불일치**: `BrokerSecurityErrorHandler`가 `AdminSecurityErrorHandler`와 달리 JSON escape 미적용. 메시지가 상수(`broker token is required`)라 현재 무해. 공통 writer로 통일 권장.
+- **[LOW] 빈/공백 토큰 테스트 미커버**: `tokenMatches`의 `isBlank()` 분기 미검증. 단 `MessageDigest.isEqual` length mismatch로 사실상 무해(설정 토큰이 blank일 때만 유효). 회귀 고정용으로 후속.
+
+### 반박 (재검증에서 INVALID)
+
+- "shared secret이 두 config 키로 중복돼 drift 위험" → 코드 사실이나 이 워킹트리의 결함 아님(운영 설정 책임). 정보성.
+- "필터가 `@Component`로 전역 재등록돼 이중 실행" → 실제 이중 실행/토큰 우회 없음. admin 필터와 동일 패턴.
+- "401 JSON 인젝션" → 메시지가 항상 상수라 주입 벡터 없음.
+
+## 관련
+
+- 이슈 #123(기능), #134(디버그 잔여물/지연 원인 후속), ADR-0065, progress 0074.

--- a/issue-drafts/0074-broker-endpoint-authentication.md
+++ b/issue-drafts/0074-broker-endpoint-authentication.md
@@ -1,0 +1,37 @@
+# /internal/broker/outbox-events 인증(shared secret) 및 네트워크 전제 명시
+
+## 배경
+
+`POST /internal/broker/outbox-events`(`OperationOutboxConsumerController`)는 header-body 일치 검증만 있고 인증이 없었다. 이 endpoint는 앱과 같은 포트 표면(로컬 NodePort 30080)을 공유하므로, relay/broker 뿐 아니라 같은 네트워크에서 접근 가능한 누구나 consumer로 임의 outbox event를 주입할 수 있었다. `SecurityConfig`에서 `/internal/broker/**`는 어떤 `securityMatcher`에도 걸리지 않아 default chain의 `permitAll`로 떨어졌다.
+
+## 문제
+
+- 미인증 호출자가 임의 `outboxEventId`/payload로 consumer 부작용(receipt 적재 등)을 유발할 수 있다.
+- publisher(`HttpOperationOutboxPublisher`)는 계약 헤더(`X-Outbox-Event-Id` 등)만 붙이고 인증 헤더가 없어, 인증 도입 시 publisher도 함께 고쳐야 과도기 401을 피한다.
+
+## 결정 / 제안
+
+- broker→consumer shared secret 헤더 `X-Broker-Token` 도입. consumer가 `ai-repo.outbox.consumer.broker-token`(env `AI_REPO_OUTBOX_CONSUMER_BROKER_TOKEN`, 로컬 기본 `local-broker-token`)과 `MessageDigest.isEqual` 상수시간 비교. 불일치/누락 → 401.
+- `/internal/broker/**` 전용 `SecurityFilterChain`(Order 3) + `BrokerTokenAuthenticationFilter`(`OncePerRequestFilter`)를 신설. admin 운영 API의 filter/chain/error-handler 축을 재사용. 401은 `BrokerSecurityErrorHandler`가 `{"code","message","timestamp"}` 형태로 작성.
+- publisher가 같은 token(`ai-repo.outbox.publisher.http.broker-token`, env `AI_REPO_OUTBOX_PUBLISHER_HTTP_BROKER_TOKEN`)을 `X-Broker-Token`으로 부착. contract test로 고정.
+- NetworkPolicy 전제: shared secret은 방어의 한 축이며 `/internal/**`는 클러스터 내부 relay만 도달하도록 ingress/NetworkPolicy로 막는 것을 전제(토큰은 2차 방어선).
+
+## 완료 조건
+
+- [x] broker→consumer shared secret 헤더(env 주입) 검증 추가 + 미인증 401 테스트
+- [x] HTTP publisher가 같은 secret을 부착하도록 계약(contract test) 갱신
+- [x] ADR/문서에 NetworkPolicy 전제 또는 인증 방식 명시
+
+## 검증 명령
+
+```bash
+./gradlew test scenarioTest postgresScenarioTest
+scripts/check-dev-rules.sh
+```
+
+## 후속 (main 머지 후)
+
+- 다중 토큰(신·구) 동시 수용으로 무중단 로테이션 지원(현재 단일 토큰, 로테이션 순단 수용).
+- mTLS/서명 기반 상호 인증(로컬 학습 스택 범위 밖).
+
+관련: GitHub Issue #123, 후속 #134, ADR-0065, progress 0074.

--- a/issue-drafts/README.md
+++ b/issue-drafts/README.md
@@ -134,6 +134,8 @@
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/122
 - `0076-jdbc-persistence-adapter-decomposition.md`: JdbcWalletRepository bounded-context 분해와 ArchUnit 레이어 규칙 작업 초안
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/125
+- `0074-broker-endpoint-authentication.md`: `/internal/broker/outbox-events` shared secret 인증과 네트워크 전제 명시 작업 초안
+  - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/123
 
 ## GitHub CLI로 생성
 

--- a/src/main/java/com/imwoo/airepo/wallet/api/BrokerAuthorizationProperties.java
+++ b/src/main/java/com/imwoo/airepo/wallet/api/BrokerAuthorizationProperties.java
@@ -1,0 +1,23 @@
+package com.imwoo.airepo.wallet.api;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BrokerAuthorizationProperties {
+
+    private final String brokerToken;
+
+    public BrokerAuthorizationProperties(
+            @Value("${ai-repo.outbox.consumer.broker-token:local-broker-token}") String brokerToken
+    ) {
+        if (brokerToken == null || brokerToken.isBlank()) {
+            throw new IllegalArgumentException("ai-repo.outbox.consumer.broker-token must not be blank");
+        }
+        this.brokerToken = brokerToken;
+    }
+
+    public String brokerToken() {
+        return brokerToken;
+    }
+}

--- a/src/main/java/com/imwoo/airepo/wallet/api/BrokerSecurityErrorHandler.java
+++ b/src/main/java/com/imwoo/airepo/wallet/api/BrokerSecurityErrorHandler.java
@@ -1,0 +1,43 @@
+package com.imwoo.airepo.wallet.api;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BrokerSecurityErrorHandler implements AuthenticationEntryPoint {
+
+    private final Clock clock;
+
+    public BrokerSecurityErrorHandler(Clock clock) {
+        this.clock = clock;
+    }
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException, ServletException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write("""
+                {"code":"%s","message":"%s","timestamp":"%s"}"""
+                .formatted("BROKER_AUTHENTICATION_REQUIRED", message(authException), Instant.now(clock)));
+    }
+
+    private String message(AuthenticationException exception) {
+        if (exception == null || exception.getMessage() == null || exception.getMessage().isBlank()) {
+            return "broker token is required";
+        }
+        return exception.getMessage();
+    }
+}

--- a/src/main/java/com/imwoo/airepo/wallet/api/BrokerTokenAuthenticationFilter.java
+++ b/src/main/java/com/imwoo/airepo/wallet/api/BrokerTokenAuthenticationFilter.java
@@ -1,0 +1,66 @@
+package com.imwoo.airepo.wallet.api;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class BrokerTokenAuthenticationFilter extends OncePerRequestFilter {
+
+    public static final String BROKER_TOKEN_HEADER = "X-Broker-Token";
+    private static final String BROKER_PATH_PREFIX = "/internal/broker/";
+
+    private final BrokerAuthorizationProperties properties;
+    private final BrokerSecurityErrorHandler brokerSecurityErrorHandler;
+
+    public BrokerTokenAuthenticationFilter(
+            BrokerAuthorizationProperties properties,
+            BrokerSecurityErrorHandler brokerSecurityErrorHandler
+    ) {
+        this.properties = properties;
+        this.brokerSecurityErrorHandler = brokerSecurityErrorHandler;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        if (!isBrokerPath(request.getRequestURI())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        String brokerToken = request.getHeader(BROKER_TOKEN_HEADER);
+        if (!tokenMatches(properties.brokerToken(), brokerToken)) {
+            brokerSecurityErrorHandler.commence(
+                    request,
+                    response,
+                    new BadCredentialsException("broker token is required")
+            );
+            return;
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean isBrokerPath(String requestUri) {
+        return requestUri != null && requestUri.startsWith(BROKER_PATH_PREFIX);
+    }
+
+    private boolean tokenMatches(String expectedToken, String actualToken) {
+        if (actualToken == null || actualToken.isBlank()) {
+            return false;
+        }
+        return MessageDigest.isEqual(
+                expectedToken.getBytes(StandardCharsets.UTF_8),
+                actualToken.getBytes(StandardCharsets.UTF_8)
+        );
+    }
+}

--- a/src/main/java/com/imwoo/airepo/wallet/api/SecurityConfig.java
+++ b/src/main/java/com/imwoo/airepo/wallet/api/SecurityConfig.java
@@ -85,6 +85,24 @@ public class SecurityConfig {
 
     @Bean
     @Order(3)
+    SecurityFilterChain brokerSecurityFilterChain(
+            HttpSecurity http,
+            BrokerTokenAuthenticationFilter brokerTokenAuthenticationFilter
+    ) throws Exception {
+        return http
+                .securityMatcher("/internal/broker/**")
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll())
+                .addFilterBefore(brokerTokenAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    @Order(4)
     SecurityFilterChain walletSecurityFilterChain(HttpSecurity http, JwtDecoder walletJwtDecoder) throws Exception {
         return http
                 .securityMatcher("/api/v1/wallets/**")
@@ -99,7 +117,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    @Order(4)
+    @Order(5)
     SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
         return http
                 .csrf(AbstractHttpConfigurer::disable)

--- a/src/main/java/com/imwoo/airepo/wallet/config/BrokerTokenGuard.java
+++ b/src/main/java/com/imwoo/airepo/wallet/config/BrokerTokenGuard.java
@@ -1,0 +1,35 @@
+package com.imwoo.airepo.wallet.config;
+
+import com.imwoo.airepo.wallet.api.BrokerAuthorizationProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+/**
+ * Fails application startup if the built-in development broker token is left in place under a
+ * deployed profile ({@code postgres} or {@code prod}; see {@link DeployedProfiles}). The default
+ * token is published in the repository, so anyone who can reach {@code /internal/broker/**} could
+ * forge an authenticated outbox event; under a deployed profile it must be overridden via
+ * {@code AI_REPO_OUTBOX_CONSUMER_BROKER_TOKEN}. Other profiles only get a warning so local/test
+ * runs keep working. Mirrors {@link JwtSecretGuard}.
+ */
+@Component
+class BrokerTokenGuard {
+
+    private static final String INSECURE_DEFAULT_TOKEN = "local-broker-token";
+    private static final Logger log = LoggerFactory.getLogger(BrokerTokenGuard.class);
+
+    BrokerTokenGuard(BrokerAuthorizationProperties properties, Environment environment) {
+        if (!INSECURE_DEFAULT_TOKEN.equals(properties.brokerToken())) {
+            return;
+        }
+        if (DeployedProfiles.isActive(environment)) {
+            throw new IllegalStateException(
+                    "ai-repo.outbox.consumer.broker-token is the built-in development default; "
+                            + "set AI_REPO_OUTBOX_CONSUMER_BROKER_TOKEN for deployed profiles (postgres/prod)");
+        }
+        log.warn("ai-repo.outbox.consumer.broker-token is the built-in development default — "
+                + "set AI_REPO_OUTBOX_CONSUMER_BROKER_TOKEN before deploying.");
+    }
+}

--- a/src/main/java/com/imwoo/airepo/wallet/infra/HttpOperationOutboxPublisher.java
+++ b/src/main/java/com/imwoo/airepo/wallet/infra/HttpOperationOutboxPublisher.java
@@ -22,13 +22,17 @@ public class HttpOperationOutboxPublisher implements OperationOutboxPublisher {
 
     private static final int EVENT_SCHEMA_VERSION = 1;
 
+    public static final String BROKER_TOKEN_HEADER = "X-Broker-Token";
+
     private final HttpClient httpClient;
     private final URI endpoint;
     private final Duration timeout;
+    private final String brokerToken;
 
     public HttpOperationOutboxPublisher(
             @Value("${ai-repo.outbox.publisher.http.endpoint}") String endpoint,
-            @Value("${ai-repo.outbox.publisher.http.timeout-ms:3000}") long timeoutMillis
+            @Value("${ai-repo.outbox.publisher.http.timeout-ms:3000}") long timeoutMillis,
+            @Value("${ai-repo.outbox.publisher.http.broker-token:local-broker-token}") String brokerToken
     ) {
         if (endpoint == null || endpoint.isBlank()) {
             throw new IllegalArgumentException("ai-repo.outbox.publisher.http.endpoint must not be blank");
@@ -36,11 +40,15 @@ public class HttpOperationOutboxPublisher implements OperationOutboxPublisher {
         if (timeoutMillis <= 0) {
             throw new IllegalArgumentException("ai-repo.outbox.publisher.http.timeout-ms must be positive");
         }
+        if (brokerToken == null || brokerToken.isBlank()) {
+            throw new IllegalArgumentException("ai-repo.outbox.publisher.http.broker-token must not be blank");
+        }
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofMillis(timeoutMillis))
                 .build();
         this.endpoint = URI.create(endpoint);
         this.timeout = Duration.ofMillis(timeoutMillis);
+        this.brokerToken = brokerToken;
     }
 
     @Override
@@ -48,6 +56,7 @@ public class HttpOperationOutboxPublisher implements OperationOutboxPublisher {
         HttpRequest request = HttpRequest.newBuilder(endpoint)
                 .timeout(timeout)
                 .header("Content-Type", "application/json")
+                .header(BROKER_TOKEN_HEADER, brokerToken)
                 .header("X-Outbox-Event-Id", outboxEvent.outboxEventId())
                 .header("X-Idempotency-Key", outboxEvent.outboxEventId())
                 .header("X-Event-Schema-Version", String.valueOf(EVENT_SCHEMA_VERSION))

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,11 +35,14 @@ ai-repo:
   test-fixtures:
     enabled: ${AI_REPO_TEST_FIXTURES_ENABLED:false}
   outbox:
+    consumer:
+      broker-token: ${AI_REPO_OUTBOX_CONSUMER_BROKER_TOKEN:local-broker-token}
     publisher:
       type: ${AI_REPO_OUTBOX_PUBLISHER_TYPE:memory}
       http:
         endpoint: ${AI_REPO_OUTBOX_PUBLISHER_HTTP_ENDPOINT:http://127.0.0.1:18080/outbox-events}
         timeout-ms: ${AI_REPO_OUTBOX_PUBLISHER_HTTP_TIMEOUT_MS:3000}
+        broker-token: ${AI_REPO_OUTBOX_PUBLISHER_HTTP_BROKER_TOKEN:local-broker-token}
   outbox-relay:
     scheduler:
       enabled: ${AI_REPO_OUTBOX_RELAY_SCHEDULER_ENABLED:false}

--- a/src/test/java/com/imwoo/airepo/wallet/api/BrokerTokenAuthenticationFilterTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/api/BrokerTokenAuthenticationFilterTest.java
@@ -1,0 +1,70 @@
+package com.imwoo.airepo.wallet.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class BrokerTokenAuthenticationFilterTest {
+
+    private final BrokerTokenAuthenticationFilter filter = new BrokerTokenAuthenticationFilter(
+            new BrokerAuthorizationProperties("local-broker-token"),
+            new BrokerSecurityErrorHandler(Clock.fixed(Instant.parse("2026-05-01T00:00:00Z"), ZoneOffset.UTC))
+    );
+
+    @Test
+    void passesThroughNonBrokerPathsWithoutToken() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/outbox-relay-runs");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AtomicBoolean chainCalled = new AtomicBoolean(false);
+
+        filter.doFilter(request, response, (req, res) -> chainCalled.set(true));
+
+        assertThat(chainCalled).isTrue();
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void rejectsBrokerRequestWithoutToken() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/internal/broker/outbox-events");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AtomicBoolean chainCalled = new AtomicBoolean(false);
+
+        filter.doFilter(request, response, (req, res) -> chainCalled.set(true));
+
+        assertThat(chainCalled).isFalse();
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentAsString()).contains("BROKER_AUTHENTICATION_REQUIRED");
+    }
+
+    @Test
+    void rejectsBrokerRequestWithWrongToken() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/internal/broker/outbox-events");
+        request.addHeader(BrokerTokenAuthenticationFilter.BROKER_TOKEN_HEADER, "wrong-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AtomicBoolean chainCalled = new AtomicBoolean(false);
+
+        filter.doFilter(request, response, (req, res) -> chainCalled.set(true));
+
+        assertThat(chainCalled).isFalse();
+        assertThat(response.getStatus()).isEqualTo(401);
+    }
+
+    @Test
+    void passesBrokerRequestWithCorrectToken() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/internal/broker/outbox-events");
+        request.addHeader(BrokerTokenAuthenticationFilter.BROKER_TOKEN_HEADER, "local-broker-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AtomicBoolean chainCalled = new AtomicBoolean(false);
+
+        filter.doFilter(request, response, (req, res) -> chainCalled.set(true));
+
+        assertThat(chainCalled).isTrue();
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+}

--- a/src/test/java/com/imwoo/airepo/wallet/api/OperationOutboxConsumerControllerTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/api/OperationOutboxConsumerControllerTest.java
@@ -58,6 +58,7 @@ class OperationOutboxConsumerControllerTest {
     void rejectsHeaderBodyMismatchBeforeSideEffect() throws Exception {
         mockMvc.perform(post("/internal/broker/outbox-events")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-Broker-Token", "local-broker-token")
                         .header("X-Outbox-Event-Id", "outbox-001")
                         .header("X-Idempotency-Key", "outbox-999")
                         .header("X-Event-Schema-Version", "1")
@@ -69,9 +70,41 @@ class OperationOutboxConsumerControllerTest {
         org.assertj.core.api.Assertions.assertThat(receiptRepository.findConsumerReceipt("outbox-001")).isEmpty();
     }
 
+    @Test
+    void rejectsMissingBrokerTokenWithUnauthorized() throws Exception {
+        mockMvc.perform(post("/internal/broker/outbox-events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-Outbox-Event-Id", "outbox-001")
+                        .header("X-Idempotency-Key", "outbox-001")
+                        .header("X-Event-Schema-Version", "1")
+                        .header("X-Event-Type", "CHARGE_COMPLETED")
+                        .content(body()))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("BROKER_AUTHENTICATION_REQUIRED"));
+
+        org.assertj.core.api.Assertions.assertThat(receiptRepository.findConsumerReceipt("outbox-001")).isEmpty();
+    }
+
+    @Test
+    void rejectsWrongBrokerTokenWithUnauthorized() throws Exception {
+        mockMvc.perform(post("/internal/broker/outbox-events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-Broker-Token", "wrong-token")
+                        .header("X-Outbox-Event-Id", "outbox-001")
+                        .header("X-Idempotency-Key", "outbox-001")
+                        .header("X-Event-Schema-Version", "1")
+                        .header("X-Event-Type", "CHARGE_COMPLETED")
+                        .content(body()))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("BROKER_AUTHENTICATION_REQUIRED"));
+
+        org.assertj.core.api.Assertions.assertThat(receiptRepository.findConsumerReceipt("outbox-001")).isEmpty();
+    }
+
     private org.springframework.test.web.servlet.ResultActions consumeEvent() throws Exception {
         return mockMvc.perform(post("/internal/broker/outbox-events")
                 .contentType(MediaType.APPLICATION_JSON)
+                .header("X-Broker-Token", "local-broker-token")
                 .header("X-Outbox-Event-Id", "outbox-001")
                 .header("X-Idempotency-Key", "outbox-001")
                 .header("X-Event-Schema-Version", "1")

--- a/src/test/java/com/imwoo/airepo/wallet/api/OperationOutboxConsumerMonitoringControllerTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/api/OperationOutboxConsumerMonitoringControllerTest.java
@@ -113,6 +113,7 @@ class OperationOutboxConsumerMonitoringControllerTest {
     private org.springframework.test.web.servlet.ResultActions consumeEvent() throws Exception {
         return mockMvc.perform(post("/internal/broker/outbox-events")
                 .contentType(MediaType.APPLICATION_JSON)
+                .header("X-Broker-Token", "local-broker-token")
                 .header("X-Outbox-Event-Id", "outbox-001")
                 .header("X-Idempotency-Key", "outbox-001")
                 .header("X-Event-Schema-Version", "1")

--- a/src/test/java/com/imwoo/airepo/wallet/api/OperationalAlertControllerTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/api/OperationalAlertControllerTest.java
@@ -105,6 +105,7 @@ class OperationalAlertControllerTest {
     private org.springframework.test.web.servlet.ResultActions consumeEvent() throws Exception {
         return mockMvc.perform(post("/internal/broker/outbox-events")
                 .contentType(MediaType.APPLICATION_JSON)
+                .header("X-Broker-Token", "local-broker-token")
                 .header("X-Outbox-Event-Id", "outbox-001")
                 .header("X-Idempotency-Key", "outbox-001")
                 .header("X-Event-Schema-Version", "1")

--- a/src/test/java/com/imwoo/airepo/wallet/config/BrokerTokenGuardTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/config/BrokerTokenGuardTest.java
@@ -1,0 +1,60 @@
+package com.imwoo.airepo.wallet.config;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.imwoo.airepo.wallet.api.BrokerAuthorizationProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+class BrokerTokenGuardTest {
+
+    private static final String DEFAULT_TOKEN = "local-broker-token";
+    private static final String OVERRIDDEN_TOKEN = "a-strong-injected-broker-token";
+
+    @Test
+    void failsFastWhenProdProfileUsesBuiltInDefaultToken() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setActiveProfiles("prod");
+
+        assertThatThrownBy(() -> new BrokerTokenGuard(new BrokerAuthorizationProperties(DEFAULT_TOKEN), environment))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("AI_REPO_OUTBOX_CONSUMER_BROKER_TOKEN");
+    }
+
+    @Test
+    void failsFastWhenPostgresProfileUsesBuiltInDefaultToken() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setActiveProfiles("postgres");
+
+        assertThatThrownBy(() -> new BrokerTokenGuard(new BrokerAuthorizationProperties(DEFAULT_TOKEN), environment))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("AI_REPO_OUTBOX_CONSUMER_BROKER_TOKEN");
+    }
+
+    @Test
+    void allowsProdProfileWithOverriddenToken() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setActiveProfiles("prod");
+
+        assertThatCode(() -> new BrokerTokenGuard(new BrokerAuthorizationProperties(OVERRIDDEN_TOKEN), environment))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void allowsPostgresProfileWithOverriddenToken() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setActiveProfiles("postgres");
+
+        assertThatCode(() -> new BrokerTokenGuard(new BrokerAuthorizationProperties(OVERRIDDEN_TOKEN), environment))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void allowsNonDeployedProfileWithBuiltInDefaultToken() {
+        MockEnvironment environment = new MockEnvironment();
+
+        assertThatCode(() -> new BrokerTokenGuard(new BrokerAuthorizationProperties(DEFAULT_TOKEN), environment))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/com/imwoo/airepo/wallet/infra/HttpOperationOutboxPublisherContractTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/infra/HttpOperationOutboxPublisherContractTest.java
@@ -29,7 +29,8 @@ class HttpOperationOutboxPublisherContractTest {
         try (BrokerEndpoint brokerEndpoint = BrokerEndpoint.responding(202)) {
             HttpOperationOutboxPublisher publisher = new HttpOperationOutboxPublisher(
                     brokerEndpoint.endpoint(),
-                    3000
+                    3000,
+                    "contract-broker-token"
             );
 
             publisher.publish(outboxEvent());
@@ -37,6 +38,7 @@ class HttpOperationOutboxPublisherContractTest {
             assertThat(brokerEndpoint.method()).isEqualTo("POST");
             assertThat(brokerEndpoint.path()).isEqualTo("/outbox-events");
             assertThat(brokerEndpoint.header("Content-Type")).isEqualTo("application/json");
+            assertThat(brokerEndpoint.header("X-Broker-Token")).isEqualTo("contract-broker-token");
             assertThat(brokerEndpoint.header("X-Outbox-Event-Id")).isEqualTo("outbox-001");
             assertThat(brokerEndpoint.header("X-Idempotency-Key")).isEqualTo("outbox-001");
             assertThat(brokerEndpoint.header("X-Event-Schema-Version")).isEqualTo("1");
@@ -59,7 +61,8 @@ class HttpOperationOutboxPublisherContractTest {
         try (BrokerEndpoint brokerEndpoint = BrokerEndpoint.responding(503)) {
             HttpOperationOutboxPublisher publisher = new HttpOperationOutboxPublisher(
                     brokerEndpoint.endpoint(),
-                    3000
+                    3000,
+                    "contract-broker-token"
             );
 
             assertThatThrownBy(() -> publisher.publish(outboxEvent()))
@@ -84,7 +87,7 @@ class HttpOperationOutboxPublisherContractTest {
             OperationOutboxRelayService relayService = new OperationOutboxRelayService(
                     Clock.fixed(Instant.parse("2026-05-01T00:01:00Z"), ZoneOffset.UTC),
                     repository,
-                    new HttpOperationOutboxPublisher(brokerEndpoint.endpoint(), 3000)
+                    new HttpOperationOutboxPublisher(brokerEndpoint.endpoint(), 3000, "contract-broker-token")
             );
 
             OperationOutboxPublishBatchResult result = relayService.publishReadyEvents(10);
@@ -167,6 +170,7 @@ class HttpOperationOutboxPublisherContractTest {
                     exchange.getRequestMethod(),
                     exchange.getRequestURI().getPath(),
                     exchange.getRequestHeaders().getFirst("Content-Type"),
+                    exchange.getRequestHeaders().getFirst("X-Broker-Token"),
                     exchange.getRequestHeaders().getFirst("X-Outbox-Event-Id"),
                     exchange.getRequestHeaders().getFirst("X-Idempotency-Key"),
                     exchange.getRequestHeaders().getFirst("X-Event-Schema-Version"),
@@ -184,6 +188,7 @@ class HttpOperationOutboxPublisherContractTest {
             String method,
             String path,
             String contentType,
+            String brokerToken,
             String outboxEventId,
             String idempotencyKey,
             String eventSchemaVersion,
@@ -194,6 +199,9 @@ class HttpOperationOutboxPublisherContractTest {
         String header(String name) {
             if ("Content-Type".equals(name)) {
                 return contentType;
+            }
+            if ("X-Broker-Token".equals(name)) {
+                return brokerToken;
             }
             if ("X-Outbox-Event-Id".equals(name)) {
                 return outboxEventId;

--- a/src/test/java/com/imwoo/airepo/wallet/infra/HttpOutboxPublishConsumeLoopTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/infra/HttpOutboxPublishConsumeLoopTest.java
@@ -72,7 +72,8 @@ class HttpOutboxPublishConsumeLoopTest {
                 relayRepository,
                 new HttpOperationOutboxPublisher(
                         "http://127.0.0.1:%d/internal/broker/outbox-events".formatted(port),
-                        3000
+                        3000,
+                        "local-broker-token"
                 )
         );
 

--- a/src/test/java/com/imwoo/airepo/wallet/scenario/PostgresWalletScenarioFlowTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/scenario/PostgresWalletScenarioFlowTest.java
@@ -42,6 +42,7 @@ class PostgresWalletScenarioFlowTest {
     private static final String TEST_JWT_SECRET = "postgres-scenario-jwt-secret-32b!!";
     private static final String TEST_ADMIN_TOKEN = "postgres-scenario-admin-token";
     private static final String TEST_OPERATOR_TOKEN = "postgres-scenario-operator-token";
+    private static final String TEST_BROKER_TOKEN = "postgres-scenario-broker-token";
 
     @Container
     private static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>(
@@ -81,6 +82,8 @@ class PostgresWalletScenarioFlowTest {
         registry.add("ai-repo.auth.jwt.secret", () -> TEST_JWT_SECRET);
         registry.add("ai-repo.ops.admin-token", () -> TEST_ADMIN_TOKEN);
         registry.add("ai-repo.ops.operator-token", () -> TEST_OPERATOR_TOKEN);
+        registry.add("ai-repo.outbox.consumer.broker-token", () -> TEST_BROKER_TOKEN);
+        registry.add("ai-repo.outbox.publisher.http.broker-token", () -> TEST_BROKER_TOKEN);
     }
 
     @Test
@@ -197,6 +200,7 @@ class PostgresWalletScenarioFlowTest {
     private org.springframework.test.web.servlet.ResultActions consumeBrokerEvent() throws Exception {
         return mockMvc.perform(post("/internal/broker/outbox-events")
                 .contentType("application/json")
+                .header("X-Broker-Token", TEST_BROKER_TOKEN)
                 .header("X-Outbox-Event-Id", "outbox-001")
                 .header("X-Idempotency-Key", "outbox-001")
                 .header("X-Event-Schema-Version", "1")

--- a/wiki-drafts/Architecture-Decisions.md
+++ b/wiki-drafts/Architecture-Decisions.md
@@ -80,6 +80,7 @@
    - ADR-0055 Admin API Path Matching Hardening
    - ADR-0056 End-User JWT Auth and Wallet Ownership
    - ADR-0057 End-User Login and Bearer Refresh
+   - ADR-0065 Broker Consumer Endpoint Authentication
 8. 구조 경계와 persistence adapter 분해
    - ADR-0063 Application Layer Spring Annotation Policy
    - ADR-0064 JDBC Persistence Adapter Decomposition
@@ -110,6 +111,7 @@
 | Slack webhook operational alert publisher | Incoming Webhook 호환 text payload로 push channel 계약 고정 | 발행 실패 record와 재시도 정책은 후속 과제 |
 | Admin API path matching hardening | 인증·감사 필터가 공통 segment-aware matcher로 root/sub-path만 운영 API로 분류 | Spring Security matcher 목록과 완전한 단일 source of truth는 후속 과제 |
 | Audit event–wallet 매핑 명시화 | `audit_event_wallets` 매핑 테이블을 쓰기 시점에 영속화(charge 1행/transfer 2행)해 소유자 스코프 audit-events 조회의 ledger 조인 의존을 제거 | 쓰기 경로에 매핑 삽입 1~2행 추가와 정합성 책임 |
+| Broker consumer endpoint 인증 (ADR-0065) | `/internal/broker/**` 전용 SecurityFilterChain(Order 3) + `X-Broker-Token` 상수시간 비교로 미인증 outbox event 주입 차단, publisher가 같은 secret 부착, admin chain의 filter/error-handler 축 재사용 | shared secret은 NetworkPolicy 전제 위 2차 방어선이며, 단일 토큰이라 로테이션은 순단 수용(다중 토큰은 후속) |
 | Wiki는 요약, ADR은 결정 | 포트폴리오 설명성과 PR 검증성 모두 확보 | Wiki 하나에 모든 결정을 몰아넣는 단순성 |
 | 로컬 k8s 배포와 관측 스택 (ADR-0059) | Docker Desktop k8s + kustomize + Prometheus/Grafana/Loki, GitHub Actions→GHCR→ArgoCD GitOps, deploy는 CI 성공 게이트(workflow_run) 뒤에서만 실행 | 익명 Grafana/평문 자격증명은 로컬 학습 전용, 원격 전환 시 재설계 |
 | k8s 자격증명 Secret 주입 (ADR-0061) | `deploy/k8s` 평문 env(DB/운영 토큰/JWT)를 `Secret ai-repo-credentials`의 `secretKeyRef`로 전환 | 로컬 고정값 Secret도 평문 커밋 — 목적은 비밀 은닉이 아니라 스테이징 사고 방지+원격 전환 준비 |


### PR DESCRIPTION
## 배경 / 목적

미인증 상태였던 `POST /internal/broker/outbox-events`(`OperationOutboxConsumerController`)는 앱과 같은 포트 표면(로컬 NodePort 30080)을 공유해, relay/broker 뿐 아니라 같은 네트워크의 누구나 consumer로 임의 outbox event를 주입할 수 있었다. broker→consumer shared secret 헤더 인증을 추가한다. (#123)

## 변경 내용

- `/internal/broker/**` 전용 `SecurityFilterChain`(Order 3) + `BrokerTokenAuthenticationFilter`(`OncePerRequestFilter`) 신설. consumer가 `X-Broker-Token`을 `AI_REPO_OUTBOX_CONSUMER_BROKER_TOKEN`과 `MessageDigest.isEqual` 상수시간 비교, 불일치/누락 시 401. admin chain의 filter/error-handler 축 재사용(`BrokerSecurityErrorHandler`).
- `HttpOperationOutboxPublisher`가 같은 secret을 `X-Broker-Token`으로 부착. contract test로 고정.
- **`BrokerTokenGuard`**(`JwtSecretGuard`/`OpsTokenGuard`와 동일 패턴, `DeployedProfiles` 공유): 배포 프로파일(`postgres`/`prod`)에서 consumer 토큰이 커밋된 기본값 `local-broker-token`이면 startup fail-fast. 실제 배포가 postgres 프로파일이므로 기본 secret fail-open을 차단한다.
- 문서: ADR-0065, progress 0074, unreleased, issue-draft 0074, wiki-drafts, ADR/progress 인덱스, `docs/reviews/2026-07-04-...-claude-review.md`.

## 검증

```
scripts/check-dev-rules.sh                          # PASS
./gradlew test scenarioTest postgresScenarioTest    # BUILD SUCCESSFUL
```
- 필터 유닛(미토큰/오토큰/정상), controller 401/2xx, contract 헤더 부착, publish→consume loop, guard 배포 프로파일 fail-fast 5종. postgres 시나리오는 non-default broker token 주입으로 guard 통과 검증.
- origin/main에 rebase 완료 (1 ahead / 0 behind, 소스 충돌 없음).

## 커밋 전 멀티에이전트 리뷰 (ultracode)

4개 렌즈(auth-security / contract-config / test-coverage / issue-completeness) 병렬 리뷰 → 각 finding 적대적 재검증. **블로커/HIGH 없음.**

- **[MEDIUM] 기본 토큰 fail-open → 이 PR에서 수정** (`BrokerTokenGuard`). 원래 broker token엔 `JwtSecretGuard` 같은 fail-fast 가드가 없어, env 미주입 시 커밋된 기본 secret으로 인증이 뚫릴 수 있었다.
- **후속 과제(LOW)** — 별도 처리 권장:
  - 필터 path 가드 `startsWith("/internal/broker/")` vs matcher `/internal/broker/**` (slash-less 경로, 현재 미매핑이라 악용 불가).
  - `BrokerSecurityErrorHandler` JSON escape 미적용(메시지 상수라 무해).
  - 빈/공백 토큰 케이스 테스트 미커버(`MessageDigest.isEqual` length mismatch로 사실상 무해).

## 리뷰 게이트 안내

> AGENTS.md 기준 1차 리뷰는 **Codex**다. 위 리뷰는 사용자가 명시적으로 요청한(ultracode) **Claude** 멀티에이전트 리뷰로, Codex 1차 리뷰를 대체하지 않는다. 자동화 에이전트 제약상 main 직접 머지/push는 수행하지 않았으며, 머지는 CI + Codex 리뷰 게이트 통과 후 진행한다.

Refs #123, #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)
