### PR TITLE
fix(deploy): broker token 주입 — BrokerTokenGuard 기동 실패 회귀 수정

### DIFF
--- a/deploy/k8s/app.yaml
+++ b/deploy/k8s/app.yaml
@@ -49,6 +49,16 @@ spec:
                 secretKeyRef:
                   name: ai-repo-credentials
                   key: AI_REPO_AUTH_JWT_SECRET
+            - name: AI_REPO_OUTBOX_CONSUMER_BROKER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: ai-repo-credentials
+                  key: AI_REPO_OUTBOX_CONSUMER_BROKER_TOKEN
+            - name: AI_REPO_OUTBOX_PUBLISHER_HTTP_BROKER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: ai-repo-credentials
+                  key: AI_REPO_OUTBOX_PUBLISHER_HTTP_BROKER_TOKEN
             - name: AI_REPO_OUTBOX_RELAY_SCHEDULER_ENABLED
               value: "true"
           ports:

--- a/deploy/k8s/secrets.yaml
+++ b/deploy/k8s/secrets.yaml
@@ -25,3 +25,7 @@ stringData:
   AI_REPO_OPS_OPERATOR_TOKEN: local-k8s-ops-operator-token
   # 엔드유저 JWT 서명 비밀(app.yaml)
   AI_REPO_AUTH_JWT_SECRET: local-k8s-jwt-secret-please-change-32b
+  # broker→consumer shared secret(app.yaml) — BrokerTokenGuard(ADR-0065)가 배포 프로파일에서
+  # 공개 기본값(local-broker-token)을 거부하므로 반드시 비-기본 값을 쓴다. consumer/publisher 동일 값.
+  AI_REPO_OUTBOX_CONSUMER_BROKER_TOKEN: local-k8s-broker-token
+  AI_REPO_OUTBOX_PUBLISHER_HTTP_BROKER_TOKEN: local-k8s-broker-token


### PR DESCRIPTION
## 문제
`BrokerTokenGuard`(ADR-0065)는 배포 프로파일(postgres/prod)에서 broker consumer 토큰이 공개 기본값이면 기동 실패시킨다. 그런데 `deploy/k8s`에 토큰 주입이 빠져 있어 **GitOps 배포 앱 파드가 CrashLoopBackOff**였다(구 ReplicaSet 파드가 남아 서비스는 유지, 롤아웃은 정지 → ArgoCD Health `Degraded`).

```
IllegalStateException: ai-repo.outbox.consumer.broker-token is the built-in development default;
set AI_REPO_OUTBOX_CONSUMER_BROKER_TOKEN for deployed profiles (postgres/prod)
  at BrokerTokenGuard.<init>(BrokerTokenGuard.java:28)
```
> 이 startup 스택트레이스는 방금 구성한 **ELK 로깅 스택으로 검색해 특정**했다(스택의 실사용 예).

## 수정
- `deploy/k8s/secrets.yaml`: `AI_REPO_OUTBOX_CONSUMER_BROKER_TOKEN` / `AI_REPO_OUTBOX_PUBLISHER_HTTP_BROKER_TOKEN` = `local-k8s-broker-token`(비-기본, 동일 값) 추가.
- `deploy/k8s/app.yaml`: 두 env를 `secretKeyRef`로 주입(ops/jwt 토큰과 동일 패턴).

ADR-0062(기본 자격증명 fail-fast) · ADR-0061(Secret 주입) 정책을 broker 토큰으로 확장. 머지 후 ArgoCD 동기화로 크래시 해소.

## 검증
`kubectl kustomize deploy/k8s` build OK · yaml parse OK · check-dev-rules PASS(deploy 전용).

## 후속(선택)
"DeployedProfiles 가드 추가 시 deploy secret 주입 누락"을 막는 드리프트 가드 테스트는 후속 과제.

🤖 Generated with [Claude Code](https://claude.com/claude-code)