### PR TITLE
feat(observability): opt-in ELK 2단계 로깅 스택 + 문서·가이드·학습문서

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,20 @@ IntelliJ IDEA 기준 설정은 [Local Setup](docs/development/local-setup.md)을
 
 서비스별 전체 접속 정보(Postgres·Loki 포함)와 복사-실행 명령어 모음은 [k8s 로컬 배포 + 모니터링 + 로그 검색](docs/development/k8s-local-monitoring.md)의 "접속 정보"·"전체 명령어 모음" 섹션에 있습니다. 인프라·애플리케이션 구조는 [아키텍처 다이어그램](docs/development/architecture-diagrams.md)(mermaid)을 참고합니다.
 
+#### (선택) ELK 로그 스택 — opt-in 학습용
+
+기본 로그 스택은 위 PLG(Loki)입니다. 로그 파싱·검색을 학습하려면 **opt-in** ELK 스택(Filebeat→Logstash→Elasticsearch→Kibana)을 `logging` 네임스페이스에 별도로 띄울 수 있습니다. PLG를 대체하지 않고 병존하며, ArgoCD(GitOps)에는 포함하지 않고 아래 스크립트로만 수동 기동합니다(ADR-0066). 구동·KQL 검색·트러블슈팅은 [ELK 로컬 로깅 가이드](docs/development/elk-local-logging.md), 개념 학습은 [ELK 학습 문서](docs/learning/elk-stack.md)를 따릅니다.
+
+```bash
+./scripts/elk-local-up.sh     # ELK 스택 기동 (logging 네임스페이스)
+./scripts/elk-local-down.sh   # ELK 스택 제거
+```
+
+| 서비스 | URL | 계정 |
+| --- | --- | --- |
+| Kibana (Discover/KQL) | http://localhost:30561 | 없음 (로컬 학습용 `xpack.security.enabled=false`) |
+| Elasticsearch API | http://localhost:30920 | 없음 (인덱스 패턴 `spring-logs-*`) |
+
 현재 기능 흐름은 잔액/거래내역 조회, 회원/지갑 계정, 충전/송금, 원장/감사 로그 1차 API를 제공합니다.
 
 - `GET /api/v1/wallets/wallet-001/balance`

--- a/deploy/k8s/logging/README.md
+++ b/deploy/k8s/logging/README.md
@@ -1,0 +1,36 @@
+# ELK 로깅 스택 (opt-in, 학습용)
+
+Filebeat → Logstash(grok) → Elasticsearch → Kibana 로그 파이프라인의 자기완결적 kustomize overlay다.
+기존 PLG(Prometheus/Loki/Grafana/Alloy)와 **별개의 학습용 스택**으로, PLG를 대체하지 않고 병존한다.
+
+> **opt-in**: 이 overlay는 ArgoCD GitOps(`deploy/gitops`)에 **포함되지 않는다**. 항상 켜지지 않으며,
+> 아래 스크립트로만 수동 기동/제거한다. 로컬 학습 전제(`xpack.security.enabled=false`, 단일노드,
+> ephemeral `emptyDir`, 리소스 축소)이므로 프로덕션 용도가 아니다.
+
+## 구성요소
+
+- **namespace.yaml** — `logging` 네임스페이스 (앱 `ai-repo`와 분리).
+- **elasticsearch.yaml** — Elasticsearch 8.16.1 단일노드. ClusterIP(9200/9300) + NodePort(30920, API 확인용). 역색인 저장/검색 엔진.
+- **logstash.yaml** — Logstash 8.16.1. beats(5044) 입력을 grok으로 파싱해 ES로 전송. 파이프라인/설정 ConfigMap 포함.
+- **kibana.yaml** — Kibana 8.16.1. NodePort(30561)로 노출되는 검색/시각화 UI.
+- **filebeat.yaml** — Filebeat 8.16.1 DaemonSet. `*ai-repo*` 컨테이너 로그를 수집해 Logstash로 전송(ServiceAccount/RBAC 포함).
+- **kustomization.yaml** — 위 리소스를 묶는 overlay.
+
+## 기동 / 제거
+
+```bash
+scripts/elk-local-up.sh      # 배포 + 롤아웃 대기 + 접속 안내
+scripts/elk-local-down.sh    # 전체 삭제 (ES 데이터 포함 초기화)
+```
+
+`CONTEXT` 환경변수로 kube context를 바꿀 수 있다(기본 `docker-desktop`).
+
+## 접속
+
+| 대상 | URL | 비고 |
+| --- | --- | --- |
+| Kibana | http://localhost:30561 | Discover → data view `spring-logs-*` 생성 |
+| Elasticsearch | http://localhost:30920 | health: `/_cluster/health` |
+
+로그 흐름: **Filebeat → Logstash:5044(grok) → Elasticsearch:9200 → Kibana:5601**, 인덱스 `spring-logs-YYYY.MM.dd`.
+grok 파싱에 실패해도 원본 `message`는 유지되어 ES로 전달되므로(`_grokparsefailure_spring` 태그가 붙음) 로그가 유실되지 않는다.

--- a/deploy/k8s/logging/elasticsearch.yaml
+++ b/deploy/k8s/logging/elasticsearch.yaml
@@ -1,0 +1,83 @@
+# 로컬 학습용 Elasticsearch (single-node, security off, ephemeral emptyDir).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: elasticsearch
+  namespace: logging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: elasticsearch
+  template:
+    metadata:
+      labels:
+        app: elasticsearch
+    spec:
+      containers:
+        - name: elasticsearch
+          image: docker.elastic.co/elasticsearch/elasticsearch:8.16.1
+          env:
+            - name: discovery.type
+              value: single-node
+            - name: xpack.security.enabled
+              value: "false"
+            - name: cluster.name
+              value: ai-repo-logging
+            - name: ES_JAVA_OPTS
+              value: -Xms1g -Xmx1g
+            - name: bootstrap.memory_lock
+              value: "false"
+          ports:
+            - containerPort: 9200
+            - containerPort: 9300
+          readinessProbe:
+            httpGet:
+              path: /_cluster/health
+              port: 9200
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 250m
+              memory: 1536Mi
+            limits:
+              memory: 2560Mi
+          volumeMounts:
+            - name: data
+              mountPath: /usr/share/elasticsearch/data
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch
+  namespace: logging
+spec:
+  selector:
+    app: elasticsearch
+  ports:
+    - name: http
+      port: 9200
+      targetPort: 9200
+    - name: transport
+      port: 9300
+      targetPort: 9300
+---
+# API 확인용 NodePort (localhost:30920 -> ES 9200).
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch-nodeport
+  namespace: logging
+spec:
+  type: NodePort
+  selector:
+    app: elasticsearch
+  ports:
+    - name: http
+      port: 9200
+      targetPort: 9200
+      nodePort: 30920

--- a/deploy/k8s/logging/filebeat.yaml
+++ b/deploy/k8s/logging/filebeat.yaml
@@ -1,0 +1,102 @@
+# 로컬 학습용 Filebeat DaemonSet — ai-repo 컨테이너 로그를 수집해 Logstash(5044)로 전송.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: filebeat
+  namespace: logging
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: filebeat
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces", "nodes"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: filebeat
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: filebeat
+subjects:
+  - kind: ServiceAccount
+    name: filebeat
+    namespace: logging
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: filebeat-config
+  namespace: logging
+data:
+  filebeat.yml: |
+    filebeat.inputs:
+      - type: container
+        paths: ["/var/log/containers/*ai-repo*.log"]
+    processors:
+      - add_kubernetes_metadata:
+          host: ${NODE_NAME}
+          matchers: [ { logs_path: { logs_path: "/var/log/containers/" } } ]
+    output.logstash:
+      hosts: ["logstash:5044"]
+    logging.level: info
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: filebeat
+  namespace: logging
+spec:
+  selector:
+    matchLabels:
+      app: filebeat
+  template:
+    metadata:
+      labels:
+        app: filebeat
+    spec:
+      serviceAccountName: filebeat
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+      containers:
+        - name: filebeat
+          image: docker.elastic.co/beats/filebeat:8.16.1
+          args: ["-c", "/etc/filebeat.yml", "-e"]
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          securityContext:
+            runAsUser: 0
+          resources:
+            requests:
+              memory: 128Mi
+            limits:
+              memory: 256Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/filebeat.yml
+              subPath: filebeat.yml
+              readOnly: true
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: filebeat-config
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers

--- a/deploy/k8s/logging/kibana.yaml
+++ b/deploy/k8s/logging/kibana.yaml
@@ -1,0 +1,53 @@
+# 로컬 학습용 Kibana (NodePort localhost:30561 -> 5601).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kibana
+  namespace: logging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kibana
+  template:
+    metadata:
+      labels:
+        app: kibana
+    spec:
+      containers:
+        - name: kibana
+          image: docker.elastic.co/kibana/kibana:8.16.1
+          env:
+            - name: ELASTICSEARCH_HOSTS
+              value: http://elasticsearch:9200
+            - name: SERVER_HOST
+              value: 0.0.0.0
+            - name: SERVER_PUBLICBASEURL
+              value: http://localhost:30561
+          ports:
+            - containerPort: 5601
+          readinessProbe:
+            httpGet:
+              path: /api/status
+              port: 5601
+            initialDelaySeconds: 40
+            periodSeconds: 10
+          resources:
+            requests:
+              memory: 768Mi
+            limits:
+              memory: 1280Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kibana
+  namespace: logging
+spec:
+  type: NodePort
+  selector:
+    app: kibana
+  ports:
+    - port: 5601
+      targetPort: 5601
+      nodePort: 30561

--- a/deploy/k8s/logging/kustomization.yaml
+++ b/deploy/k8s/logging/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - elasticsearch.yaml
+  - logstash.yaml
+  - kibana.yaml
+  - filebeat.yaml

--- a/deploy/k8s/logging/logstash.yaml
+++ b/deploy/k8s/logging/logstash.yaml
@@ -1,0 +1,83 @@
+# 로컬 학습용 Logstash (2단계 파이프라인: beats 입력 -> grok 파싱 -> Elasticsearch 출력).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: logstash-settings
+  namespace: logging
+data:
+  logstash.yml: |
+    http.host: "0.0.0.0"
+    xpack.monitoring.enabled: false
+    pipeline.ecs_compatibility: disabled
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: logstash-pipeline
+  namespace: logging
+data:
+  pipeline.conf: |
+    input { beats { port => 5044 } }
+    filter {
+      grok {
+        match => { "message" => "%{TIMESTAMP_ISO8601:log_timestamp}%{SPACE}%{LOGLEVEL:level}%{SPACE}%{POSINT:pid}%{SPACE}---%{SPACE}\[%{DATA:appname}\]%{SPACE}\[%{DATA:thread}\]%{SPACE}%{NOTSPACE:logger}%{SPACE}:%{SPACE}%{GREEDYDATA:log_message}" }
+        tag_on_failure => ["_grokparsefailure_spring"]
+      }
+      if [log_timestamp] { date { match => ["log_timestamp","ISO8601"] target => "@timestamp" } mutate { remove_field => ["log_timestamp"] } }
+      mutate { strip => ["thread","logger","level"] }
+    }
+    output { elasticsearch { hosts => ["http://elasticsearch:9200"] index => "spring-logs-%{+YYYY.MM.dd}" } }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: logstash
+  namespace: logging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: logstash
+  template:
+    metadata:
+      labels:
+        app: logstash
+    spec:
+      containers:
+        - name: logstash
+          image: docker.elastic.co/logstash/logstash:8.16.1
+          env:
+            - name: LS_JAVA_OPTS
+              value: -Xmx512m -Xms512m
+          ports:
+            - containerPort: 5044
+          resources:
+            requests:
+              memory: 768Mi
+            limits:
+              memory: 1280Mi
+          volumeMounts:
+            - name: pipeline
+              mountPath: /usr/share/logstash/pipeline/
+            - name: settings
+              mountPath: /usr/share/logstash/config/logstash.yml
+              subPath: logstash.yml
+      volumes:
+        - name: pipeline
+          configMap:
+            name: logstash-pipeline
+        - name: settings
+          configMap:
+            name: logstash-settings
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: logstash
+  namespace: logging
+spec:
+  selector:
+    app: logstash
+  ports:
+    - port: 5044
+      targetPort: 5044

--- a/deploy/k8s/logging/namespace.yaml
+++ b/deploy/k8s/logging/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: logging

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,6 +82,7 @@ flowchart LR
 - **4-eyes requeue**: 승인자/반려자는 요청자와 달라야 함. 직접 requeue API는 `410 Gone`으로 폐기(ADR-0040).
 - **컨슈머**: `@Transactional`, processed-event dedup, receipt/delivery metric 기록, 스키마 버전 1.
 - **관측/운영**: relay-run health, consumer 지표, operational-alert(중복 suppression) → Slack/Noop, admin API 접근 감사, 스케줄러 기반 pruning(모두 기본 비활성).
+- **로그**: 기본은 PLG(Loki) 파드 로그 수집이며, 학습용 **opt-in ELK 대안**(Filebeat→Logstash→ES→Kibana)을 병존 스택으로 둘 수 있다(ArgoCD 미포함, 수동 기동). → [ELK 학습 문서](learning/elk-stack.md)
 
 ## 5. 시큐리티 체인
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -52,6 +52,19 @@
 | **ownership check** | 토큰 소유자와 지갑 소유자를 대조하는 per-user 접근 정책(`WalletAccessPolicy`). |
 | **admin API access audit** | 운영 API 접근 성공/실패 이력 기록. (ADR-0031) |
 
+## 관측·로그 (opt-in ELK)
+
+기본 로그 스택은 PLG(Loki)이며, 아래 용어는 학습용 **opt-in** ELK 대안 스택에서 쓴다. (ADR-0066, [ELK 학습 문서](learning/elk-stack.md))
+
+| 용어 | 정의 |
+| --- | --- |
+| **ELK / Elastic Stack** | Elasticsearch·Logstash·Kibana(+Beats) 로그 수집·검색·시각화 스택. ai-repo에서는 PLG를 대체하지 않는 **opt-in 학습 스택**으로 병존한다(ArgoCD 미포함, `scripts/elk-local-up.sh` 수동 기동). |
+| **Filebeat** | 노드마다 도는 경량 로그 shipper(DaemonSet). `ai-repo` 파드 로그 파일을 tail해 Logstash로 전송한다. backpressure를 지원해 하류가 밀리면 전송을 늦춘다. |
+| **Logstash** | input→filter→output 파이프라인. `beats:5044` 입력을 받아 **grok** 필터로 Spring 로그를 필드로 파싱하고 Elasticsearch로 출력한다. |
+| **grok** | 정규식 기반 로그 파싱 필터. 이름 붙은 패턴(`%{TIMESTAMP_ISO8601}`, `%{LOGLEVEL}` 등)으로 비정형 로그 라인을 구조화 필드로 분해한다. 파싱 실패 시 원본 `message`는 유지되고 `_grokparsefailure_spring` 태그가 붙는다. |
+| **역색인 (Inverted Index)** | Elasticsearch의 핵심 자료구조. "문서→단어"가 아니라 "단어→그 단어를 포함한 문서 목록"으로 뒤집어 저장해 전문 검색을 빠르게 한다. Loki의 라벨 인덱스(값은 grep)와 대비된다. |
+| **Kibana** | Elasticsearch 위의 검색·시각화 UI. Discover에서 data view(`spring-logs-*`)와 **KQL**(`level: ERROR` 등)로 로그를 탐색한다(NodePort 30561). |
+
 ## 하네스·프로세스
 
 | 용어 | 정의 |

--- a/docs/adr/0066-elk-logging-stack.md
+++ b/docs/adr/0066-elk-logging-stack.md
@@ -1,0 +1,66 @@
+# ADR-0066: 학습용 opt-in ELK 로깅 스택
+
+## 상태
+
+Accepted
+
+## 배경
+
+ai-repo의 기본 관측 스택은 PLG(Prometheus/Loki/Grafana/Alloy)이며, 로그는 Alloy가 수집해 Loki에 적재한다(ADR-0059). Loki는 로그 본문을 인덱싱하지 않고 라벨(label)만 인덱싱한 뒤 본문은 압축 저장하고 조회 시 grep 방식으로 훑는 구조라 운영 비용이 낮다.
+
+한편 로그 파이프라인의 대표 구성인 ELK(Elasticsearch/Logstash/Kibana + Filebeat)는 로그 본문을 역색인(inverted index)으로 색인해 임의 필드/전문 검색을 빠르게 지원하고, Logstash grok으로 비정형 로그를 구조화하는 파싱 단계를 학습할 수 있다. 이 저장소는 학습 목적을 겸하므로, PLG를 대체하지 않고 ELK를 **직접 만져보며 두 접근(라벨-grep vs 역색인, 파싱 유무)의 차이를 체감**할 수단이 필요했다.
+
+문제는 ELK가 상시 켜두기에는 무겁다는 점이다. Elasticsearch 단독으로도 JVM 힙 1g 이상을 요구하고 Logstash/Kibana까지 더하면 로컬 리소스를 크게 점유한다. 상시 배포(ArgoCD) 대상에 넣으면 학습 의도와 무관하게 항상 자원을 소모한다.
+
+## 결정
+
+Filebeat → Logstash(grok) → Elasticsearch → Kibana 4-tier ELK 스택을 **학습용 opt-in 모듈**로 도입하고, 기존 PLG와 **병존(대체 아님)**시킨다.
+
+| 항목 | 결정 |
+| --- | --- |
+| 토폴로지 | Filebeat(수집) → Logstash(파싱/변환) → Elasticsearch(색인/저장) → Kibana(검색/시각화)의 **2단계(Logstash 경유)** 구성. Beats가 ES로 직접 보내는 1단계 대신 Logstash를 끼워 grok 파싱을 학습 |
+| 배치 위치 | 앱(`ai-repo`)과 분리된 `logging` 네임스페이스에 자기완결적 kustomize overlay(`deploy/k8s/logging/`)로 구성 |
+| opt-in | ArgoCD GitOps(`deploy/gitops`)에 **포함하지 않는다**. 항상 켜지지 않으며 `scripts/elk-local-up.sh`/`elk-local-down.sh`로 수동 기동·제거 |
+| 파싱 | Logstash pipeline에서 Spring Boot 로그(`ISO8601 LEVEL PID --- [app] [thread] logger : message`)를 grok으로 분해해 `level`/`pid`/`thread`/`logger`/`log_message` 필드화. grok 실패 시 `_grokparsefailure_spring` 태그를 붙이되 원본 `message`는 유지해 ES로 전달 |
+| 인덱스 | `spring-logs-%{+YYYY.MM.dd}` 일자별 인덱스, Kibana data view `spring-logs-*` |
+| 버전 | Elastic Stack **8.16.1** 고정(ES/Logstash/Kibana/Filebeat 동일 버전) |
+| 로컬 전제 | `xpack.security.enabled=false`(인증 없음), `discovery.type=single-node`, 데이터는 emptyDir(ephemeral), 힙/리소스 축소 |
+| 접속 | Kibana NodePort 30561(`http://localhost:30561`), Elasticsearch NodePort 30920(`http://localhost:30920`) |
+
+## 왜 PLG를 두고 ELK를 별도로 두는가
+
+PLG와 ELK는 로그를 다루는 철학이 다르다. Loki는 라벨만 인덱싱하고 본문은 grep으로 훑어 저장·운영 비용이 낮은 대신 임의 필드 검색이 느리다. Elasticsearch는 본문을 역색인해 임의 필드·전문 검색이 빠른 대신 색인 비용과 리소스가 크다. **어느 쪽이 우월한 것이 아니라 트레이드오프가 반대 방향**이므로, 기본 운영 스택(PLG)은 그대로 두고 ELK는 두 접근을 비교 학습하는 대안으로 병존시킨다.
+
+또한 Logstash grok 파싱 단계 자체가 학습 대상이다. Loki 경로에는 없는 "비정형 로그 → 구조화 필드" 변환을 직접 작성해봄으로써 파이프라인의 파싱 계층을 이해할 수 있다.
+
+## 왜 상시 배포가 아니라 opt-in인가
+
+ELK는 상시 켜두기에 무겁다(ES JVM 힙 1g + Logstash/Kibana). 학습 목적의 스택을 ArgoCD 상시 배포에 넣으면 필요 없을 때도 로컬 자원을 계속 점유한다. 그래서 GitOps 대상에서 제외하고, 필요할 때만 스크립트로 올렸다가 내리는 opt-in으로 둔다. `logging` 네임스페이스 분리와 자기완결적 overlay 덕분에 앱/PLG 스택에 영향 없이 기동·제거가 가능하다.
+
+## 로컬 전제와 라이선스
+
+- **비프로덕션 전제**: `xpack.security.enabled=false`로 인증·TLS를 끈다. 학습 편의를 위한 것이며 클러스터 외부에 노출하지 않는 로컬 사용을 전제로 한다. 프로덕션에서는 보안 활성화와 자격증명 주입이 필수다.
+- **단일 노드·ephemeral**: `discovery.type=single-node`, 데이터는 emptyDir이라 파드 재기동 시 인덱스가 사라진다. 영속성은 학습 범위 밖으로 둔다(PVC는 후속 과제).
+- **리소스**: ES 힙 `-Xms1g -Xmx1g`, Logstash `-Xmx512m`로 축소하고 각 컴포넌트에 requests/limits를 건다. 그래도 로컬에서 상당한 메모리를 요구하므로 파드 pending 시 리소스 부족을 우선 의심한다.
+- **라이선스**: Elastic Stack 8.16은 **AGPLv3 옵션**이 존재한다(SSPL/Elastic License 외 선택지). 성숙도가 높고 자료가 풍부한 8.16.1을 학습 버전으로 고정한다.
+
+## 트레이드오프
+
+### 장점
+
+- PLG(라벨-grep)와 ELK(역색인)를 같은 저장소에서 나란히 비교·학습할 수 있다.
+- Logstash grok으로 파싱 계층을 직접 다뤄본다. grok 실패해도 원본 로그가 보존돼 데이터 유실 없이 패턴을 반복 교정할 수 있다.
+- `logging` 네임스페이스 + opt-in 분리로 기본 운영 스택(앱/PLG)과 완전히 격리된다.
+
+### 비용
+
+- ELK는 무겁다. 상시 배포가 아닌 수동 기동이라 항상 최신 로그를 보지 못하고, 올릴 때마다 리소스를 확보해야 한다.
+- 보안 off·단일노드·ephemeral 전제라 프로덕션 구성과 거리가 있다. 학습용 구성을 그대로 운영에 쓸 수 없다.
+- 스택이 두 벌(PLG·ELK) 존재하므로 문서/구성의 인지 부담이 늘어난다. opt-in·별도 네임스페이스로 격리해 완화한다.
+
+## 대안
+
+- **PLG로 통일(ELK 미도입)**: 가장 단순하고 운영 스택이 하나로 유지되지만, 역색인·grok 파싱을 학습할 수단이 없어 이 결정의 학습 목표를 충족하지 못한다.
+- **ELK 1단계(Filebeat → ES 직접, Logstash 생략)**: 구성이 가볍지만 grok 파싱 계층 학습이 빠진다. ES Ingest Pipeline으로 파싱을 대체할 수 있으나, 파이프라인 학습 관점에서 독립 Logstash를 두는 편이 명확하다.
+- **ELK 상시 배포(ArgoCD 포함)**: 항상 최신 로그를 검색할 수 있으나 학습용 스택이 상시 리소스를 점유해 로컬 부담이 크다. opt-in 의도와 맞지 않는다.
+- **보안 활성화 구성**: 프로덕션에 가깝지만 인증서·자격증명 설정 비용이 커 로컬 학습 진입장벽을 높인다. 범위 밖으로 둔다.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -81,3 +81,4 @@ ADR은 이 저장소에서 중요한 결정의 source of truth입니다. README�
 | ADR-0063 | Application Layer Spring Annotation Policy | Accepted |
 | ADR-0064 | JDBC Persistence Adapter Decomposition | Accepted |
 | ADR-0065 | Broker Consumer Endpoint Authentication | Accepted |
+| ADR-0066 | 학습용 opt-in ELK 로깅 스택 | Accepted |

--- a/docs/development/architecture-diagrams.md
+++ b/docs/development/architecture-diagrams.md
@@ -193,6 +193,46 @@ graph LR
 
 지표 목록과 대시보드 패널: `docs/development/k8s-local-monitoring.md` Outbox 커스텀 지표 섹션.
 
+## 4. (opt-in) ELK 로그 파이프라인
+
+기본 로그 스택은 PLG(Loki)이며, 학습용으로 **opt-in** ELK 스택을 병존시킬 수 있다. ArgoCD(GitOps)에는 포함하지 않고 `scripts/elk-local-up.sh`로만 수동 기동한다. Filebeat(DaemonSet)가 `ai-repo` 파드 로그를 tail → Logstash가 grok으로 Spring 로그를 파싱 → Elasticsearch 역색인(`spring-logs-YYYY.MM.dd`) → Kibana Discover에서 KQL 검색한다.
+
+```mermaid
+graph LR
+    pods["ai-repo 파드 로그<br/>/var/log/containers/*ai-repo*.log"]
+
+    subgraph LOGGING["logging 네임스페이스 (opt-in · ArgoCD 미포함)"]
+        fb["Filebeat<br/>DaemonSet (노드별 tail)"]
+        ls["Logstash<br/>grok 파싱 :5044"]
+        es[("Elasticsearch<br/>역색인 :9200 / NodePort 30920<br/>index spring-logs-YYYY.MM.dd")]
+        kb["Kibana<br/>Discover/KQL :5601 / NodePort 30561"]
+    end
+
+    dev["개발자<br/>localhost:30561"]
+
+    pods -->|container input| fb
+    fb -->|beats| ls
+    ls -->|bulk index| es
+    kb -->|query| es
+    dev -->|브라우저| kb
+
+    classDef source fill:#e2e8f0,stroke:#475569
+    classDef optin fill:#fce7f3,stroke:#be185d
+    classDef store fill:#fef9c3,stroke:#ca8a04,stroke-width:2px
+    classDef actor fill:#fff3cd,stroke:#b45309,stroke-width:2px
+
+    class pods source
+    class fb,ls,kb optin
+    class es store
+    class dev actor
+    style LOGGING fill:#fdf2f8,stroke:#f9a8d4,stroke-dasharray:5 5
+```
+
+> 색상: ⚪ 로그 소스 · 🩷 ELK 컴포넌트(opt-in, 점선 = ArgoCD 미포함 수동 기동) · 🟨 Elasticsearch 역색인 · 🟡 개발자
+
+- grok 파싱에 실패해도 원본 `message`는 유지되어 ES로 전달된다(`_grokparsefailure_spring` 태그).
+- 기동/제거·접속 URL·KQL 예시: `docs/development/elk-local-logging.md`, 개념 학습: `docs/learning/elk-stack.md`, 결정 배경: `docs/adr/0066-elk-logging-stack.md`.
+
 ## 관련 문서
 
 - `docs/development/k8s-local-monitoring.md` — 접속 정보·명령어·지표·로그 검색

--- a/docs/development/elk-local-logging.md
+++ b/docs/development/elk-local-logging.md
@@ -1,0 +1,165 @@
+# 로컬 ELK 로깅 스택 (opt-in) — Filebeat → Logstash → Elasticsearch → Kibana
+
+기존 PLG(Prometheus/Loki/Grafana/Alloy)와 **별개의 학습용 opt-in 로깅 스택**을 Docker Desktop 내장 Kubernetes에 기동하는 가이드. PLG를 대체하지 않고 병존하며, 항상 켜지지 않는다(ArgoCD 미포함). 로그를 grok로 **파싱**해 필드 단위(`level`, `logger`, `log_message` …)로 검색하는 역색인 방식을 학습하는 것이 목적이다.
+
+배경/결정은 `docs/adr/0066-elk-logging-stack.md`, 원리 심화는 `docs/learning/elk-stack.md` 참고.
+
+## 전제 조건
+
+- Docker Desktop 실행 중, **Settings → Kubernetes → Enable Kubernetes** 활성화
+- `kubectl` 설치 (`docker-desktop` context 자동 생성됨)
+- **메모리 여유**: ELK는 무겁다. Elasticsearch 단독으로 `-Xms1g -Xmx1g`(요청 1536Mi / 제한 2560Mi), Logstash·Kibana 각 768Mi~1280Mi를 쓴다. Docker Desktop **Settings → Resources → Memory를 최소 6~8GB**로 올려야 pod가 pending 없이 뜬다. PLG 스택까지 동시에 띄우려면 더 필요하다.
+- ai-repo 앱이 이미 떠 있어야 로그가 수집된다(`./scripts/k8s-local-up.sh`). Filebeat는 `/var/log/containers/*ai-repo*.log`만 tail하므로 앱이 없으면 인덱스가 비어 있다.
+
+## 기동 / 정리
+
+```bash
+./scripts/elk-local-up.sh    # kubectl apply -k → ES·Logstash·Kibana 롤아웃 + Filebeat DaemonSet 대기
+./scripts/elk-local-down.sh  # logging 네임스페이스 전체 제거 (emptyDir이므로 데이터도 소멸)
+```
+
+기동 스크립트는 `logging` 네임스페이스에 매니페스트를 적용하고 ES → Logstash → Kibana 순으로 `rollout status`(각 300s)를 기다린 뒤 Filebeat DaemonSet ready까지 확인하고 접속 URL을 출력한다. `CONTEXT` 환경변수로 context를 바꿀 수 있다(기본 `docker-desktop`).
+
+```bash
+CONTEXT=my-cluster ./scripts/elk-local-up.sh   # 다른 context에 기동
+```
+
+## 접속 정보 (URL · 인증)
+
+| 서비스 | URL | 인증 |
+| --- | --- | --- |
+| Kibana | http://localhost:30561 | **없음** — 로컬 학습 전용 `xpack.security.enabled=false` |
+| Kibana Discover | http://localhost:30561/app/discover | 없음 |
+| Elasticsearch API | http://localhost:30920 | 없음 (NodePort, API 확인용) |
+| 클러스터 헬스 | http://localhost:30920/_cluster/health | 없음 — `status: green\|yellow` 확인 |
+| 인덱스 목록 | http://localhost:30920/_cat/indices?v | 없음 — `spring-logs-YYYY.MM.dd` 확인 |
+
+> **보안 주의**: 로컬 학습 편의를 위해 인증을 끈(`xpack.security.enabled=false`) 단일노드·ephemeral(emptyDir) 구성이다. 데이터는 pod 재시작 시 사라지며, 원격/프로덕션에서는 절대 이 설정을 쓰지 않는다.
+
+## Kibana에서 로그 보기 (Discover)
+
+1. http://localhost:30561 접속 → 좌측 메뉴 **☰ → Analytics → Discover**
+2. 최초 진입 시 **data view**가 없으면 생성 창이 뜬다. **Create data view** 클릭
+   - **Name**: `spring-logs` (임의)
+   - **Index pattern**: `spring-logs-*`  ← 날짜별 인덱스를 한 번에 매칭
+   - **Timestamp field**: `@timestamp` (Logstash가 로그 시각을 여기에 매핑)
+   - **Save data view to Kibana**
+3. Discover 상단 검색창에서 KQL/Lucene로 검색. 우상단 시간 범위(기본 Last 15 minutes)를 넉넉히(Last 1 hour) 잡아야 로그가 보인다.
+
+### 파싱된 필드
+
+Logstash grok가 Spring Boot 로그 한 줄을 아래 필드로 분해한다. Discover 좌측 **Available fields**에서 확인·추가한다.
+
+| 필드 | 의미 | 예시 |
+| --- | --- | --- |
+| `@timestamp` | 로그 발생 시각(ISO8601 → 매핑) | `2026-07-04T09:50:42.320Z` |
+| `level` | 로그 레벨 | `INFO`, `ERROR`, `WARN` |
+| `pid` | 프로세스 ID | `1` |
+| `appname` | 앱 이름(`[...]` 안) | `ai-repo` |
+| `thread` | 스레드명 | `main`, `http-nio-8080-exec-1` |
+| `logger` | 로거(클래스) | `com.imwoo.airepo.AiRepoApplication` |
+| `log_message` | 실제 메시지 | `Started AiRepoApplication in 15.044 seconds` |
+| `message` | 원본 전체 줄(파싱 실패해도 유지) | (한 줄 전체) |
+
+> grok가 실패해도 **원본 `message`는 그대로 ES에 저장**되고 `_grokparsefailure_spring` 태그가 붙는다(트러블슈팅 참고). 로그가 유실되지 않는다.
+
+## 검색 예시 (KQL / Lucene)
+
+Discover 검색창 기본은 **KQL**. Lucene으로 바꾸려면 검색창 우측 언어 토글을 쓴다.
+
+```text
+# ── KQL ──────────────────────────────────────────────
+level: ERROR                         # 에러 레벨만
+level: ERROR or level: WARN          # 에러 + 경고
+log_message: *timeout*               # 메시지에 timeout 포함 (와일드카드)
+logger: *OutboxRelay*                # 특정 로거(클래스)
+thread: main and level: INFO         # 조건 결합
+not level: INFO                      # INFO 제외
+log_message: "wallet-001"            # 특정 지갑 추적(따옴표 = 구문)
+tags: _grokparsefailure_spring       # 파싱 실패한 로그만 (grok 디버깅)
+
+# ── Lucene ───────────────────────────────────────────
+level:ERROR AND log_message:*timeout*
+log_message:/.*[Tt]ransfer.*/        # 정규식
+```
+
+## 파이프라인 확인 (kubectl)
+
+로그가 Kibana에 안 보이면 **Filebeat 수집 → Logstash 파싱 → ES 색인** 순서로 각 단계를 점검한다.
+
+```bash
+# ── 파드 상태 (모두 Running / DaemonSet DESIRED=CURRENT 확인) ──────
+kubectl --context docker-desktop -n logging get pods -o wide
+kubectl --context docker-desktop -n logging get ds filebeat
+
+# ── Filebeat: ai-repo 로그를 잡아 Logstash로 보내는지 ─────────────
+kubectl --context docker-desktop -n logging logs ds/filebeat --tail=100 -f
+#   "Harvester started for file: /var/log/containers/...ai-repo..." 가 보이면 수집 중
+#   "Connecting to backoff(async(tcp://logstash:5044))" 연결 확인
+
+# ── Logstash: grok 파싱 / ES 출력 상태 ───────────────────────────
+kubectl --context docker-desktop -n logging logs deploy/logstash --tail=100 -f
+#   "Pipeline started" / beats input 5044 리슨 / elasticsearch output 연결 확인
+
+# ── Elasticsearch: 인덱스가 생성되고 문서가 쌓이는지 ──────────────
+kubectl --context docker-desktop -n logging logs deploy/elasticsearch --tail=50
+curl -s http://localhost:30920/_cat/indices?v                    # spring-logs-YYYY.MM.dd 행 + docs.count
+curl -s http://localhost:30920/_cluster/health?pretty            # status green/yellow
+curl -s 'http://localhost:30920/spring-logs-*/_search?size=1&pretty'  # 문서 1건 직접 조회(파싱 필드 확인)
+
+# ── 파드 이벤트 (pending 원인 / OOM / probe 실패) ─────────────────
+kubectl --context docker-desktop -n logging get events --sort-by=.lastTimestamp
+```
+
+## 리소스 주의
+
+- ELK는 로컬에서 가장 무거운 스택이다. **Elasticsearch만으로 힙 1GB + 오버헤드**를 쓰고, 세 컴포넌트 합쳐 요청 3GB / 제한 5GB 수준이다. Docker Desktop 메모리가 부족하면 pod가 `Pending`에 머문다.
+- 학습이 끝나면 **반드시 `./scripts/elk-local-down.sh`로 내려서** 메모리를 회수한다. emptyDir이라 어차피 데이터는 보존되지 않으니 상시 켜둘 이유가 없다.
+- PLG와 ELK를 **동시에** 띄우면 메모리 압박이 커진다. 학습 시에는 한 번에 하나만 권장.
+
+## 트러블슈팅
+
+| 증상 | 원인 | 조치 |
+| --- | --- | --- |
+| pod가 `Pending`에서 안 뜸 | 노드 메모리·CPU 부족(스케줄 불가) | `kubectl -n logging describe pod <name>`의 Events에서 `Insufficient memory` 확인 → Docker Desktop 메모리 상향(6~8GB↑) 또는 PLG 스택 내리기 |
+| Kibana `Kibana server is not ready yet` | ES가 아직 green/yellow 아님(초기화 중) | 30~60초 대기. `curl :30920/_cluster/health`로 status 확인. ES pod가 OOM이면 events 확인 |
+| Discover에 로그가 없음 | ① 시간 범위 좁음 ② 앱 미기동 ③ 인덱스 미생성 | 시간 범위를 Last 1 hour로 확대 · ai-repo 앱 기동 확인 · `_cat/indices`에 `spring-logs-*` 있는지 확인 |
+| 필드가 파싱 안 되고 `message`만 있음 | grok 매칭 실패 | KQL `tags: _grokparsefailure_spring`로 실패 로그 확인. 로그 포맷이 스펙(`ISO8601 LEVEL PID --- [app] [thread] logger : msg`)과 다르면 `deploy/k8s/logging/logstash.yaml`의 grok 패턴을 조정 |
+| data view 생성 시 인덱스가 안 보임 | 아직 문서가 색인되지 않음 | 로그가 최소 1건 ES에 들어와야 패턴이 매칭된다. 파이프라인 확인 절차로 Filebeat→Logstash→ES 흐름 점검 |
+| Filebeat 로그에 harvester 없음 | ai-repo 파드가 없거나 다른 노드 | 앱 기동 확인. Filebeat는 DaemonSet이라 노드마다 뜨며 `/var/log/containers/*ai-repo*.log`만 tail |
+
+> **grok 실패해도 로그는 유실되지 않는다.** 파싱에 실패한 줄은 `_grokparsefailure_spring` 태그와 함께 원본 `message`를 담아 ES로 그대로 전달된다. 즉 파싱 실패 = 검색 필드 부재이지 로그 손실이 아니다.
+
+## PLG(Loki) LogQL ↔ ELK KQL 치트시트
+
+같은 로그를 두 스택에서 어떻게 검색하는지 대응표. **핵심 차이**: Loki는 라벨(`app`, `namespace`)로 스트림을 고른 뒤 본문을 grep(`|=`, `|~`)한다(라벨 인덱스). ELK는 grok로 미리 쪼갠 **필드**를 역색인으로 직접 질의한다(`level: ERROR`처럼 필드=값).
+
+| 목적 | Loki LogQL (Grafana Explore) | ELK KQL (Kibana Discover) |
+| --- | --- | --- |
+| 앱 전체 로그 | `{app="ai-repo"}` | (data view `spring-logs-*` 전체, 쿼리 비움) |
+| 에러만 | `{app="ai-repo"} |= "ERROR"` | `level: ERROR` |
+| 에러 + 경고 | `{app="ai-repo"} |~ "ERROR|WARN"` | `level: ERROR or level: WARN` |
+| 부분 문자열(timeout) | `{app="ai-repo"} |= "timeout"` | `log_message: *timeout*` |
+| 정규식 매칭 | `{app="ai-repo"} |~ "Transfer|TRANSFER"` | `log_message: *ransfer*` (또는 Lucene `log_message:/.*[Tt]ransfer.*/`) |
+| 특정 로거/클래스 | `{app="ai-repo"} |= "OutboxRelay"` | `logger: *OutboxRelay*` |
+| 특정 값 추적 | `{app="ai-repo"} |= "wallet-001"` | `log_message: "wallet-001"` |
+| 제외 | `{app="ai-repo"} != "INFO"` | `not level: INFO` |
+| 조건 결합 | `{app="ai-repo"} |= "ERROR" |= "timeout"` | `level: ERROR and log_message: *timeout*` |
+| 발생률/집계 | `sum by (app) (rate({namespace="ai-repo"}[5m]))` | Kibana **Lens/Visualize**로 `@timestamp` 히스토그램 집계 |
+
+> 한 줄 요약: **Loki = 라벨로 좁히고 본문 grep(쓰기 저렴/검색은 스캔), ELK = 필드 역색인 직접 질의(쓰기 비쌈/필드 검색 강력).** 자세한 비교는 `docs/learning/elk-stack.md`.
+
+## 이슈 트래킹
+
+로그에서 문제(에러 급증, 파싱 실패, 파드 크래시)를 발견하면:
+
+1. Kibana Discover의 KQL 쿼리 결과 스크린샷 또는 `curl :30920/spring-logs-*/_search` 출력, `kubectl describe` 출력을 증적으로 수집
+2. `issue-drafts/`에 `.github/ISSUE_TEMPLATE/bug.yml` 형식으로 초안 작성(재현 절차 + 증적 포함)
+3. GitHub Issue 생성 후 `issue-drafts/README.md` 목록에 링크 기록, 수정 PR에 이슈 연결
+
+## 관련 문서
+
+- `docs/adr/0066-elk-logging-stack.md` — ELK 도입 결정(PLG 병존, opt-in, 2단계 Logstash grok 선택 이유)
+- `docs/learning/elk-stack.md` — ELK 4-tier 아키텍처·grok 원리·PLG vs ELK 심화
+- `docs/development/k8s-local-monitoring.md` — 기본 PLG(Prometheus/Grafana/Loki) 로컬 모니터링
+- `deploy/k8s/logging/README.md` — 매니페스트 overlay 구성 설명

--- a/docs/learning/README.md
+++ b/docs/learning/README.md
@@ -1,0 +1,9 @@
+# 학습 문서 (Learning)
+
+ai-repo를 소재로 한 **개념 학습용 튜토리얼** 모음입니다. 실제 실행/운영 문서는 [Getting Started](../GETTING-STARTED.md)와 [development/](../development/)를, 결정 근거는 [ADR](../adr/README.md)를 참고하세요. 이 폴더의 글은 "왜 이렇게 동작하는가"를 초심자에게 친절히 설명하는 데 초점을 둡니다.
+
+## 목록
+
+| 문서 | 무엇을 배우나 | 관련 |
+| --- | --- | --- |
+| [elk-stack.md](elk-stack.md) | ELK 로깅 스택(Filebeat→Logstash→Elasticsearch→Kibana) 4-tier 아키텍처, grok 파싱, 역색인, PLG(Loki)와의 비교, Kibana 실습 | opt-in · [ADR-0066](../adr/0066-elk-logging-stack.md) · [가이드](../development/elk-local-logging.md) |

--- a/docs/learning/elk-stack.md
+++ b/docs/learning/elk-stack.md
@@ -1,0 +1,288 @@
+# ELK 로깅 스택 배우기 (Filebeat → Logstash → Elasticsearch → Kibana)
+
+> 이 문서는 ai-repo에 붙어 있는 **학습용 opt-in ELK 스택**을 처음 보는 사람을 위한 튜토리얼입니다. 기존 기본 로그 스택은 PLG(Loki)이고, ELK는 "로그를 다른 방식으로 다뤄보는 실습장"으로 병존합니다. 실제 기동/정리는 `scripts/elk-local-up.sh` / `scripts/elk-local-down.sh`, 매니페스트는 `deploy/k8s/logging/`, 실무 가이드는 [elk-local-logging.md](../development/elk-local-logging.md)를 참고하세요. 도입 배경/결정은 [ADR-0066](../adr/0066-elk-logging-stack.md)에 있습니다.
+
+로그 한 줄이 앱에서 나와서 Kibana 화면에서 검색되기까지, **네 개의 부품**이 릴레이 하듯 로그를 넘깁니다. 이 문서를 다 읽으면 "왜 부품이 네 개나 필요한가", "grok이 도대체 무슨 마법인가", "Loki랑 뭐가 다른가"를 스스로 설명할 수 있게 됩니다.
+
+---
+
+## 1. ELK 4-tier 아키텍처 한눈에 보기
+
+ELK는 원래 **E**lasticsearch + **L**ogstash + **K**ibana 세 글자였는데, 로그를 실어 나르는 경량 수집기 **Filebeat**(Beats 계열)가 합류하면서 사실상 4단(tier) 구조가 되었습니다. 각 단은 "한 가지 일만 잘한다"는 원칙으로 분리돼 있습니다.
+
+| 단(tier) | 부품 | 한 줄 역할 | ai-repo에서 |
+| --- | --- | --- | --- |
+| 수집 | **Filebeat** | 각 노드에서 로그 파일을 tail 해서 밀어줌 | DaemonSet, `*ai-repo*.log`만 수집 |
+| 가공 | **Logstash** | 원본 텍스트를 파싱해 구조화(필드 분리) | grok으로 Spring 로그 분해, :5044 |
+| 저장/검색 | **Elasticsearch** | 역색인으로 저장하고 빠른 전문검색 제공 | 인덱스 `spring-logs-YYYY.MM.dd`, :9200 |
+| 시각화 | **Kibana** | 검색 UI(Discover/KQL)와 대시보드 | NodePort 30561 |
+
+```mermaid
+flowchart LR
+    app["ai-repo 파드<br/>(Spring Boot 로그 → stdout)"]
+    node["노드 파일<br/>/var/log/containers/*ai-repo*.log"]
+    fb["Filebeat<br/>(DaemonSet, 경량 shipper)"]
+    ls["Logstash :5044<br/>(input → filter/grok → output)"]
+    es[("Elasticsearch :9200<br/>역색인 저장<br/>spring-logs-YYYY.MM.dd")]
+    kb["Kibana :5601 / NodePort 30561<br/>(Discover · KQL · 대시보드)"]
+    user["개발자 브라우저"]
+
+    app -->|"stdout → 컨테이너 로그 파일"| node
+    node -->|"tail + k8s 메타 부착"| fb
+    fb -->|"beats 프로토콜 push"| ls
+    ls -->|"구조화된 JSON 문서 색인"| es
+    kb -->|"검색 질의"| es
+    user -->|"localhost:30561"| kb
+
+    classDef collect fill:#dcfce7,stroke:#16a34a;
+    classDef process fill:#ffedd5,stroke:#ea580c;
+    classDef store fill:#dbeafe,stroke:#1d4ed8;
+    classDef view fill:#fce7f3,stroke:#be185d;
+    class fb collect
+    class ls process
+    class es store
+    class kb view
+```
+
+**왜 이렇게 나눠놨을까?** 각 단을 독립적으로 확장/교체할 수 있기 때문입니다. 로그가 폭증하면 Filebeat는 그대로 두고 Logstash만 늘릴 수 있고, 파싱 규칙을 바꿔도 저장소(ES)는 건드리지 않습니다. 반대로 단이 많다는 건 **운영 부담과 리소스 비용**이 크다는 뜻이기도 합니다(그래서 ai-repo에서는 학습용 opt-in으로만 둡니다).
+
+---
+
+## 2. 컴포넌트 심화
+
+### 2-1. Filebeat — 경량 shipper와 backpressure
+
+Filebeat는 Go로 짜인 **아주 가벼운** 로그 수집기입니다. 하는 일은 단순합니다.
+
+- 지정한 파일들(`/var/log/containers/*ai-repo*.log`)을 계속 열어두고 새 줄이 추가되면 읽어서 다음 단으로 보냄(tail -f 같은 동작).
+- **어디까지 읽었는지 offset을 기억**(registry)합니다. 그래서 Filebeat가 재시작돼도 중복/누락 없이 이어서 읽습니다.
+- ai-repo에서는 DaemonSet으로 배포돼 **모든 노드에 한 개씩** 뜨고, 그 노드의 컨테이너 로그를 훑습니다. `add_kubernetes_metadata` 프로세서가 파드 이름·네임스페이스 같은 k8s 메타데이터를 로그에 붙여줍니다.
+
+가장 중요한 개념이 **backpressure(역압)**입니다. 다음 단(Logstash)이 느려지거나 잠깐 죽으면 어떻게 될까요? Filebeat는 무작정 밀어붙이지 않고 **전송 속도를 늦추거나 멈춥니다**. 보낸 데이터가 확인(ack)되기 전까지 offset을 전진시키지 않기 때문에, 병목이 풀리면 멈췄던 지점부터 다시 보냅니다. 즉 "로그를 잃지 않으려고 스스로 브레이크를 밟는" 구조입니다. 무거운 Logstash를 앞단에서 얇은 Filebeat가 감싸주는 이유가 이것입니다.
+
+### 2-2. Logstash — input / filter / output 3단 파이프라인
+
+Logstash는 ELK에서 가장 무거운(JVM 기반) 부품이고, 하는 일은 **가공**입니다. 파이프라인은 항상 세 블록으로 이뤄집니다. ai-repo의 `deploy/k8s/logging/logstash.yaml` ConfigMap에 든 `pipeline.conf`가 정확히 이 구조입니다.
+
+```
+input  { beats { port => 5044 } }          # 어디서 받나: Filebeat가 5044로 보냄
+filter { grok { ... } date { ... } ... }   # 어떻게 가공하나: 텍스트 → 필드
+output { elasticsearch { ... } }           # 어디로 보내나: ES 인덱스에 색인
+```
+
+- **input**: `beats` 입력으로 Filebeat의 연결을 5044 포트에서 받습니다.
+- **filter**: 핵심입니다. `grok`으로 한 줄 문자열을 여러 필드로 쪼개고, `date`로 로그 안의 시간 문자열을 진짜 `@timestamp`로 바꾸고, `mutate`로 공백을 다듬습니다(자세한 건 3장).
+- **output**: 가공된 문서를 `http://elasticsearch:9200`의 `spring-logs-%{+YYYY.MM.dd}` 인덱스로 보냅니다. 인덱스 이름에 날짜가 들어가 **하루에 하나씩** 인덱스가 생깁니다(오래된 로그를 날짜 단위로 지우기 쉬움).
+
+### 2-3. Elasticsearch — 역색인 · 샤드 · 인덱스
+
+Elasticsearch는 저장 + 검색 엔진입니다. 세 단어만 이해하면 됩니다.
+
+- **문서(document)**: 로그 한 줄이 JSON 문서 하나입니다. `{ "level": "INFO", "logger": "...", "log_message": "Started ...", "@timestamp": "..." }` 같은 모양.
+- **인덱스(index)**: 문서들을 담는 논리적 통. ai-repo에서는 날짜별 `spring-logs-2026.07.04` 형태. (RDB의 "테이블"에 가깝다고 생각하면 편합니다.)
+- **샤드(shard)**: 인덱스를 물리적으로 쪼갠 조각. 데이터가 커지면 여러 샤드/노드로 분산해 병렬 검색합니다. (우리 로컬 학습 스택은 단일 노드라 샤드 분산 효과는 크지 않지만 개념은 동일합니다.)
+
+**역색인(inverted index)** 이 ES의 심장입니다. 보통 우리가 아는 색인은 "문서 → 그 안의 단어들"이지만, 역색인은 거꾸로 **"단어 → 그 단어가 등장한 문서 목록"** 을 미리 만들어 둡니다.
+
+```
+문서1: "connection timeout error"
+문서2: "user timeout retry"
+
+역색인:
+  timeout   → [문서1, 문서2]
+  error     → [문서1]
+  retry     → [문서2]
+```
+
+그래서 `timeout`을 검색하면 전체 문서를 훑지 않고 `timeout` 항목만 보면 즉시 [문서1, 문서2]가 나옵니다. 로그 수백만 줄에서 특정 단어를 밀리초 단위로 찾는 비결이 이 미리 만들어 둔 단어 사전입니다. 대신 **색인을 미리 만드는 비용(디스크·CPU)** 이 든다는 트레이드오프가 있습니다 — 이 점이 5장에서 Loki와 갈리는 지점입니다.
+
+### 2-4. Kibana — Discover와 KQL
+
+Kibana는 ES 앞단의 웹 UI입니다. 처음 만질 곳은 **Discover** 화면입니다.
+
+- 먼저 **data view**(예전 이름 index pattern)로 `spring-logs-*`를 등록하면, Kibana가 이 인덱스들의 필드를 읽어 검색 대상으로 삼습니다.
+- 검색창에서는 **KQL(Kibana Query Language)** 로 질의합니다. 사람이 읽기 쉬운 문법입니다.
+  - `level: ERROR` → level 필드가 ERROR인 로그
+  - `log_message: *timeout*` → 메시지에 timeout이 든 로그
+  - `level: ERROR and logger: *Wallet*` → 조건 결합
+- 시간 범위(우측 상단)로 "최근 15분" 같은 창을 잡고, 히스토그램으로 로그 급증 구간을 눈으로 봅니다.
+
+KQL은 grok이 만들어 준 **필드**(level, logger, log_message 등) 위에서 동작합니다. 즉 3장의 파싱이 잘 돼 있어야 4장 검색이 편해지는, 앞뒤가 연결된 구조입니다.
+
+---
+
+## 3. grok 파싱 원리 — 이 repo의 Spring 로그를 필드로 분해하기
+
+### grok이 하는 일
+
+grok은 **"이름 붙은 정규식 조각"** 을 조립해 한 줄 텍스트에서 값을 뽑아내는 도구입니다. 날것의 정규식은 읽기 괴롭기 때문에, 자주 쓰는 패턴에 `TIMESTAMP_ISO8601`, `LOGLEVEL`, `POSINT` 같은 이름을 미리 붙여두고 `%{패턴이름:필드이름}` 문법으로 씁니다.
+
+- `%{LOGLEVEL:level}` = "여기에 로그레벨 패턴이 오는데, 매치되면 그 값을 `level` 필드에 담아라".
+- 매치에 성공하면 그 부분 문자열이 잘려 나와 필드가 되고, 다음 패턴이 그 뒤부터 이어서 매치합니다.
+
+### 실습: ai-repo의 진짜 Spring 로그 한 줄 분해
+
+대상 로그(스펙의 실제 샘플):
+
+```
+2026-07-04T09:50:42.320Z  INFO 1 --- [ai-repo] [           main] com.imwoo.airepo.AiRepoApplication       : Started AiRepoApplication in 15.044 seconds
+```
+
+`deploy/k8s/logging/logstash.yaml`의 grok 패턴은 이렇습니다:
+
+```
+%{TIMESTAMP_ISO8601:log_timestamp}%{SPACE}%{LOGLEVEL:level}%{SPACE}%{POSINT:pid}%{SPACE}---%{SPACE}\[%{DATA:appname}\]%{SPACE}\[%{DATA:thread}\]%{SPACE}%{NOTSPACE:logger}%{SPACE}:%{SPACE}%{GREEDYDATA:log_message}
+```
+
+한 조각씩, 로그의 어느 부분을 먹는지 짝지어 보면:
+
+| grok 조각 | 매치하는 부분 | 뽑히는 필드 = 값 |
+| --- | --- | --- |
+| `%{TIMESTAMP_ISO8601:log_timestamp}` | `2026-07-04T09:50:42.320Z` | `log_timestamp` = 2026-07-04T09:50:42.320Z |
+| `%{SPACE}` | (공백들, 우측정렬 패딩 흡수) | — (버림) |
+| `%{LOGLEVEL:level}` | `INFO` | `level` = INFO |
+| `%{SPACE}` | ` ` | — |
+| `%{POSINT:pid}` | `1` | `pid` = 1 |
+| `%{SPACE}---%{SPACE}` | ` --- ` | — (구분자, 버림) |
+| `\[%{DATA:appname}\]` | `[ai-repo]` | `appname` = ai-repo |
+| `%{SPACE}` | ` ` | — |
+| `\[%{DATA:thread}\]` | `[           main]` | `thread` = "           main"(공백 포함) |
+| `%{SPACE}` | ` ` | — |
+| `%{NOTSPACE:logger}` | `com.imwoo.airepo.AiRepoApplication` | `logger` = com.imwoo.airepo.AiRepoApplication |
+| `%{SPACE}:%{SPACE}` | `       : ` | — (콜론 구분자) |
+| `%{GREEDYDATA:log_message}` | `Started AiRepoApplication in 15.044 seconds` | `log_message` = Started ... seconds |
+
+핵심 포인트 몇 가지:
+
+- **`%{SPACE}` 는 "공백을 먹어치우는" 조각**입니다. Spring 로그는 레벨을 우측정렬(`INFO`, ` WARN`)하고 thread/logger를 공백으로 패딩하기 때문에, 고정 개수의 공백을 쓰면 안 되고 `%{SPACE}`로 가변 공백을 흡수해야 합니다.
+- **`\[` `\]` 는 대괄호 자체를 매치**합니다(정규식에서 `[`는 특수문자라 이스케이프). `[ai-repo]`의 바깥 괄호를 소비하고 안쪽 `ai-repo`만 `appname`으로 뽑습니다.
+- **`%{DATA}` vs `%{NOTSPACE}` vs `%{GREEDYDATA}`**: `DATA`는 최소 매치(다음 패턴이 나올 때까지만), `NOTSPACE`는 공백 아닌 문자 연속(logger 클래스명에 딱), `GREEDYDATA`는 남은 전부(메시지는 공백이 있으니 끝까지). 순서와 종류를 잘못 고르면 필드가 엉뚱하게 잘립니다.
+- 뽑은 뒤 filter에서 `date { match => ["log_timestamp","ISO8601"] target => "@timestamp" }` 로 `log_timestamp`를 진짜 시간축(`@timestamp`)에 심고 원본 필드는 지웁니다. `mutate { strip => [...] }`로 thread/logger/level에 남은 앞뒤 공백을 다듬습니다.
+
+### grok이 실패하면?
+
+패턴과 안 맞는 줄(예: 멀티라인 스택트레이스 조각)이 들어오면 grok은 필드를 못 만들고 `tag_on_failure => ["_grokparsefailure_spring"]` 태그를 붙입니다. **하지만 원본 `message` 필드는 그대로 살아서 ES까지 갑니다.** 즉 파싱에 실패해도 로그를 잃지 않고, Kibana에서 `tags: _grokparsefailure_spring`로 "파싱 못 한 줄"만 골라내 패턴을 고칠 수 있습니다. 이게 "로그는 절대 버리지 않되, 되는 만큼 구조화한다"는 안전한 설계입니다.
+
+---
+
+## 4. 두 가지 토폴로지와 Ingest Pipeline 대안
+
+로그를 ES에 넣는 길은 하나가 아닙니다. 상황에 맞게 고릅니다.
+
+### 토폴로지 A — Filebeat가 ES로 직접 (Logstash 없음)
+
+```mermaid
+flowchart LR
+    fb["Filebeat"] -->|"직접 색인"| es[("Elasticsearch")]
+    es --> kb["Kibana"]
+    classDef c fill:#dcfce7,stroke:#16a34a;
+    class fb c
+```
+
+- **장점**: 부품이 하나 적어 가볍고 단순. Filebeat 자체 모듈이 파싱을 어느 정도 해줌.
+- **단점**: 복잡한 커스텀 파싱(우리 Spring grok 같은)이나 여러 소스 합류·변환이 어렵습니다.
+- 어울리는 경우: 표준 포맷(nginx, 시스템 로그) + 무거운 가공 불필요.
+
+### 토폴로지 B — Filebeat → Logstash → ES (ai-repo가 택한 길)
+
+```mermaid
+flowchart LR
+    fb["Filebeat"] -->|":5044"| ls["Logstash<br/>grok 파싱"] -->|"색인"| es[("Elasticsearch")]
+    es --> kb["Kibana"]
+    classDef a fill:#dcfce7,stroke:#16a34a;
+    classDef b fill:#ffedd5,stroke:#ea580c;
+    class fb a
+    class ls b
+```
+
+- **장점**: Logstash의 grok/date/mutate로 **원하는 대로 파싱·변환**. 학습 목적(파싱을 직접 다뤄보기)에 딱.
+- **단점**: JVM 부품 하나가 늘어 리소스·운영 부담 증가.
+- ai-repo가 이 길을 택한 이유는 바로 **grok 파싱을 손으로 배우는 것**이 목적이기 때문입니다([ADR-0066](../adr/0066-elk-logging-stack.md)).
+
+### 대안 — Elasticsearch Ingest Pipeline
+
+Logstash를 따로 두지 않고 **ES 안에서** 파싱하는 방법도 있습니다. ES의 Ingest Pipeline에 `grok` processor를 등록하면, Filebeat가 직접 ES로 보내되 색인 직전에 ES가 grok을 돌려 필드를 만듭니다.
+
+```mermaid
+flowchart LR
+    fb["Filebeat"] -->|"직접 전송"| es[("Elasticsearch<br/>Ingest Pipeline<br/>(grok processor)")]
+    es --> kb["Kibana"]
+    classDef c fill:#dcfce7,stroke:#16a34a;
+    classDef d fill:#dbeafe,stroke:#1d4ed8;
+    class fb c
+    class es d
+```
+
+- **장점**: 별도 Logstash 파드 없이 grok 파싱을 얻어 가벼움.
+- **단점**: 파싱 부하가 ES 노드에 얹혀 검색 성능과 자원을 두고 경합. 복잡한 다단 변환·여러 output은 Logstash가 더 유연.
+- 정리: **가벼운 파싱이면 Ingest Pipeline, 무겁고 유연한 파이프라인이면 Logstash.** ai-repo는 "파이프라인을 눈으로 보고 배우기" 위해 Logstash를 명시적으로 둡니다.
+
+---
+
+## 5. PLG(Loki) vs ELK — 역색인 vs 라벨 인덱스
+
+ai-repo의 **기본** 로그 스택은 Loki(PLG: Prometheus/Loki/Grafana/Alloy)입니다. ELK는 그 옆에 붙인 학습용 대안입니다. 둘의 근본 차이는 **"로그 본문을 미리 색인하느냐"** 한 문장으로 요약됩니다.
+
+| 항목 | PLG (Loki) | ELK (Elasticsearch) |
+| --- | --- | --- |
+| 색인 방식 | **라벨(label)만 색인** — 본문은 압축 저장 | **역색인** — 본문의 단어까지 색인 |
+| 검색 | 라벨로 후보를 좁힌 뒤 **본문 grep**(LogQL) | 단어 즉시 조회(**전문검색**, KQL/Lucene) |
+| 저장 비용 | 낮음(색인 작음) | 높음(단어 사전이 큼) |
+| 임의 단어 검색 속도 | 범위가 넓으면 느림(grep) | 빠름(미리 색인됨) |
+| 파싱 시점 | 주로 쿼리 시점(LogQL 파서) | 주로 색인 시점(grok) |
+| 수집기 | Alloy | Filebeat |
+| 질의어 | LogQL | KQL / Lucene |
+| ai-repo에서 | 기본, 항상 켜짐 | opt-in, 학습용 |
+
+**비유로**: Loki는 "책들을 라벨(제목·저자)로만 분류해 서가에 꽂아두고, 특정 서가를 골라 그 책들을 처음부터 읽어 원하는 단어를 찾는" 방식입니다. 색인이 얇아 저렴하지만, 넓은 범위에서 임의 단어를 찾으면 결국 많이 읽어야 합니다. ELK는 "모든 책의 모든 단어로 색인 카드를 미리 만들어 둔 도서관"입니다. 어떤 단어든 카드만 보면 즉시 찾지만, 카드를 만드는 공간·비용이 큽니다.
+
+**언제 뭘 쓰나**: 라벨(네임스페이스·파드·레벨)로 충분히 좁혀지고 비용을 아끼고 싶으면 Loki. 로그 본문을 자유자재로 전문검색·집계·대시보드하고 싶으면 ELK. ai-repo는 평소엔 Loki로 가볍게 가고, "역색인과 grok을 직접 만져보고 싶을 때만" ELK를 opt-in으로 켭니다.
+
+---
+
+## 6. 실습 과제 — 에러 급증을 Kibana에서 찾아내기
+
+배운 걸 손으로 확인해 봅시다. (자세한 명령·트러블슈팅은 [elk-local-logging.md](../development/elk-local-logging.md)를 함께 보세요.)
+
+**목표**: 앱에서 ERROR 로그를 일부러 만들고, Filebeat→Logstash→ES를 타고 흘러온 그 로그를 Kibana에서 검색해 급증 구간을 눈으로 확인한다.
+
+1. **스택 켜기**
+   ```bash
+   ./scripts/elk-local-up.sh
+   ```
+   ES → Logstash → Kibana rollout과 Filebeat DaemonSet ready까지 기다린 뒤 접속 URL이 출력됩니다.
+
+2. **Kibana 열고 data view 만들기**
+   브라우저에서 `http://localhost:30561` → Discover → data view 생성 시 인덱스 패턴 `spring-logs-*`, 시간 필드 `@timestamp` 선택.
+
+3. **에러를 일부러 유발**
+   ai-repo에 없는 리소스를 두들기거나 잘못된 요청을 여러 번 보내 ERROR 로그가 쌓이게 합니다. 예:
+   ```bash
+   for i in $(seq 1 20); do curl -s -o /dev/null http://localhost:30080/api/does-not-exist; done
+   ```
+   (엔드포인트는 상황에 맞게 조정. 핵심은 "짧은 시간에 에러 로그를 다발로 만드는 것".)
+
+4. **Kibana에서 검색**
+   - 우측 상단 시간 범위를 "Last 15 minutes"로.
+   - 검색창: `level: ERROR`
+   - 상단 히스토그램에서 방금 만든 **급증 막대**를 확인. 막대를 드래그하면 그 구간으로 줌인됩니다.
+   - 특정 메시지만: `level: ERROR and log_message: *not*` 처럼 KQL로 좁혀보기.
+
+5. **파싱 결과 뜯어보기**
+   로그 한 건을 펼쳐(expand) `level`, `logger`, `thread`, `log_message`, `@timestamp` 필드가 grok으로 잘 분리됐는지 확인합니다. 만약 `tags`에 `_grokparsefailure_spring`이 보이면, 그 줄은 패턴과 안 맞은 것 — 원본 `message`는 살아 있으니 패턴을 어떻게 고칠지 생각해 봅니다(3장 복습).
+
+6. **정리**
+   ```bash
+   ./scripts/elk-local-down.sh
+   ```
+
+**확장 도전**: `level: ERROR`를 Loki(Grafana, LogQL `{namespace="ai-repo"} |= "ERROR"`)에서도 같은 걸 찾아보고, 두 검색 경험(라벨+grep vs 역색인 전문검색)이 어떻게 다른지 5장과 대조해 보세요.
+
+---
+
+## 더 읽을거리
+
+- [ADR-0066: ELK 로깅 스택 도입](../adr/0066-elk-logging-stack.md) — 왜 도입했고 PLG와 어떻게 병존하는지
+- [로컬 ELK 로깅 가이드](../development/elk-local-logging.md) — 실제 기동·검색·트러블슈팅, LogQL↔KQL 치트시트
+- [Architecture Overview](../ARCHITECTURE.md) · [Glossary](../GLOSSARY.md)
+- 매니페스트: `deploy/k8s/logging/` · 스크립트: `scripts/elk-local-up.sh`, `scripts/elk-local-down.sh`

--- a/docs/progress/0077-elk-logging-stack.md
+++ b/docs/progress/0077-elk-logging-stack.md
@@ -1,0 +1,43 @@
+# 0077. ELK 2단계 로깅 스택 (학습용 opt-in)
+
+## 스펙 목표
+
+- 기존 PLG(Prometheus/Loki/Grafana/Alloy)와 **별개의 학습용 opt-in 스택**으로 ELK(Filebeat→Logstash→Elasticsearch→Kibana)를 구성한다. PLG를 대체하지 않고 병존한다.
+- Logstash의 grok 필터로 Spring Boot 로그를 구조화 파싱(`level`, `pid`, `appname`, `thread`, `logger`, `log_message`)해 역색인 검색을 학습한다.
+- ArgoCD(`deploy/gitops`)에 포함하지 않고 수동 스크립트로만 기동하는 **opt-in** 스택으로 분리한다(항상 켜지지 않음).
+- 로컬 학습 전제: `xpack.security.enabled=false`, 단일노드, ephemeral(emptyDir), 리소스 축소.
+
+## 완료 결과
+
+- **매니페스트**(`deploy/k8s/logging`, 자기완결적 kustomize overlay): `namespace.yaml`(ns `logging`) + `elasticsearch.yaml`(Deployment + ClusterIP 9200/9300 + NodePort `elasticsearch-nodeport` 9200→30920) + `logstash.yaml`(Deployment + ClusterIP 5044 + `logstash-pipeline`/`logstash-settings` ConfigMap) + `kibana.yaml`(Deployment + NodePort 5601→30561) + `filebeat.yaml`(ServiceAccount + ClusterRole/Binding + `filebeat-config` ConfigMap + DaemonSet) + `kustomization.yaml`.
+- **버전/이미지**: Elastic Stack **8.16.1**(`docker.elastic.co/{elasticsearch,logstash,kibana}/…:8.16.1`, `…/beats/filebeat:8.16.1`).
+- **grok 파이프라인**: `input{beats 5044} → filter{grok + date + mutate strip} → output{elasticsearch spring-logs-%{+YYYY.MM.dd}}`. grok 실패 시에도 원본 `message`는 유지되어 ES로 전달되며 `_grokparsefailure_spring` 태그로 식별 가능.
+- **스크립트**: `scripts/elk-local-up.sh`(apply -k + ES→Logstash→Kibana rollout + Filebeat DaemonSet 대기 + 접속 안내), `scripts/elk-local-down.sh`(delete -k). `CONTEXT=${CONTEXT:-docker-desktop}`.
+- **문서**: `docs/adr/0066-elk-logging-stack.md`, `docs/development/elk-local-logging.md`(구동·접속·KQL 검색·트러블슈팅·LogQL↔KQL 치트시트), `docs/learning/elk-stack.md`(4-tier 아키텍처·컴포넌트 심화·grok 원리·PLG vs ELK 비교), progress 0077, issue-draft 0077.
+
+## 개선 건수
+
+1. 학습용 opt-in ELK 로깅 스택(`deploy/k8s/logging`) 신설 — PLG와 병존, ArgoCD 미포함.
+2. Logstash grok 파이프라인으로 Spring 로그 구조화 파싱과 `spring-logs-*` 인덱스 색인.
+3. 기동/제거 스크립트와 학습·가이드 문서 신설.
+
+## 검증
+
+- `kubectl --context docker-desktop apply -k deploy/k8s/logging` → ES/Logstash/Kibana rollout Ready + Filebeat DaemonSet Ready
+- ES 확인: `http://localhost:30920/_cluster/health`(status green/yellow), `_cat/indices?v`에 `spring-logs-YYYY.MM.dd` 생성
+- Kibana `http://localhost:30561` → Discover → data view `spring-logs-*` 생성 → `level: ERROR`, `log_message: *timeout*` KQL 검색
+- grok 파싱 필드(`level`, `logger`, `thread`, `log_message`) 노출 및 `_grokparsefailure_spring` 태그 부재 확인
+
+## 남은 일
+
+- GitHub Issue 생성 후 링크 연결(현재 미정).
+- 실배포 스모크(Docker Desktop k8s 리소스 여유 필요, 파드 pending=리소스 부족 주의)로 end-to-end 색인·검색 확인.
+- 학습 확장 과제: ES Ingest Pipeline(무-Logstash) 대안 토폴로지 비교, ILM 기반 인덱스 수명주기 정책.
+
+## 관련 문서
+
+- GitHub Issue: (미정 — 작성 후 연결)
+- `docs/adr/0066-elk-logging-stack.md`
+- `docs/development/elk-local-logging.md`
+- `docs/learning/elk-stack.md`
+- `issue-drafts/0077-elk-logging-stack.md`

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -92,6 +92,7 @@ ADR은 “왜 그렇게 결정했는가”를 기록하고, 이 폴더는 “각
 | 0074 | [Broker Consumer Endpoint Authentication](0074-broker-endpoint-authentication.md) | 완료 |
 | 0075 | [Admin Path Drift Guard](0075-admin-path-drift-guard.md) | 완료 |
 | 0076 | [JDBC Persistence Adapter Decomposition](0076-jdbc-persistence-adapter-decomposition.md) | 완료 |
+| 0077 | [ELK 2단계 로깅 스택 (학습용 opt-in)](0077-elk-logging-stack.md) | 완료 |
 
 ## 현재 기준선
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -43,6 +43,7 @@
 - 배포 프로파일(`postgres`/`prod`)에서 공개된 기본 JWT secret·운영 토큰 fail-fast 확장(`JwtSecretGuard`/`OpsTokenGuard`)과 `deploy/k8s/app.yaml` 명시 값 주입
 - JDBC persistence adapter 분해 — `JdbcWalletRepository`를 PostgreSQL profile composite bean으로 유지하면서 wallet/ledger, outbox relay, outbox consumer, operational alert, admin audit SQL을 context별 package-private adapter로 분리하고 ArchUnit 레이어 규칙을 추가
 - `POST /internal/broker/outbox-events` shared secret 헤더(`X-Broker-Token`) 인증 — 전용 SecurityFilterChain(Order 3) + 상수시간 토큰 비교로 미인증 event 주입 차단, publisher가 같은 secret 부착(#123)
+- opt-in ELK 로깅 스택 — 학습용 Filebeat→Logstash(grok)→Elasticsearch(역색인)→Kibana를 `logging` 네임스페이스에 PLG(Loki)와 병존시키되 ArgoCD 미포함·`scripts/elk-local-up.sh`/`down.sh` 수동 기동, 로컬 학습 전제(security off·단일노드·ephemeral), Spring 로그 grok 파싱과 `spring-logs-*` KQL 검색 (ADR-0066)
 
 ## MVP 출시 판단 기준
 

--- a/issue-drafts/0077-elk-logging-stack.md
+++ b/issue-drafts/0077-elk-logging-stack.md
@@ -1,0 +1,44 @@
+# ELK 2단계 로깅 스택 (학습용 opt-in)
+
+## 배경
+
+ai-repo는 기본 관측 스택으로 PLG(Prometheus/Loki/Grafana/Alloy)를 사용한다(0069). Loki는 라벨 인덱스 + grep 방식이라 가볍지만, 역색인 기반 전문 검색과 필드 파싱(grok) 같은 로그 파이프라인 학습에는 적합하지 않다. 학습 목적으로 Filebeat→Logstash→Elasticsearch→Kibana(ELK) 스택을 **PLG와 병존하는 별개의 opt-in 모듈**로 도입한다. PLG를 대체하지 않으며, 항상 켜두지 않고 필요 시 수동 기동한다.
+
+## 제안
+
+- `deploy/k8s/logging`에 자기완결적 kustomize overlay로 ELK 4-tier(Filebeat DaemonSet → Logstash grok → Elasticsearch → Kibana)를 구성한다.
+- Logstash grok 필터로 Spring Boot 로그(`ISO8601 LEVEL PID --- [appname] [thread] logger : message`)를 `level`/`pid`/`appname`/`thread`/`logger`/`log_message` 필드로 파싱하고 `spring-logs-%{+YYYY.MM.dd}` 인덱스에 색인한다.
+- Elastic Stack **8.16.1**, 네임스페이스 `logging`(앱과 분리), 서비스/포트 `elasticsearch:9200`(NodePort 30920) · `logstash:5044` · `kibana:5601`(NodePort 30561).
+- 로컬 학습 전제로 `xpack.security.enabled=false`, 단일노드, ephemeral(emptyDir), 리소스 축소.
+- **ArgoCD(`deploy/gitops`)에 포함하지 않고** `scripts/elk-local-up.sh`/`elk-local-down.sh`로만 기동·제거하는 opt-in으로 유지한다.
+- ADR-0066, 가이드(`docs/development/elk-local-logging.md`), 학습문서(`docs/learning/elk-stack.md`)를 남긴다.
+
+## 완료 조건
+
+- [ ] `deploy/k8s/logging` kustomize 스택과 `scripts/elk-local-up.sh`/`elk-local-down.sh`로 기동·제거된다.
+- [ ] Filebeat가 `*ai-repo*` 컨테이너 로그를 수집해 Logstash로 전달하고, grok으로 파싱된 필드가 ES에 색인된다.
+- [ ] `http://localhost:30920/_cat/indices`에 `spring-logs-YYYY.MM.dd`가 생성된다.
+- [ ] Kibana(`http://localhost:30561`) Discover에서 data view `spring-logs-*`로 `level: ERROR` 등 KQL 검색이 된다.
+- [ ] grok 실패 시에도 원본 `message`가 보존되고 `_grokparsefailure_spring` 태그로 식별된다.
+- [ ] 이 스택이 ArgoCD에 포함되지 않는(opt-in) 상태가 유지된다.
+- [ ] ADR-0066, progress 0077, 가이드/학습 문서가 기록된다.
+
+## 검증
+
+```bash
+kubectl --context docker-desktop apply -k deploy/k8s/logging
+scripts/elk-local-up.sh
+# ES/Kibana 확인 후
+scripts/elk-local-down.sh
+```
+
+## 관련 문서
+
+- `docs/adr/0066-elk-logging-stack.md`
+- `docs/progress/0077-elk-logging-stack.md`
+- `docs/development/elk-local-logging.md`
+- `docs/learning/elk-stack.md`
+
+관련: progress 0069(PLG 관측 스택), ADR-0066.
+
+GitHub Issue: (미정 — 작성 후 연결)

--- a/issue-drafts/README.md
+++ b/issue-drafts/README.md
@@ -136,6 +136,7 @@
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/124
 - `0076-jdbc-persistence-adapter-decomposition.md`: JdbcWalletRepository bounded-context 분해와 ArchUnit 레이어 규칙 작업 초안
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/125
+- `0077-elk-logging-stack.md`: ELK 2단계 로깅 스택(Filebeat→Logstash grok→ES→Kibana) 학습용 opt-in 작업 초안
 
 ## GitHub CLI로 생성
 

--- a/scripts/elk-local-down.sh
+++ b/scripts/elk-local-down.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# 로컬 k8s의 opt-in ELK 로깅 스택을 제거한다. (namespace 삭제로 ES 데이터(emptyDir)도 함께 초기화됨)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+CONTEXT=${CONTEXT:-docker-desktop}
+
+kubectl --context "$CONTEXT" delete -k deploy/k8s/logging --ignore-not-found
+echo "정리 완료 (ELK 스택 전체 삭제, ES 데이터 포함)"

--- a/scripts/elk-local-up.sh
+++ b/scripts/elk-local-up.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# 로컬 Docker Desktop k8s에 opt-in ELK 로깅 스택(Filebeat -> Logstash -> Elasticsearch -> Kibana)을 배포한다.
+# PLG(Prometheus/Loki/Grafana)와 별개의 학습용 스택이며, ArgoCD에는 포함되지 않는다(수동 기동).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+CONTEXT=${CONTEXT:-docker-desktop}
+
+echo "==> K8s 확인"
+kubectl --context "$CONTEXT" get nodes >/dev/null || {
+  echo "docker-desktop k8s 클러스터에 연결할 수 없습니다 (Docker Desktop 설정에서 Kubernetes 활성화)."; exit 1; }
+
+echo "==> 매니페스트 적용 (namespace logging)"
+kubectl --context "$CONTEXT" apply -k deploy/k8s/logging
+
+echo "==> 롤아웃 대기 (ES -> Logstash -> Kibana)"
+kubectl --context "$CONTEXT" -n logging rollout status deployment/elasticsearch --timeout=300s
+kubectl --context "$CONTEXT" -n logging rollout status deployment/logstash --timeout=300s
+kubectl --context "$CONTEXT" -n logging rollout status deployment/kibana --timeout=300s
+
+echo "==> Filebeat DaemonSet 대기"
+kubectl --context "$CONTEXT" -n logging rollout status daemonset/filebeat --timeout=300s
+
+cat <<'EOF'
+
+배포 완료 (opt-in ELK 로깅 스택):
+  Kibana         http://localhost:30561          (Discover -> data view 'spring-logs-*' 생성)
+  Elasticsearch  http://localhost:30920          (health: /_cluster/health)
+  인덱스 패턴     spring-logs-*                   (일자별 spring-logs-YYYY.MM.dd)
+
+로그 흐름: Filebeat(ai-repo 컨테이너 로그) -> Logstash:5044(grok 파싱) -> Elasticsearch:9200 -> Kibana:5601
+정리: scripts/elk-local-down.sh
+EOF

--- a/wiki-drafts/Architecture-Decisions.md
+++ b/wiki-drafts/Architecture-Decisions.md
@@ -84,6 +84,8 @@
 8. 구조 경계와 persistence adapter 분해
    - ADR-0063 Application Layer Spring Annotation Policy
    - ADR-0064 JDBC Persistence Adapter Decomposition
+9. 로깅 관측 (opt-in)
+   - ADR-0066 ELK Logging Stack (opt-in, PLG와 병존)
 
 ## 중요한 트레이드오프
 
@@ -118,6 +120,7 @@
 | 배포 프로파일 기본 자격증명 fail-fast (ADR-0062) | `postgres`/`prod`에서 공개된 기본 JWT secret·운영 토큰이면 기동 실패, `deploy/k8s/app.yaml`에 명시 값 주입 | 배포 프로파일 목록 하드코딩과 `app.yaml` 평문 값(Secret 주입은 #121에서 완결) |
 | Application layer Spring annotation policy (ADR-0063) | `@Service`, policy/properties `@Component`/`@Value`, 필요한 `@Transactional`을 제한적으로 허용하고 adapter 의존은 금지 | framework-free usecase 분리는 후속 전환 ADR 필요 |
 | JDBC persistence adapter decomposition (ADR-0064) | `JdbcWalletRepository`는 Spring composite bean으로 유지하고 SQL은 wallet/ledger, outbox relay, outbox consumer, operational alert, admin audit adapter로 분리 | composite가 여러 port를 계속 구현하는 절충은 유지 |
+| opt-in ELK 로그 스택 (ADR-0066) | 학습용 ELK(Filebeat→Logstash grok→Elasticsearch 역색인→Kibana)를 `logging` 네임스페이스에 PLG와 **병존**시키되 ArgoCD 미포함·수동 스크립트로만 기동, 2단계(Logstash grok) 토폴로지로 파싱 학습 | 로컬 학습 전용(security off·단일노드·ephemeral)이라 운영 신뢰성은 범위 밖, PLG 대비 리소스 비용이 크고 상시 구동하지 않음 |
 
 ## 다음 구조 후보
 

--- a/wiki-drafts/Release-Notes.md
+++ b/wiki-drafts/Release-Notes.md
@@ -71,6 +71,7 @@
 
 ## 다음 후보
 
+- opt-in ELK 로깅 스택(Filebeat→Logstash grok→Elasticsearch→Kibana) — `logging` 네임스페이스에 PLG와 병존, ArgoCD 미포함·수동 스크립트(`scripts/elk-local-up.sh`/`down.sh`) 기동, 로그 파싱·역색인 검색 학습용 (ADR-0066)
 - JWT refresh token 기반 만료/갱신 정책 강화(현재는 401 시 password-less 재발급)
 - 로그인 회원의 실제 보유 지갑 조회 API(현재는 fixture 기반 파생)
 - broker-specific Testcontainers contract


### PR DESCRIPTION
## 목적
기존 **PLG**(Prometheus/Loki/Grafana/Alloy)와 **별개의 학습용 ELK 스택**(Filebeat→Logstash→Elasticsearch→Kibana)을 **opt-in 모듈**로 추가. PLG를 대체하지 않고 병존하며, ArgoCD 기본 동기화에 포함하지 않아 **필요할 때만 스크립트로 기동**한다. (2단계 = Logstash grok 파싱 포함)

## 인프라 (`deploy/k8s/logging/`, ns `logging`, Elastic **8.16.1**)
| 컴포넌트 | 구성 | 접속 |
|---|---|---|
| Elasticsearch | single-node, security off, heap 1g, emptyDir | `elasticsearch:9200` + NodePort **30920** |
| Logstash | beats:5044 → **grok(Spring 로그 파싱)** → ES `spring-logs-YYYY.MM.dd` | ClusterIP 5044 |
| Kibana | ES 연결 | NodePort **30561** |
| Filebeat | DaemonSet(+RBAC), container 입력(`*ai-repo*.log`) → logstash | — |

- opt-in: `deploy/k8s/kustomization.yaml`/`deploy/gitops`에서 **미참조**(ArgoCD 자동배포 안 됨).
- 기동/정리: `scripts/elk-local-up.sh` / `scripts/elk-local-down.sh`.

## 문서
- **ADR-0066** / progress 0077 / issue-draft 0077 (+ 인덱스)
- 가이드 `docs/development/elk-local-logging.md` — 구동·접속·KQL·**LogQL↔KQL 치트시트**·트러블슈팅
- 학습문서 `docs/learning/elk-stack.md` — 4-tier 아키텍처·컴포넌트 심화·grok 원리·2가지 토폴로지·**PLG vs ELK**·실습
- 현행화: ARCHITECTURE(로그 PLG기본/ELK opt-in), architecture-diagrams(ELK mermaid), GLOSSARY(ELK/Filebeat/Logstash/grok/역색인), README(k8s opt-in), wiki-drafts, releases/unreleased

## 검증
- `kubectl kustomize deploy/k8s/logging` **build OK**(15 리소스), server dry-run 스키마 OK.
- `scripts/check-dev-rules.sh` **PASS**.
- 멀티에이전트(ultracode) 저작 후 적대적 검증(매니페스트 유효성 + 문서↔매니페스트 정합성) 통과, 0 issues.
- **라이브 미기동**: ELK는 리소스 부담(ES 1~2GB+)이 커서 opt-in 유지. 로컬 기동 시 `scripts/elk-local-up.sh` → Kibana http://localhost:30561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)