### PR TITLE
[Fix] 배포 outbox publisher http 전환·endpoint 경로 정합 (#144)

### DIFF
--- a/deploy/k8s/app.yaml
+++ b/deploy/k8s/app.yaml
@@ -61,6 +61,10 @@ spec:
                   key: AI_REPO_OUTBOX_PUBLISHER_HTTP_BROKER_TOKEN
             - name: AI_REPO_OUTBOX_RELAY_SCHEDULER_ENABLED
               value: "true"
+            - name: AI_REPO_OUTBOX_PUBLISHER_TYPE
+              value: "http"
+            - name: AI_REPO_OUTBOX_PUBLISHER_HTTP_ENDPOINT
+              value: "http://ai-repo:8080/internal/broker/outbox-events"
           ports:
             - containerPort: 8080
           readinessProbe:

--- a/docs/adr/0067-outbox-publisher-deployment-wiring.md
+++ b/docs/adr/0067-outbox-publisher-deployment-wiring.md
@@ -1,0 +1,42 @@
+# ADR-0067: Outbox Publisher Deployment Wiring
+
+## 상태
+
+Accepted
+
+## 배경
+
+배포(`postgres`) 프로파일에서 outbox relay가 event를 발행하지만 컨슈머가 이를 수신하지 못하고, 재시작 시 유실되는 결함이 있었다. 두 결함이 겹쳐 있었다.
+
+1. **memory 기본값 무동작**: `deploy/k8s/app.yaml`이 `AI_REPO_OUTBOX_PUBLISHER_TYPE`를 주입하지 않아 `application.yml` 기본값 `memory`가 선택된다. 이때 `InMemoryOperationOutboxPublisher`(`matchIfMissing=true`)가 발행을 담당하는데, relay는 event를 `PUBLISHED`로 마킹하지만 실제로는 in-memory 큐에만 쌓여 컨슈머(`POST /internal/broker/outbox-events`)로 전달되지 않는다. 프로세스 재시작 시 큐 내용이 사라져 event가 유실된다.
+2. **endpoint 경로 불일치**: `http` 모드로 전환하더라도 기본 endpoint 경로가 `http://127.0.0.1:18080/outbox-events`로, 실제 컨슈머 매핑 `/internal/broker/outbox-events`(`OperationOutboxConsumerController`)와 어긋난다. broker-token(ADR-0065)은 이미 배포 secret으로 주입되지만, 경로가 맞지 않으면 발행이 404로 실패한다.
+
+## 결정
+
+배포 프로파일에서 outbox relay가 자기 서비스의 컨슈머 endpoint로 실제 HTTP 발행을 하도록 배선을 명시하고, http 모드 기본 경로를 컨슈머 매핑과 정합시킨다.
+
+| 항목 | 결정 |
+| --- | --- |
+| 배포 publisher 타입 | `deploy/k8s/app.yaml`에 `AI_REPO_OUTBOX_PUBLISHER_TYPE=http` env 주입. memory 기본값 대신 HTTP publisher(`HttpOperationOutboxPublisher`)를 선택 |
+| 배포 endpoint | `AI_REPO_OUTBOX_PUBLISHER_HTTP_ENDPOINT=http://ai-repo:8080/internal/broker/outbox-events` 주입. Service 이름 `ai-repo`, 포트 8080으로 앱이 자기 자신의 컨슈머 endpoint에 발행해 publish→consume loop를 완성 |
+| 기본 경로 정합 | `application.yml`의 http 기본 endpoint 경로를 `/outbox-events` → `/internal/broker/outbox-events`로 변경(host/port `127.0.0.1:18080`는 유지). type만 http로 켰을 때도 컨슈머 매핑과 일치 |
+| broker-token | 이미 secret으로 주입되는 `AI_REPO_OUTBOX_PUBLISHER_HTTP_BROKER_TOKEN`(ADR-0065)을 그대로 사용. 추가 변경 없음 |
+
+## 트레이드오프
+
+### 장점
+
+- java 변경 없이 배포 매니페스트 env 2줄 + 기본 경로 1줄로 event 유실 회귀를 닫는다.
+- 앱이 자기 Service endpoint로 발행하므로 별도 broker 인프라 없이 배포 환경에서 publish→consume loop가 완성된다.
+- http 기본 경로가 컨슈머 매핑과 일치해, 이후 다른 배포/로컬 환경에서 type만 http로 켜도 경로 불일치 함정이 사라진다.
+
+### 비용
+
+- 배포 프로파일에서 publisher type이 여전히 env 주입에 의존한다. env가 누락되면 다시 memory 기본값으로 조용히 무동작한다(가드 없음).
+- 앱이 자기 자신에게 HTTP 호출을 하므로, 컨슈머 endpoint가 준비되기 전(startup 초기)의 발행은 실패·재시도에 의존한다.
+
+## 대안
+
+- **배포 프로파일 fail-fast 가드**: `postgres`/`prod` 프로파일에서 publisher type이 `memory`이면 startup을 실패시키는 가드(`BrokerTokenGuard` 패턴). 조용한 무동작을 원천 차단하지만 java 변경이 필요하고 로컬/테스트 프로파일과의 경계 설계가 필요하다. 남은 일로 기록한다.
+- **application.yml 기본값을 http로 변경**: 배포뿐 아니라 모든 프로파일 기본이 바뀌어 로컬/테스트에서 예기치 않은 HTTP 발행이 발생한다. 배포에만 국한하는 env 주입이 영향 범위가 작다.
+- **경로 불일치를 컨슈머 매핑 변경으로 해결**: 컨슈머 매핑(`/internal/broker/outbox-events`)은 broker 인증 체인(ADR-0065)과 결합돼 있어, publisher 기본값을 맞추는 것이 영향이 작다.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -82,3 +82,4 @@ ADR은 이 저장소에서 중요한 결정의 source of truth입니다. README�
 | ADR-0064 | JDBC Persistence Adapter Decomposition | Accepted |
 | ADR-0065 | Broker Consumer Endpoint Authentication | Accepted |
 | ADR-0066 | 학습용 opt-in ELK 로깅 스택 | Accepted |
+| ADR-0067 | Outbox Publisher Deployment Wiring | Accepted |

--- a/docs/progress/0078-outbox-publisher-deployment-wiring.md
+++ b/docs/progress/0078-outbox-publisher-deployment-wiring.md
@@ -1,0 +1,31 @@
+# 0078. Outbox Publisher Deployment Wiring
+
+## 스펙 목표
+
+- Issue #144의 배포(`postgres`) 프로파일 outbox 발행 무동작(event 유실)을 닫는다.
+- 배포 relay가 자기 서비스의 컨슈머 endpoint로 실제 HTTP 발행을 하도록 배선한다.
+- http 모드 기본 endpoint 경로를 컨슈머 매핑과 정합시킨다.
+
+## 완료 결과
+
+- `deploy/k8s/app.yaml` 컨테이너 env에 두 항목을 추가했다.
+  - `AI_REPO_OUTBOX_PUBLISHER_TYPE=http` — memory 기본값 대신 HTTP publisher 선택.
+  - `AI_REPO_OUTBOX_PUBLISHER_HTTP_ENDPOINT=http://ai-repo:8080/internal/broker/outbox-events` — 앱이 자기 Service endpoint로 발행해 publish→consume loop 완성.
+- `src/main/resources/application.yml`의 http 기본 endpoint 경로를 `/outbox-events` → `/internal/broker/outbox-events`로 변경(host/port `127.0.0.1:18080` 유지)해 컨슈머 매핑과 일치시켰다.
+- broker-token(`AI_REPO_OUTBOX_PUBLISHER_HTTP_BROKER_TOKEN`)은 이미 secret으로 주입되므로 그대로 두었다.
+- ADR-0067로 두 결함(memory 기본·경로 불일치)과 결정을 기록하고, unreleased release note에 반영했다.
+
+## 검증
+
+- `AI_REPO_DEV_RULES_BASE=origin/main bash scripts/check-dev-rules.sh` = PASS
+- java/migration/frontend 미변경이라 테스트 강제 대상 아님(배포 매니페스트·설정 기본값 변경).
+
+## 남은 일
+
+- 배포 프로파일(`postgres`/`prod`)에서 publisher type이 `memory`이면 startup을 실패시키는 fail-fast 가드(`BrokerTokenGuard` 패턴)는 후속으로 둔다. 현재는 env 누락 시 다시 memory로 조용히 무동작한다.
+
+## 관련 문서
+
+- `docs/adr/0067-outbox-publisher-deployment-wiring.md`
+- `docs/releases/unreleased.md`
+- `issue-drafts/0078-outbox-publisher-deploy-wiring.md`

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -93,6 +93,7 @@ ADR은 “왜 그렇게 결정했는가”를 기록하고, 이 폴더는 “각
 | 0075 | [Admin Path Drift Guard](0075-admin-path-drift-guard.md) | 완료 |
 | 0076 | [JDBC Persistence Adapter Decomposition](0076-jdbc-persistence-adapter-decomposition.md) | 완료 |
 | 0077 | [ELK 2단계 로깅 스택 (학습용 opt-in)](0077-elk-logging-stack.md) | 완료 |
+| 0078 | [Outbox Publisher Deployment Wiring](0078-outbox-publisher-deployment-wiring.md) | 완료 |
 
 ## 현재 기준선
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -44,6 +44,7 @@
 - JDBC persistence adapter 분해 — `JdbcWalletRepository`를 PostgreSQL profile composite bean으로 유지하면서 wallet/ledger, outbox relay, outbox consumer, operational alert, admin audit SQL을 context별 package-private adapter로 분리하고 ArchUnit 레이어 규칙을 추가
 - `POST /internal/broker/outbox-events` shared secret 헤더(`X-Broker-Token`) 인증 — 전용 SecurityFilterChain(Order 3) + 상수시간 토큰 비교로 미인증 event 주입 차단, publisher가 같은 secret 부착(#123)
 - opt-in ELK 로깅 스택 — 학습용 Filebeat→Logstash(grok)→Elasticsearch(역색인)→Kibana를 `logging` 네임스페이스에 PLG(Loki)와 병존시키되 ArgoCD 미포함·`scripts/elk-local-up.sh`/`down.sh` 수동 기동, 로컬 학습 전제(security off·단일노드·ephemeral), Spring 로그 grok 파싱과 `spring-logs-*` KQL 검색. `AI_REPO_ELK_ENABLED` 토글·독립 스크립트·별도 ArgoCD Application(수동 sync)로 on/off (ADR-0066)
+- 배포 outbox publisher 배선 — `deploy/k8s/app.yaml`이 `AI_REPO_OUTBOX_PUBLISHER_TYPE`를 안 줘 memory 기본값으로 event가 유실되던 결함을 `type=http` + 자기 Service endpoint(`http://ai-repo:8080/internal/broker/outbox-events`) 주입으로 수정하고, http 기본 endpoint 경로를 컨슈머 매핑(`/internal/broker/outbox-events`)과 정합 (ADR-0067, #144)
 
 ## MVP 출시 판단 기준
 

--- a/issue-drafts/0078-outbox-publisher-deploy-wiring.md
+++ b/issue-drafts/0078-outbox-publisher-deploy-wiring.md
@@ -1,0 +1,26 @@
+# 배포 outbox publisher 무동작(event 유실)과 endpoint 경로 정합
+
+## 증상
+
+배포(`postgres`) 프로파일에서 outbox 발행이 무동작한다.
+
+- `deploy/k8s/app.yaml`이 `AI_REPO_OUTBOX_PUBLISHER_TYPE`를 주입하지 않아 `application.yml` 기본값 `memory`(`InMemoryOperationOutboxPublisher`, `matchIfMissing=true`)가 선택된다. relay는 event를 `PUBLISHED`로 마킹하지만 in-memory 큐에만 쌓여 컨슈머로 전달되지 않고, 재시작 시 유실된다.
+- `http`로 바꿔도 기본 endpoint(`http://127.0.0.1:18080/outbox-events`)가 컨슈머 매핑(`/internal/broker/outbox-events`)과 불일치해 발행이 실패한다.
+
+## 결정
+
+- `deploy/k8s/app.yaml`에 `AI_REPO_OUTBOX_PUBLISHER_TYPE=http`와 `AI_REPO_OUTBOX_PUBLISHER_HTTP_ENDPOINT=http://ai-repo:8080/internal/broker/outbox-events` 주입. 앱이 자기 Service endpoint로 발행해 publish→consume loop 완성.
+- `application.yml`의 http 기본 endpoint 경로를 `/outbox-events` → `/internal/broker/outbox-events`로 정합(host/port 유지).
+- broker-token은 이미 secret으로 주입되므로 그대로 둔다.
+
+## 검증
+
+```bash
+AI_REPO_DEV_RULES_BASE=origin/main bash scripts/check-dev-rules.sh
+```
+
+## 후속 (main 머지 후)
+
+- 배포 프로파일(`postgres`/`prod`)에서 publisher type이 `memory`이면 startup을 실패시키는 fail-fast 가드(`BrokerTokenGuard` 패턴).
+
+관련: GitHub Issue #144, ADR-0067, progress 0078.

--- a/issue-drafts/README.md
+++ b/issue-drafts/README.md
@@ -137,6 +137,8 @@
 - `0076-jdbc-persistence-adapter-decomposition.md`: JdbcWalletRepository bounded-context 분해와 ArchUnit 레이어 규칙 작업 초안
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/125
 - `0077-elk-logging-stack.md`: ELK 2단계 로깅 스택(Filebeat→Logstash grok→ES→Kibana) 학습용 opt-in 작업 초안
+- `0078-outbox-publisher-deploy-wiring.md`: 배포 outbox publisher http 전환·endpoint 경로 정합(event 유실 수정) 작업 초안
+  - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/144
 
 ## GitHub CLI로 생성
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,7 +40,7 @@ ai-repo:
     publisher:
       type: ${AI_REPO_OUTBOX_PUBLISHER_TYPE:memory}
       http:
-        endpoint: ${AI_REPO_OUTBOX_PUBLISHER_HTTP_ENDPOINT:http://127.0.0.1:18080/outbox-events}
+        endpoint: ${AI_REPO_OUTBOX_PUBLISHER_HTTP_ENDPOINT:http://127.0.0.1:18080/internal/broker/outbox-events}
         timeout-ms: ${AI_REPO_OUTBOX_PUBLISHER_HTTP_TIMEOUT_MS:3000}
         broker-token: ${AI_REPO_OUTBOX_PUBLISHER_HTTP_BROKER_TOKEN:local-broker-token}
   outbox-relay:

--- a/wiki-drafts/Release-Notes.md
+++ b/wiki-drafts/Release-Notes.md
@@ -48,6 +48,7 @@
 - Broker consumer endpoint 인증 — `/internal/broker/outbox-events`에 `X-Broker-Token` shared secret(전용 Order 3 체인, 상수시간 비교, 미인증 401), publisher 동반 부착, 배포 프로파일 기본 토큰 `BrokerTokenGuard` fail-fast (ADR-0065)
 - Grafana `ai-repo Overview` 대시보드에 Loki 로그 섹션 추가 — 로그 볼륨(level별 시계열)·앱 로그 스트림·오류/경고 로그 패널로 메트릭+로그를 한 화면에서 관측
 - 배포 broker 토큰 주입 — `deploy/k8s` secret/env에 broker 토큰이 없어 `BrokerTokenGuard`가 배포 앱을 CrashLoopBackOff시키던 회귀 수정
+- 배포 outbox publisher 배선 — 배포 프로파일이 publisher type을 안 줘 memory 기본값으로 event가 유실되던 결함을 `type=http` + 자기 Service endpoint 주입으로 수정, http 기본 경로를 컨슈머 매핑과 정합 (ADR-0067)
 
 ## 릴리스 후보 검증
 


### PR DESCRIPTION
## 요약

배포(`postgres`) 프로파일에서 outbox 발행이 무동작해 event가 유실되던 결함을 수정한다.

- `deploy/k8s/app.yaml`이 `AI_REPO_OUTBOX_PUBLISHER_TYPE`를 주입하지 않아 `application.yml` 기본값 `memory`(`InMemoryOperationOutboxPublisher`, `matchIfMissing=true`)가 선택 → relay가 `PUBLISHED`로 마킹하지만 컨슈머 미수신·재시작 시 유실.
- `http`로 바꿔도 기본 endpoint(`http://127.0.0.1:18080/outbox-events`)가 컨슈머 매핑(`/internal/broker/outbox-events`)과 불일치.

## 변경

- `deploy/k8s/app.yaml`: `AI_REPO_OUTBOX_PUBLISHER_TYPE=http` + `AI_REPO_OUTBOX_PUBLISHER_HTTP_ENDPOINT=http://ai-repo:8080/internal/broker/outbox-events` 주입(자기 Service endpoint로 발행해 publish→consume loop 완성). broker-token은 이미 secret으로 주입되어 그대로 둠.
- `src/main/resources/application.yml`: http 기본 endpoint 경로를 `/outbox-events` → `/internal/broker/outbox-events`로 정합(host/port `127.0.0.1:18080` 유지).
- 문서: ADR-0067, progress 0078, issue-draft 0078, unreleased/wiki-drafts 반영.

## 검증

- `AI_REPO_DEV_RULES_BASE=origin/main bash scripts/check-dev-rules.sh` = PASS
- java/migration/frontend 미변경이라 테스트 강제 대상 아님(배포 매니페스트·설정 기본값 변경).

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)