### PR TITLE
docs(wiki): 오늘 작업 반영 + ELK ArgoCD 토글 문구 정정

### DIFF
--- a/wiki-drafts/Architecture-Decisions.md
+++ b/wiki-drafts/Architecture-Decisions.md
@@ -120,7 +120,7 @@
 | 배포 프로파일 기본 자격증명 fail-fast (ADR-0062) | `postgres`/`prod`에서 공개된 기본 JWT secret·운영 토큰이면 기동 실패, `deploy/k8s/app.yaml`에 명시 값 주입 | 배포 프로파일 목록 하드코딩과 `app.yaml` 평문 값(Secret 주입은 #121에서 완결) |
 | Application layer Spring annotation policy (ADR-0063) | `@Service`, policy/properties `@Component`/`@Value`, 필요한 `@Transactional`을 제한적으로 허용하고 adapter 의존은 금지 | framework-free usecase 분리는 후속 전환 ADR 필요 |
 | JDBC persistence adapter decomposition (ADR-0064) | `JdbcWalletRepository`는 Spring composite bean으로 유지하고 SQL은 wallet/ledger, outbox relay, outbox consumer, operational alert, admin audit adapter로 분리 | composite가 여러 port를 계속 구현하는 절충은 유지 |
-| opt-in ELK 로그 스택 (ADR-0066) | 학습용 ELK(Filebeat→Logstash grok→Elasticsearch 역색인→Kibana)를 `logging` 네임스페이스에 PLG와 **병존**시키되 ArgoCD 미포함·수동 스크립트로만 기동, 2단계(Logstash grok) 토폴로지로 파싱 학습 | 로컬 학습 전용(security off·단일노드·ephemeral)이라 운영 신뢰성은 범위 밖, PLG 대비 리소스 비용이 크고 상시 구동하지 않음 |
+| opt-in ELK 로그 스택 (ADR-0066) | 학습용 ELK(Filebeat→Logstash grok→Elasticsearch 역색인→Kibana)를 `logging` 네임스페이스에 PLG와 **병존**시키되 기본 ArgoCD 자동배포 미포함(항상 켜짐 방지), on/off는 독립 스크립트·env 플래그·별도 ArgoCD 수동 sync App으로 토글, 2단계(Logstash grok) 토폴로지로 파싱 학습 | 로컬 학습 전용(security off·단일노드·ephemeral)이라 운영 신뢰성은 범위 밖, PLG 대비 리소스 비용이 크고 상시 구동하지 않음 |
 
 ## 다음 구조 후보
 

--- a/wiki-drafts/Release-Notes.md
+++ b/wiki-drafts/Release-Notes.md
@@ -46,6 +46,8 @@
 - k8s 로컬 스크립트 하드닝(loki/alloy rollout 대기 + Loki ready 스모크, ArgoCD 설치 버전 고정 v3.4.4)
 - JDBC persistence adapter 분해와 ArchUnit 레이어 규칙
 - Broker consumer endpoint 인증 — `/internal/broker/outbox-events`에 `X-Broker-Token` shared secret(전용 Order 3 체인, 상수시간 비교, 미인증 401), publisher 동반 부착, 배포 프로파일 기본 토큰 `BrokerTokenGuard` fail-fast (ADR-0065)
+- Grafana `ai-repo Overview` 대시보드에 Loki 로그 섹션 추가 — 로그 볼륨(level별 시계열)·앱 로그 스트림·오류/경고 로그 패널로 메트릭+로그를 한 화면에서 관측
+- 배포 broker 토큰 주입 — `deploy/k8s` secret/env에 broker 토큰이 없어 `BrokerTokenGuard`가 배포 앱을 CrashLoopBackOff시키던 회귀 수정
 
 ## 릴리스 후보 검증
 
@@ -71,7 +73,7 @@
 
 ## 다음 후보
 
-- opt-in ELK 로깅 스택(Filebeat→Logstash grok→Elasticsearch→Kibana) — `logging` 네임스페이스에 PLG와 병존, ArgoCD 미포함·수동 스크립트(`scripts/elk-local-up.sh`/`down.sh`) 기동, 로그 파싱·역색인 검색 학습용. `AI_REPO_ELK_ENABLED`·독립 스크립트·ArgoCD 수동 sync App 토글 지원 (ADR-0066)
+- opt-in ELK 로깅 스택(Filebeat→Logstash grok→Elasticsearch→Kibana) — `logging` 네임스페이스에 PLG와 병존, 기본 ArgoCD 자동배포에는 미포함(항상 켜짐 방지), 로그 파싱·역색인 검색 학습용. on/off는 독립 스크립트·`AI_REPO_ELK_ENABLED` env·별도 ArgoCD 수동 sync App(`deploy/argocd/logging-application.yaml`) 3가지 중 택1 (ADR-0066)
 - JWT refresh token 기반 만료/갱신 정책 강화(현재는 401 시 password-less 재발급)
 - 로그인 회원의 실제 보유 지갑 조회 API(현재는 fixture 기반 파생)
 - broker-specific Testcontainers contract


### PR DESCRIPTION
wiki-drafts 정리(문서 전용).
- Release-Notes: Grafana Loki 대시보드(PR #138), 배포 broker 토큰 주입 회귀 수정(PR #141) 누락분 추가.
- ELK 항목의 'ArgoCD 미포함 ↔ 수동 sync App 지원' 모순 문구 정정 → '기본 ArgoCD 자동배포 미포함 + on/off 3가지(스크립트·env·ArgoCD 수동 sync App) 택1' (Release-Notes·Architecture-Decisions).

check-dev-rules PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)