### PR TITLE
[Fix] 배포 프로파일 postgres 누락 시 fail-fast 가드 (#145)

### DIFF
--- a/docs/adr/0068-deployed-profile-persistence-guard.md
+++ b/docs/adr/0068-deployed-profile-persistence-guard.md
@@ -1,0 +1,45 @@
+# ADR-0068: Deployed Profile Persistence Guard
+
+## 상태
+
+Accepted
+
+## 배경
+
+`DeployedProfiles.isActive`는 `prod`와 `postgres`를 모두 배포 런타임으로 취급한다(자격증명 fail-fast의 판정 축, ADR-0062). 그런데 영속성 선택은 오직 `postgres` 프로파일에만 반응한다.
+
+- `JdbcWalletRepository`는 `@Profile("postgres")`
+- `InMemoryWalletRepository`는 `@Profile("!postgres")`
+
+따라서 `prod` 단독 기동(예: `postgres` 프로파일 누락)은 `JwtSecretGuard`/`OpsTokenGuard`/`BrokerTokenGuard` 같은 자격증명 가드는 통과하지만, 영속성은 `!postgres`로 판정되어 `InMemoryWalletRepository`가 로드된다. 결과적으로 배포로 인식된 런타임이 in-memory 저장소로 뜨고, 재시작 시 지갑 잔액이 유실된다(#145).
+
+## 결정
+
+`DeployedProfilePersistenceGuard`를 신설한다. 기존 자격증명 가드(`JwtSecretGuard` 등)와 동일한 패턴이다.
+
+| 항목 | 결정 |
+| --- | --- |
+| 위치 | `wallet/config` 패키지의 package-private `@Component` |
+| 판정 | 생성자에서 `Environment` 주입. `DeployedProfiles.isActive(env)`가 true인데 활성 프로파일에 `postgres`가 없으면 startup 실패 |
+| 실패 방식 | `IllegalStateException`("deployed profile requires the 'postgres' profile for JDBC persistence; in-memory wallet store must not run in a deployed profile") 을 던져 context refresh 단계에서 기동을 막음 |
+| 그 외 | 비배포(local/test/no profile) 또는 `postgres` 포함 시 no-op(`postgres` 포함 시 log.info) |
+
+이로써 "배포 프로파일 = JDBC 영속성" 불변식을 명시적 기동 실패로 강제한다. 콜사이트 변경은 없다(가드 bean 추가 1건).
+
+## 트레이드오프
+
+### 장점
+
+- 콜사이트 변경 0에 가깝다. 기존 `@Profile` 배선을 건드리지 않고 가드 bean 하나로 불변식을 강제한다.
+- 데이터 유실이라는 조용한 실패를 기동 시점의 명시적 실패로 앞당긴다(fail-fast).
+- 기존 자격증명 가드(`JwtSecretGuard`/`OpsTokenGuard`/`BrokerTokenGuard`)와 동일한 축을 재사용해 일관적이다.
+
+### 비용
+
+- 배포 프로파일 판정과 영속성 프로파일 판정이 여전히 두 곳(`DeployedProfiles`와 `@Profile`)에 분산되어 있고, 가드는 그 정합성을 런타임에 확인할 뿐 구조적으로 통일하지는 않는다.
+
+## 대안
+
+- **`InMemoryWalletRepository`의 `@Profile`을 `!postgres & !prod`로 좁히기**: 배포 프로파일에서 in-memory bean 자체가 등록되지 않게 한다. 다만 이 경우 어떤 wallet repository도 없어 bean 조회 실패로 기동이 깨지되, 메시지가 "no qualifying bean" 수준이라 원인(배포 프로파일에 postgres 누락)이 드러나지 않는다. `prod` 외 다른 배포 프로파일이 추가되면 술어를 계속 늘려야 한다.
+- **`DeployedProfiles` 술어를 영속성 기준으로 통일**: 배포 판정을 `postgres`로 좁혀 자격증명과 영속성을 한 축으로 묶는다. 하지만 `prod`를 배포로 취급하는 기존 자격증명 정책(ADR-0062)의 의미가 바뀌어 회귀 범위가 넓다.
+- 채택안(가드)은 콜사이트 변경이 거의 없고 원인을 담은 명시적 실패 메시지를 준다는 점에서 위 두 대안보다 외과적이다.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -82,3 +82,4 @@ ADR은 이 저장소에서 중요한 결정의 source of truth입니다. README�
 | ADR-0064 | JDBC Persistence Adapter Decomposition | Accepted |
 | ADR-0065 | Broker Consumer Endpoint Authentication | Accepted |
 | ADR-0066 | 학습용 opt-in ELK 로깅 스택 | Accepted |
+| ADR-0068 | Deployed Profile Persistence Guard | Accepted |

--- a/docs/progress/0079-deployed-profile-persistence-guard.md
+++ b/docs/progress/0079-deployed-profile-persistence-guard.md
@@ -1,0 +1,31 @@
+# 0079. Deployed Profile Persistence Guard
+
+## 스펙 목표
+
+- Issue #145의 배포 프로파일 in-memory 저장소 유실 위험을 fail-fast 가드로 닫는다.
+- 배포 프로파일(`prod`/`postgres`) 단독 `prod` 기동이 `postgres` 없이 In-Memory 저장소를 로드하는 경로를 startup 실패로 전환한다.
+- 결정과 대안을 ADR로 확정한다.
+
+## 완료 결과
+
+- `DeployedProfilePersistenceGuard`(`wallet/config`)를 신설했다. `DeployedProfiles.isActive(env)`가 true인데 활성 프로파일에 `postgres`가 없으면 `IllegalStateException`으로 기동을 실패시킨다.
+- 기존 자격증명 가드(`JwtSecretGuard`/`OpsTokenGuard`/`BrokerTokenGuard`)와 동일한 package-private `@Component` + `Environment` 주입 패턴을 따랐다.
+- `DeployedProfilePersistenceGuardTest`로 (a) `prod` 단독 → throws, (b) `postgres` → ok, (c) `prod`+`postgres` → ok, (d) `local` → ok, (e) 프로파일 없음 → ok 를 `MockEnvironment`로 고정했다.
+- 결정을 ADR-0068로 기록하고 대안(InMemory `@Profile` 좁히기 / `DeployedProfiles` 술어 통일)과 채택 근거를 서술했다.
+- ADR index, progress index, unreleased release note에 변경 내용을 반영했다.
+
+## 검증
+
+- `./gradlew compileTestJava`
+- `./gradlew test --tests '*DeployedProfilePersistenceGuardTest'`
+- `AI_REPO_DEV_RULES_BASE=origin/main bash scripts/check-dev-rules.sh`
+
+## 남은 일
+
+- 배포 판정(`DeployedProfiles`)과 영속성 프로파일(`@Profile`)을 한 축으로 구조적으로 통일하는 리팩터링은 회귀 범위가 넓어 후속으로 둔다.
+
+## 관련 문서
+
+- `docs/adr/0068-deployed-profile-persistence-guard.md`
+- `docs/releases/unreleased.md`
+- `issue-drafts/0079-deployed-profile-persistence-guard.md`

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -93,6 +93,7 @@ ADR은 “왜 그렇게 결정했는가”를 기록하고, 이 폴더는 “각
 | 0075 | [Admin Path Drift Guard](0075-admin-path-drift-guard.md) | 완료 |
 | 0076 | [JDBC Persistence Adapter Decomposition](0076-jdbc-persistence-adapter-decomposition.md) | 완료 |
 | 0077 | [ELK 2단계 로깅 스택 (학습용 opt-in)](0077-elk-logging-stack.md) | 완료 |
+| 0079 | [Deployed Profile Persistence Guard](0079-deployed-profile-persistence-guard.md) | 완료 |
 
 ## 현재 기준선
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -44,6 +44,7 @@
 - JDBC persistence adapter 분해 — `JdbcWalletRepository`를 PostgreSQL profile composite bean으로 유지하면서 wallet/ledger, outbox relay, outbox consumer, operational alert, admin audit SQL을 context별 package-private adapter로 분리하고 ArchUnit 레이어 규칙을 추가
 - `POST /internal/broker/outbox-events` shared secret 헤더(`X-Broker-Token`) 인증 — 전용 SecurityFilterChain(Order 3) + 상수시간 토큰 비교로 미인증 event 주입 차단, publisher가 같은 secret 부착(#123)
 - opt-in ELK 로깅 스택 — 학습용 Filebeat→Logstash(grok)→Elasticsearch(역색인)→Kibana를 `logging` 네임스페이스에 PLG(Loki)와 병존시키되 ArgoCD 미포함·`scripts/elk-local-up.sh`/`down.sh` 수동 기동, 로컬 학습 전제(security off·단일노드·ephemeral), Spring 로그 grok 파싱과 `spring-logs-*` KQL 검색. `AI_REPO_ELK_ENABLED` 토글·독립 스크립트·별도 ArgoCD Application(수동 sync)로 on/off (ADR-0066)
+- 배포 프로파일 영속성 fail-fast 가드 — `DeployedProfilePersistenceGuard`가 배포 프로파일(`prod`/`postgres`)인데 `postgres`가 없으면 startup을 실패시켜, `prod` 단독 기동이 In-Memory 지갑 저장소를 로드해 재시작 시 잔액이 유실되는 경로를 막음(#145, ADR-0068)
 
 ## MVP 출시 판단 기준
 

--- a/issue-drafts/0079-deployed-profile-persistence-guard.md
+++ b/issue-drafts/0079-deployed-profile-persistence-guard.md
@@ -1,0 +1,25 @@
+# prod 프로파일 단독 기동 시 In-Memory 저장소 로드(데이터 유실)
+
+## 증상
+
+`DeployedProfiles.isActive`는 `prod`/`postgres`를 배포로 취급하지만, 영속성은 `postgres`에만 반응한다(`JdbcWalletRepository @Profile("postgres")`, `InMemoryWalletRepository @Profile("!postgres")`). 그래서 `prod` 단독 기동은 자격증명 가드는 통과하되 In-Memory 저장소를 로드하고, 재시작 시 지갑 잔액이 유실된다.
+
+## 결정 / 제안
+
+- `DeployedProfilePersistenceGuard`(`wallet/config`)를 신설한다. `DeployedProfiles.isActive(env)`가 true인데 활성 프로파일에 `postgres`가 없으면 `IllegalStateException`으로 startup을 실패시킨다.
+- 기존 자격증명 가드(`JwtSecretGuard`/`OpsTokenGuard`/`BrokerTokenGuard`)와 동일한 package-private `@Component` + `Environment` 주입 패턴을 따른다. 콜사이트 변경은 없다.
+
+## 완료 조건
+
+- [x] 배포 프로파일에서 `postgres` 누락 시 기동 실패 가드 추가
+- [x] `MockEnvironment` 기반 회귀 테스트(prod 단독/postgres/prod+postgres/local/no-profile)
+- [x] ADR/문서에 결정과 대안(InMemory `@Profile` 좁히기 / `DeployedProfiles` 술어 통일) 기록
+
+## 검증 명령
+
+```bash
+./gradlew test --tests '*DeployedProfilePersistenceGuardTest'
+AI_REPO_DEV_RULES_BASE=origin/main bash scripts/check-dev-rules.sh
+```
+
+관련: GitHub Issue #145, ADR-0068, progress 0079.

--- a/issue-drafts/README.md
+++ b/issue-drafts/README.md
@@ -137,6 +137,8 @@
 - `0076-jdbc-persistence-adapter-decomposition.md`: JdbcWalletRepository bounded-context 분해와 ArchUnit 레이어 규칙 작업 초안
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/125
 - `0077-elk-logging-stack.md`: ELK 2단계 로깅 스택(Filebeat→Logstash grok→ES→Kibana) 학습용 opt-in 작업 초안
+- `0079-deployed-profile-persistence-guard.md`: 배포 프로파일 postgres 누락 시 In-Memory 저장소 유실 방지 fail-fast 가드 작업 초안
+  - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/145
 
 ## GitHub CLI로 생성
 

--- a/src/main/java/com/imwoo/airepo/wallet/config/DeployedProfilePersistenceGuard.java
+++ b/src/main/java/com/imwoo/airepo/wallet/config/DeployedProfilePersistenceGuard.java
@@ -1,0 +1,37 @@
+package com.imwoo.airepo.wallet.config;
+
+import java.util.Arrays;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+/**
+ * Fails application startup if a deployed profile ({@code postgres} or {@code prod}; see
+ * {@link DeployedProfiles}) runs without the {@code postgres} profile. JDBC persistence
+ * ({@code JdbcWalletRepository}) is only active under {@code postgres}, while
+ * {@code InMemoryWalletRepository} loads under {@code !postgres}. A {@code prod}-only startup would
+ * therefore pass the credential guards yet load the in-memory store, silently losing balances on
+ * restart. Requiring {@code postgres} under any deployed profile turns that data-loss trap into an
+ * explicit startup failure. Non-deployed profiles (local, test, no profile) keep the in-memory
+ * store for developer runs.
+ */
+@Component
+class DeployedProfilePersistenceGuard {
+
+    private static final Logger log = LoggerFactory.getLogger(DeployedProfilePersistenceGuard.class);
+
+    DeployedProfilePersistenceGuard(Environment environment) {
+        if (!DeployedProfiles.isActive(environment)) {
+            return;
+        }
+        boolean postgresActive = Arrays.stream(environment.getActiveProfiles())
+                .anyMatch("postgres"::equals);
+        if (!postgresActive) {
+            throw new IllegalStateException(
+                    "deployed profile requires the 'postgres' profile for JDBC persistence; "
+                            + "in-memory wallet store must not run in a deployed profile");
+        }
+        log.info("deployed profile with 'postgres' active — JDBC wallet persistence in use.");
+    }
+}

--- a/src/test/java/com/imwoo/airepo/wallet/config/DeployedProfilePersistenceGuardTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/config/DeployedProfilePersistenceGuardTest.java
@@ -1,0 +1,55 @@
+package com.imwoo.airepo.wallet.config;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+class DeployedProfilePersistenceGuardTest {
+
+    @Test
+    void failsFastWhenProdProfileRunsWithoutPostgres() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setActiveProfiles("prod");
+
+        assertThatThrownBy(() -> new DeployedProfilePersistenceGuard(environment))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("postgres");
+    }
+
+    @Test
+    void allowsPostgresProfile() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setActiveProfiles("postgres");
+
+        assertThatCode(() -> new DeployedProfilePersistenceGuard(environment))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void allowsProdAndPostgresProfilesTogether() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setActiveProfiles("prod", "postgres");
+
+        assertThatCode(() -> new DeployedProfilePersistenceGuard(environment))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void allowsNonDeployedProfile() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setActiveProfiles("local");
+
+        assertThatCode(() -> new DeployedProfilePersistenceGuard(environment))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void allowsNoActiveProfile() {
+        MockEnvironment environment = new MockEnvironment();
+
+        assertThatCode(() -> new DeployedProfilePersistenceGuard(environment))
+                .doesNotThrowAnyException();
+    }
+}

--- a/wiki-drafts/Release-Notes.md
+++ b/wiki-drafts/Release-Notes.md
@@ -74,6 +74,7 @@
 ## 다음 후보
 
 - opt-in ELK 로깅 스택(Filebeat→Logstash grok→Elasticsearch→Kibana) — `logging` 네임스페이스에 PLG와 병존, 기본 ArgoCD 자동배포에는 미포함(항상 켜짐 방지), 로그 파싱·역색인 검색 학습용. on/off는 독립 스크립트·`AI_REPO_ELK_ENABLED` env·별도 ArgoCD 수동 sync App(`deploy/argocd/logging-application.yaml`) 3가지 중 택1 (ADR-0066)
+- 배포 프로파일에서 `postgres` 누락 시 In-Memory 지갑 저장소 로드로 인한 잔액 유실을 막는 startup fail-fast 가드(`DeployedProfilePersistenceGuard`, ADR-0068)
 - JWT refresh token 기반 만료/갱신 정책 강화(현재는 401 시 password-less 재발급)
 - 로그인 회원의 실제 보유 지갑 조회 API(현재는 fixture 기반 파생)
 - broker-specific Testcontainers contract


### PR DESCRIPTION
## 요약

배포 프로파일 판정(`DeployedProfiles.isActive`)은 `prod`/`postgres`를 모두 배포로 취급하지만, 영속성은 `postgres`에만 반응한다(`JdbcWalletRepository @Profile("postgres")`, `InMemoryWalletRepository @Profile("!postgres")`). 그래서 `prod` 단독 기동은 자격증명 가드는 통과하되 In-Memory 저장소를 로드하고, 재시작 시 지갑 잔액이 유실된다.

`DeployedProfilePersistenceGuard`(`wallet/config`)를 신설해, 배포 프로파일인데 활성 프로파일에 `postgres`가 없으면 `IllegalStateException`으로 startup을 실패시킨다. 기존 `JwtSecretGuard`/`OpsTokenGuard`/`BrokerTokenGuard`와 동일한 package-private `@Component` + `Environment` 주입 패턴을 따르며 콜사이트 변경은 없다.

## 변경

- `DeployedProfilePersistenceGuard` 신설 + `DeployedProfilePersistenceGuardTest`(prod 단독→throws, postgres/prod+postgres/local/no-profile→ok)
- ADR-0068, progress 0079, issue-draft 0079, unreleased/wiki-drafts 릴리스 노트 반영

## 검증

- `./gradlew compileTestJava` — OK
- `./gradlew test --tests '*DeployedProfilePersistenceGuardTest'` — 통과
- `AI_REPO_DEV_RULES_BASE=origin/main bash scripts/check-dev-rules.sh` — PASS

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)