### PR TITLE
feat(gitops): ELK 전용 ArgoCD Application(수동 sync) — GitOps 토글

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,11 +155,16 @@ IntelliJ IDEA 기준 설정은 [Local Setup](docs/development/local-setup.md)을
 
 #### (선택) ELK 로그 스택 — opt-in 학습용
 
-기본 로그 스택은 위 PLG(Loki)입니다. 로그 파싱·검색을 학습하려면 **opt-in** ELK 스택(Filebeat→Logstash→Elasticsearch→Kibana)을 `logging` 네임스페이스에 별도로 띄울 수 있습니다. PLG를 대체하지 않고 병존하며, ArgoCD(GitOps)에는 포함하지 않고 아래 스크립트로만 수동 기동합니다(ADR-0066). 구동·KQL 검색·트러블슈팅은 [ELK 로컬 로깅 가이드](docs/development/elk-local-logging.md), 개념 학습은 [ELK 학습 문서](docs/learning/elk-stack.md)를 따릅니다.
+기본 로그 스택은 위 PLG(Loki)입니다. 로그 파싱·검색을 학습하려면 **opt-in** ELK 스택(Filebeat→Logstash→Elasticsearch→Kibana)을 `logging` 네임스페이스에 별도로 띄울 수 있습니다. PLG를 대체하지 않고 병존하며, 리소스 부담이 커 **기본 off**입니다(ADR-0066). 구동·KQL 검색·트러블슈팅은 [ELK 로컬 로깅 가이드](docs/development/elk-local-logging.md), 개념 학습은 [ELK 학습 문서](docs/learning/elk-stack.md)를 따릅니다.
+
+on/off는 세 방식 중 하나로 하며(섞지 않음): ① 독립 스크립트, ② 메인 스택 env 플래그 `AI_REPO_ELK_ENABLED=true`, ③ ArgoCD 수동 sync App(`deploy/argocd/logging-application.yaml`, `automated` 없음 — 기존 `ai-repo` App은 항상 켜지므로 분리).
 
 ```bash
-./scripts/elk-local-up.sh     # ELK 스택 기동 (logging 네임스페이스)
-./scripts/elk-local-down.sh   # ELK 스택 제거
+./scripts/elk-local-up.sh                              # ① ELK만 기동 (logging 네임스페이스)
+./scripts/elk-local-down.sh                            # ① ELK만 제거
+AI_REPO_ELK_ENABLED=true ./scripts/k8s-local-up.sh     # ② PLG + ELK 함께
+# ③ ArgoCD(GitOps): App 등록 후 UI/CLI에서 Sync(켜기)/Delete(끄기)
+kubectl apply -f deploy/argocd/logging-application.yaml && argocd app sync ai-repo-logging
 ```
 
 | 서비스 | URL | 계정 |

--- a/deploy/argocd/logging-application.yaml
+++ b/deploy/argocd/logging-application.yaml
@@ -1,0 +1,29 @@
+# ArgoCD Application — (opt-in) ELK 로깅 스택. deploy/k8s/logging 을 logging 네임스페이스로 배포한다.
+#
+# 기존 `ai-repo` App(automated+selfHeal)과 달리 automated sync를 두지 않는다(= 수동 sync).
+# ELK는 무거운 학습용 스택이라 "항상 켜짐"을 피하고, ArgoCD에서 명시적으로 Sync해야 배포된다.
+#   등록: kubectl --context docker-desktop apply -f deploy/argocd/logging-application.yaml  (App만 등록)
+#   켜기: argocd app sync ai-repo-logging          (또는 ArgoCD UI의 Sync 버튼)
+#   끄기: argocd app delete ai-repo-logging         (cascade prune → logging ns 리소스 제거)
+#
+# 주의: 이 App으로 관리하기 시작하면 토글 주체를 ArgoCD로 일원화한다.
+#       scripts/elk-local-up.sh / elk-local-down.sh(수동 kubectl)와 병행하면 상태가 어긋날 수 있다.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ai-repo-logging
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/IMWoo94/ai-repo.git
+    targetRevision: main
+    path: deploy/k8s/logging
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: logging
+  syncPolicy:
+    # automated 블록 없음 = 수동 sync(opt-in). automated(selfHeal)를 넣으면
+    # "항상 ON"이 되어 opt-in 의도가 깨지므로 의도적으로 두지 않는다.
+    syncOptions:
+      - CreateNamespace=true

--- a/docs/adr/0066-elk-logging-stack.md
+++ b/docs/adr/0066-elk-logging-stack.md
@@ -62,5 +62,5 @@ ELK는 상시 켜두기에 무겁다(ES JVM 힙 1g + Logstash/Kibana). 학습 �
 
 - **PLG로 통일(ELK 미도입)**: 가장 단순하고 운영 스택이 하나로 유지되지만, 역색인·grok 파싱을 학습할 수단이 없어 이 결정의 학습 목표를 충족하지 못한다.
 - **ELK 1단계(Filebeat → ES 직접, Logstash 생략)**: 구성이 가볍지만 grok 파싱 계층 학습이 빠진다. ES Ingest Pipeline으로 파싱을 대체할 수 있으나, 파이프라인 학습 관점에서 독립 Logstash를 두는 편이 명확하다.
-- **ELK 상시 배포(ArgoCD 포함)**: 항상 최신 로그를 검색할 수 있으나 학습용 스택이 상시 리소스를 점유해 로컬 부담이 크다. opt-in 의도와 맞지 않는다. 대신 `AI_REPO_ELK_ENABLED` env 플래그로 메인 스택과 함께 on/off 하거나 독립 스크립트로 제어한다.
+- **ELK 상시 배포(ArgoCD 포함)**: 항상 최신 로그를 검색할 수 있으나 학습용 스택이 상시 리소스를 점유해 로컬 부담이 크다. opt-in 의도와 맞지 않는다. 대신 `AI_REPO_ELK_ENABLED` env 플래그·독립 스크립트로 제어하거나, `automated`(selfHeal)를 두지 않은 **별도 ArgoCD Application**(`deploy/argocd/logging-application.yaml`)으로 UI/CLI에서 수동 Sync/Delete 토글한다. 기존 `ai-repo` App(automated)에 편입하면 항상 켜져 opt-in이 깨지므로 분리한다.
 - **보안 활성화 구성**: 프로덕션에 가깝지만 인증서·자격증명 설정 비용이 커 로컬 학습 진입장벽을 높인다. 범위 밖으로 둔다.

--- a/docs/development/elk-local-logging.md
+++ b/docs/development/elk-local-logging.md
@@ -26,10 +26,11 @@ CONTEXT=my-cluster ./scripts/elk-local-up.sh   # 다른 context에 기동
 
 ### 켜기 / 끄기 옵션 (토글)
 
-ELK는 두 가지 방식으로 on/off 한다.
+ELK는 세 가지 방식으로 on/off 한다. **하나만 골라 일관되게** 쓴다(스크립트와 ArgoCD를 섞으면 상태가 어긋난다).
 
-1. **독립 제어** — 위 `elk-local-up.sh` / `elk-local-down.sh`. PLG 스택과 무관하게 ELK만 켜고 끈다.
-2. **메인 스택과 함께 (env 플래그)** — `AI_REPO_ELK_ENABLED=true`를 주면 메인 `k8s-local-up.sh`/`k8s-local-down.sh`가 ELK도 함께 기동/정리한다. 기본값은 off라 아무 설정 없이 실행하면 PLG만 뜬다.
+1. **독립 스크립트** — `elk-local-up.sh` / `elk-local-down.sh`. PLG와 무관하게 ELK만 켜고 끈다.
+2. **메인 스택 env 플래그** — `AI_REPO_ELK_ENABLED=true`를 주면 메인 `k8s-local-up.sh`/`k8s-local-down.sh`가 ELK도 함께 기동/정리한다. 기본 off라 아무 설정 없이 실행하면 PLG만 뜬다.
+3. **ArgoCD로 토글(GitOps)** — 아래 별도 섹션. 선언형으로 관리하고 UI/CLI에서 Sync/Delete로 켜고 끈다.
 
 ```bash
 AI_REPO_ELK_ENABLED=true ./scripts/k8s-local-up.sh    # PLG + ELK 함께 기동
@@ -38,6 +39,25 @@ AI_REPO_ELK_ENABLED=true ./scripts/k8s-local-down.sh  # PLG + ELK 함께 정리
 ```
 
 > ELK는 리소스 부담(ES 힙 1g+)이 크므로 **기본 off**로 두고 학습할 때만 켜는 것을 권장한다.
+
+### ArgoCD로 토글 (GitOps, 선택)
+
+스크립트(명령형) 대신 ArgoCD로 선언형 관리하고 싶으면 **ELK 전용 Application**(`deploy/argocd/logging-application.yaml`)을 쓴다. 기존 `ai-repo` App은 `automated+selfHeal`이라 **여기에 ELK를 넣으면 항상 켜져서 opt-in이 깨진다.** 그래서 ELK는 `automated`를 두지 않은 **별도 App(수동 sync)** 으로 분리한다.
+
+```bash
+# ① App 등록(1회) — App만 ArgoCD에 등록될 뿐, 이 시점에 ELK가 배포되지는 않는다(OutOfSync 상태).
+kubectl --context docker-desktop apply -f deploy/argocd/logging-application.yaml
+
+# ② 켜기 — 명시적으로 Sync (ArgoCD UI의 Sync 버튼 또는 CLI)
+argocd app sync ai-repo-logging
+
+# ③ 끄기 — App 삭제(cascade prune)로 logging ns 리소스 제거
+argocd app delete ai-repo-logging --cascade
+```
+
+- **자동복구(selfHeal) 없음**이 핵심이다. `automated`를 넣으면 삭제해도 되살아나 "항상 ON"이 된다.
+- ArgoCD UI에서 diff·헬스·리소스 트리를 보며 토글할 수 있어 **GitOps 학습**에 좋다.
+- 이 방식을 쓸 때는 위 스크립트 토글(1·2)과 **병행하지 않는다**(수동 delete와 ArgoCD 상태 불일치 방지).
 
 ### 로그 수집 범위 (autodiscover)
 

--- a/docs/progress/0077-elk-logging-stack.md
+++ b/docs/progress/0077-elk-logging-stack.md
@@ -21,7 +21,7 @@
 1. 학습용 opt-in ELK 로깅 스택(`deploy/k8s/logging`) 신설 — PLG와 병존, ArgoCD 미포함.
 2. Logstash grok 파이프라인으로 Spring 로그 구조화 파싱과 `spring-logs-*` 인덱스 색인.
 3. 기동/제거 스크립트와 학습·가이드 문서 신설.
-4. `AI_REPO_ELK_ENABLED` env 토글(메인 스택과 함께 on/off) + Filebeat를 라벨 `app=ai-repo` autodiscover로 범위 한정(네임스페이스 glob 오매칭 회피).
+4. 3-way on/off 토글: `AI_REPO_ELK_ENABLED` env(메인 스택과 함께), 독립 스크립트, `automated` 없는 별도 ArgoCD Application(`deploy/argocd/logging-application.yaml`, 수동 Sync/Delete) + Filebeat를 라벨 `app=ai-repo` autodiscover로 범위 한정(네임스페이스 glob 오매칭 회피).
 
 ## 검증
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -43,7 +43,7 @@
 - 배포 프로파일(`postgres`/`prod`)에서 공개된 기본 JWT secret·운영 토큰 fail-fast 확장(`JwtSecretGuard`/`OpsTokenGuard`)과 `deploy/k8s/app.yaml` 명시 값 주입
 - JDBC persistence adapter 분해 — `JdbcWalletRepository`를 PostgreSQL profile composite bean으로 유지하면서 wallet/ledger, outbox relay, outbox consumer, operational alert, admin audit SQL을 context별 package-private adapter로 분리하고 ArchUnit 레이어 규칙을 추가
 - `POST /internal/broker/outbox-events` shared secret 헤더(`X-Broker-Token`) 인증 — 전용 SecurityFilterChain(Order 3) + 상수시간 토큰 비교로 미인증 event 주입 차단, publisher가 같은 secret 부착(#123)
-- opt-in ELK 로깅 스택 — 학습용 Filebeat→Logstash(grok)→Elasticsearch(역색인)→Kibana를 `logging` 네임스페이스에 PLG(Loki)와 병존시키되 ArgoCD 미포함·`scripts/elk-local-up.sh`/`down.sh` 수동 기동, 로컬 학습 전제(security off·단일노드·ephemeral), Spring 로그 grok 파싱과 `spring-logs-*` KQL 검색. `AI_REPO_ELK_ENABLED` 토글로 메인 스택과 함께 on/off (ADR-0066)
+- opt-in ELK 로깅 스택 — 학습용 Filebeat→Logstash(grok)→Elasticsearch(역색인)→Kibana를 `logging` 네임스페이스에 PLG(Loki)와 병존시키되 ArgoCD 미포함·`scripts/elk-local-up.sh`/`down.sh` 수동 기동, 로컬 학습 전제(security off·단일노드·ephemeral), Spring 로그 grok 파싱과 `spring-logs-*` KQL 검색. `AI_REPO_ELK_ENABLED` 토글·독립 스크립트·별도 ArgoCD Application(수동 sync)로 on/off (ADR-0066)
 
 ## MVP 출시 판단 기준
 

--- a/wiki-drafts/Release-Notes.md
+++ b/wiki-drafts/Release-Notes.md
@@ -71,7 +71,7 @@
 
 ## 다음 후보
 
-- opt-in ELK 로깅 스택(Filebeat→Logstash grok→Elasticsearch→Kibana) — `logging` 네임스페이스에 PLG와 병존, ArgoCD 미포함·수동 스크립트(`scripts/elk-local-up.sh`/`down.sh`) 기동, 로그 파싱·역색인 검색 학습용. `AI_REPO_ELK_ENABLED` 토글 지원 (ADR-0066)
+- opt-in ELK 로깅 스택(Filebeat→Logstash grok→Elasticsearch→Kibana) — `logging` 네임스페이스에 PLG와 병존, ArgoCD 미포함·수동 스크립트(`scripts/elk-local-up.sh`/`down.sh`) 기동, 로그 파싱·역색인 검색 학습용. `AI_REPO_ELK_ENABLED`·독립 스크립트·ArgoCD 수동 sync App 토글 지원 (ADR-0066)
 - JWT refresh token 기반 만료/갱신 정책 강화(현재는 401 시 password-less 재발급)
 - 로그인 회원의 실제 보유 지갑 조회 API(현재는 fixture 기반 파생)
 - broker-specific Testcontainers contract


### PR DESCRIPTION
ELK를 스크립트(명령형) 대신 **ArgoCD(선언형)로 켜고 끌 수 있는 옵션** 추가.

## 왜 별도 App인가
기존 `ai-repo` App은 `automated+selfHeal`이라 여기에 ELK를 넣으면 **항상 켜져 opt-in이 깨진다**. 그래서 ELK는 `automated`를 두지 않은 **별도 Application(수동 sync)** 으로 분리한다.

## 추가
- `deploy/argocd/logging-application.yaml` — `deploy/k8s/logging` → `logging` ns, **수동 sync**.
  ```bash
  kubectl apply -f deploy/argocd/logging-application.yaml   # 등록
  argocd app sync ai-repo-logging                           # 켜기 (또는 UI Sync)
  argocd app delete ai-repo-logging --cascade               # 끄기 (prune)
  ```
- 문서: 가이드 "ArgoCD로 토글(GitOps)" 섹션, README 3-way 토글, ADR-0066/progress 0077/unreleased/wiki.

## on/off 3방식 (택1, 섞지 않음)
① 독립 스크립트 · ② env 플래그 `AI_REPO_ELK_ENABLED` · ③ ArgoCD 수동 sync App

## 검증
`kubectl apply --dry-run=server` (Application CRD) OK · yaml parse OK · check-dev-rules PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)