### PR TITLE
[Feature] 핫 쿼리 인덱스 추가·outbox claim 배치 업데이트 (#148)

### DIFF
--- a/docs/adr/0071-hot-query-indexes-and-batched-outbox-claim.md
+++ b/docs/adr/0071-hot-query-indexes-and-batched-outbox-claim.md
@@ -1,0 +1,41 @@
+# ADR-0071: Hot Query Indexes and Batched Outbox Claim
+
+## 상태
+
+Accepted
+
+## 배경
+
+Issue #148은 두 가지 성능/스케일 부채를 지적했다.
+
+- `ledger_entries`·`transaction_history`는 `wallet_id` 기준 시간순 조회가 핫 경로인데 인덱스가 없어 지갑별 원장/거래내역이 커질수록 전체 스캔이 발생한다. `operation_outbox_events`도 relay claim이 `status`로 필터하고 `occurred_at, outbox_event_id` 순으로 정렬하는데 인덱스가 없어 이벤트가 쌓이면 정렬/스캔 비용이 커진다.
+- `JdbcOutboxRelayRepository.claimReadyOutboxEvents`는 claim 대상 id를 먼저 `for update skip locked`로 확보한 뒤, 각 id마다 `update ... where outbox_event_id = ?`를 **행 단위 루프**로 실행했다. 배치 크기만큼 round-trip이 발생해 batch가 커질수록 latency가 선형 증가한다.
+
+## 결정
+
+| 항목 | 결정 |
+| --- | --- |
+| 원장/거래내역 인덱스 | `ledger_entries(wallet_id, occurred_at)`, `transaction_history(wallet_id, occurred_at)` 복합 인덱스를 추가한다. |
+| outbox claim 인덱스 | `operation_outbox_events(status, occurred_at, outbox_event_id)` 복합 인덱스를 추가한다. claim 쿼리의 `status` 필터와 `order by occurred_at, outbox_event_id`를 함께 커버한다. |
+| 반영 위치 | 신규 Flyway 마이그레이션 `V19__add_hot_query_indexes.sql`과 통합 스키마 `db/postgresql/schema.sql` 양쪽에 `CREATE INDEX IF NOT EXISTS`로 동일하게 반영한다. |
+| claim 업데이트 배치화 | claim id 루프 UPDATE를 단일 `update ... set status=PROCESSING, claimed_at, lease_expires_at, next_retry_at=null, published_at=null, last_error=null where outbox_event_id in (?, ?, ...)`로 교체한다. `for update skip locked` 선행 claim 로직과 트랜잭션 경계는 유지한다. |
+
+배치 UPDATE는 기존 행 단위 UPDATE와 세팅하는 컬럼/값이 완전히 동일하므로 의미가 보존된다. claim은 이미 선행 `for update skip locked` select로 대상 id를 고정했으므로, 그 id 집합에 대한 단일 IN UPDATE는 동일한 행만 전이시킨다.
+
+## 트레이드오프
+
+### 장점
+
+- 지갑별 원장/거래내역 조회와 outbox claim 스캔이 인덱스로 커버돼 데이터 증가에도 정렬/스캔 비용이 안정적이다.
+- claim UPDATE round-trip이 배치 크기 N에서 1로 줄어 relay tick latency가 배치 크기에 비례해 늘지 않는다.
+
+### 비용
+
+- 인덱스 3개 추가로 해당 테이블 쓰기 시 인덱스 유지 비용과 저장 공간이 소폭 증가한다. 원장/outbox는 append 위주라 읽기 이득이 이를 상쇄한다.
+- IN 절 placeholder가 배치 크기만큼 늘어나므로 매우 큰 배치에서는 쿼리 파싱 비용이 커질 수 있으나, relay batch size는 제한돼 있어 실무 범위에서 문제되지 않는다.
+
+## 대안
+
+- 인덱스 없이 쿼리만 유지: 데이터가 커지면 전체 스캔으로 성능이 저하돼 이슈 요구를 충족하지 못한다.
+- `jdbcTemplate.batchUpdate`로 배치화: 여러 UPDATE 문을 한 번에 보내지만 여전히 문장 수가 N개다. 모든 행이 같은 값을 세팅하므로 단일 IN UPDATE가 더 단순하고 문장 수도 1이다.
+- PUBLISHED outbox 행 pruning: 이번 범위에서 제외하고 별도 스케줄러/서비스로 다룬다(progress 남은 일 참고).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -82,3 +82,4 @@ ADR은 이 저장소에서 중요한 결정의 source of truth입니다. README�
 | ADR-0064 | JDBC Persistence Adapter Decomposition | Accepted |
 | ADR-0065 | Broker Consumer Endpoint Authentication | Accepted |
 | ADR-0066 | 학습용 opt-in ELK 로깅 스택 | Accepted |
+| ADR-0071 | Hot Query Indexes and Batched Outbox Claim | Accepted |

--- a/docs/progress/0082-hot-query-indexes-and-batched-outbox-claim.md
+++ b/docs/progress/0082-hot-query-indexes-and-batched-outbox-claim.md
@@ -1,0 +1,33 @@
+# 0082. Hot Query Indexes and Batched Outbox Claim
+
+## 스펙 목표
+
+- Issue #148의 핫 쿼리 인덱스 부재와 outbox claim 행 단위 루프 부채를 해소한다.
+- 지갑별 원장/거래내역 조회와 outbox relay claim 스캔을 인덱스로 커버한다.
+- claim UPDATE를 단일 배치로 전환해 relay tick round-trip을 줄인다.
+
+## 완료 결과
+
+- `V19__add_hot_query_indexes.sql` 마이그레이션과 `db/postgresql/schema.sql`에 동일 인덱스를 추가했다.
+  - `ledger_entries(wallet_id, occurred_at)`
+  - `transaction_history(wallet_id, occurred_at)`
+  - `operation_outbox_events(status, occurred_at, outbox_event_id)`
+- `JdbcOutboxRelayRepository.claimReadyOutboxEvents`의 행 단위 UPDATE 루프를 `where outbox_event_id in (...)` 단일 배치 UPDATE로 교체했다. status/claimed_at/lease_expires_at/next_retry_at/published_at/last_error 세팅 값과 `for update skip locked` 선행 claim, 트랜잭션 경계는 유지했다.
+- `JdbcWalletRepositoryTest`에 N개의 ready 이벤트를 한 번에 claim할 때 전부 `PROCESSING`으로 전이하는지 검증하는 테스트를 추가했다.
+- ADR-0071로 인덱스·배치 claim 결정을 기록했다.
+
+## 검증
+
+- `./gradlew compileTestJava`
+- `./gradlew test --tests '*JdbcWalletRepositoryTest'`
+- `AI_REPO_DEV_RULES_BASE=origin/main bash scripts/check-dev-rules.sh`
+
+## 남은 일
+
+- `PUBLISHED` outbox 행 pruning(보존 기간 기준 삭제)은 이번 범위에서 제외했다. 별도 스케줄러/서비스로 relay run pruning과 같은 축에서 다룬다.
+
+## 관련 문서
+
+- `docs/adr/0071-hot-query-indexes-and-batched-outbox-claim.md`
+- `docs/releases/unreleased.md`
+- `issue-drafts/0082-hot-query-indexes-and-batched-outbox-claim.md`

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -93,6 +93,7 @@ ADR은 “왜 그렇게 결정했는가”를 기록하고, 이 폴더는 “각
 | 0075 | [Admin Path Drift Guard](0075-admin-path-drift-guard.md) | 완료 |
 | 0076 | [JDBC Persistence Adapter Decomposition](0076-jdbc-persistence-adapter-decomposition.md) | 완료 |
 | 0077 | [ELK 2단계 로깅 스택 (학습용 opt-in)](0077-elk-logging-stack.md) | 완료 |
+| 0082 | [Hot Query Indexes and Batched Outbox Claim](0082-hot-query-indexes-and-batched-outbox-claim.md) | 완료 |
 
 ## 현재 기준선
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -44,6 +44,7 @@
 - JDBC persistence adapter 분해 — `JdbcWalletRepository`를 PostgreSQL profile composite bean으로 유지하면서 wallet/ledger, outbox relay, outbox consumer, operational alert, admin audit SQL을 context별 package-private adapter로 분리하고 ArchUnit 레이어 규칙을 추가
 - `POST /internal/broker/outbox-events` shared secret 헤더(`X-Broker-Token`) 인증 — 전용 SecurityFilterChain(Order 3) + 상수시간 토큰 비교로 미인증 event 주입 차단, publisher가 같은 secret 부착(#123)
 - opt-in ELK 로깅 스택 — 학습용 Filebeat→Logstash(grok)→Elasticsearch(역색인)→Kibana를 `logging` 네임스페이스에 PLG(Loki)와 병존시키되 ArgoCD 미포함·`scripts/elk-local-up.sh`/`down.sh` 수동 기동, 로컬 학습 전제(security off·단일노드·ephemeral), Spring 로그 grok 파싱과 `spring-logs-*` KQL 검색. `AI_REPO_ELK_ENABLED` 토글·독립 스크립트·별도 ArgoCD Application(수동 sync)로 on/off (ADR-0066)
+- 핫 쿼리 인덱스 추가 + outbox claim 배치 업데이트 — `ledger_entries(wallet_id, occurred_at)`·`transaction_history(wallet_id, occurred_at)`·`operation_outbox_events(status, occurred_at, outbox_event_id)` 인덱스를 V19 마이그레이션과 통합 스키마에 추가하고, relay claim의 행 단위 UPDATE 루프를 `where outbox_event_id in (...)` 단일 배치로 교체(의미·SKIP LOCKED 선행 claim·트랜잭션 경계 보존, PUBLISHED pruning은 후속) (ADR-0071, #148)
 
 ## MVP 출시 판단 기준
 

--- a/issue-drafts/0082-hot-query-indexes-and-batched-outbox-claim.md
+++ b/issue-drafts/0082-hot-query-indexes-and-batched-outbox-claim.md
@@ -1,0 +1,29 @@
+# 핫 쿼리 인덱스 추가 + outbox claim 배치 업데이트
+
+GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/148
+
+## 증상
+
+- `ledger_entries`·`transaction_history`는 `wallet_id` 기준 시간순 조회가 핫 경로인데 인덱스가 없어 데이터가 커지면 전체 스캔이 발생한다.
+- `operation_outbox_events` relay claim은 `status` 필터 + `occurred_at, outbox_event_id` 정렬인데 인덱스가 없어 이벤트가 쌓이면 정렬/스캔 비용이 커진다.
+- `JdbcOutboxRelayRepository.claimReadyOutboxEvents`가 claim 대상 id마다 `update ... where outbox_event_id = ?`를 행 단위로 반복해 배치 크기만큼 round-trip이 발생한다.
+
+## 결정
+
+- `ledger_entries(wallet_id, occurred_at)`, `transaction_history(wallet_id, occurred_at)`, `operation_outbox_events(status, occurred_at, outbox_event_id)` 인덱스를 `V19` 마이그레이션과 통합 스키마에 추가한다.
+- claim UPDATE 루프를 `where outbox_event_id in (...)` 단일 배치로 교체하되 세팅 값·`for update skip locked` 선행 claim·트랜잭션 경계를 유지한다.
+- `PUBLISHED` 행 pruning은 이번 범위에서 제외하고 후속 과제로 둔다.
+
+## 검증
+
+```bash
+./gradlew compileTestJava
+./gradlew test --tests '*JdbcWalletRepositoryTest'
+AI_REPO_DEV_RULES_BASE=origin/main bash scripts/check-dev-rules.sh
+```
+
+## 관련 문서
+
+- `docs/adr/0071-hot-query-indexes-and-batched-outbox-claim.md`
+- `docs/progress/0082-hot-query-indexes-and-batched-outbox-claim.md`
+- `docs/releases/unreleased.md`

--- a/issue-drafts/README.md
+++ b/issue-drafts/README.md
@@ -137,6 +137,8 @@
 - `0076-jdbc-persistence-adapter-decomposition.md`: JdbcWalletRepository bounded-context 분해와 ArchUnit 레이어 규칙 작업 초안
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/125
 - `0077-elk-logging-stack.md`: ELK 2단계 로깅 스택(Filebeat→Logstash grok→ES→Kibana) 학습용 opt-in 작업 초안
+- `0082-hot-query-indexes-and-batched-outbox-claim.md`: 핫 쿼리 인덱스 추가와 outbox claim 배치 UPDATE 전환 작업 초안
+  - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/148
 
 ## GitHub CLI로 생성
 

--- a/src/main/java/com/imwoo/airepo/wallet/infra/JdbcOutboxRelayRepository.java
+++ b/src/main/java/com/imwoo/airepo/wallet/infra/JdbcOutboxRelayRepository.java
@@ -120,20 +120,22 @@ final class JdbcOutboxRelayRepository implements OperationOutboxRelayRepository,
             if (outboxEventIds.isEmpty()) {
                 return List.of();
             }
-            for (String outboxEventId : outboxEventIds) {
-                jdbcTemplate.update(
-                        """
-                                update operation_outbox_events
-                                set status = ?, next_retry_at = null, claimed_at = ?,
-                                    lease_expires_at = ?, published_at = null, last_error = null
-                                where outbox_event_id = ?
-                                """,
-                        OperationOutboxStatus.PROCESSING.name(),
-                        support.timestamp(now),
-                        support.timestamp(leaseExpiresAt),
-                        outboxEventId
-                );
+            Object[] claimArgs = new Object[outboxEventIds.size() + 3];
+            claimArgs[0] = OperationOutboxStatus.PROCESSING.name();
+            claimArgs[1] = support.timestamp(now);
+            claimArgs[2] = support.timestamp(leaseExpiresAt);
+            for (int i = 0; i < outboxEventIds.size(); i++) {
+                claimArgs[i + 3] = outboxEventIds.get(i);
             }
+            jdbcTemplate.update(
+                    """
+                            update operation_outbox_events
+                            set status = ?, next_retry_at = null, claimed_at = ?,
+                                lease_expires_at = ?, published_at = null, last_error = null
+                            where outbox_event_id in (%s)
+                            """.formatted(support.placeholders(outboxEventIds.size())),
+                    claimArgs
+            );
             return jdbcTemplate.query(
                     """
                             select outbox_event_id, operation_id, event_type, aggregate_type,

--- a/src/main/resources/db/migration/V19__add_hot_query_indexes.sql
+++ b/src/main/resources/db/migration/V19__add_hot_query_indexes.sql
@@ -1,0 +1,10 @@
+-- 지갑 원장·거래 내역 조회와 outbox claim 스캔의 핫 경로를 인덱스로 커버한다.
+CREATE INDEX IF NOT EXISTS idx_ledger_entries_wallet_id_occurred_at
+    ON ledger_entries (wallet_id, occurred_at);
+
+CREATE INDEX IF NOT EXISTS idx_transaction_history_wallet_id_occurred_at
+    ON transaction_history (wallet_id, occurred_at);
+
+-- claim 쿼리는 status로 필터하고 occurred_at, outbox_event_id 순으로 정렬한다.
+CREATE INDEX IF NOT EXISTS idx_operation_outbox_events_status_occurred_at
+    ON operation_outbox_events (status, occurred_at, outbox_event_id);

--- a/src/main/resources/db/postgresql/schema.sql
+++ b/src/main/resources/db/postgresql/schema.sql
@@ -192,6 +192,15 @@ CREATE TABLE IF NOT EXISTS operational_alerts (
 CREATE INDEX IF NOT EXISTS idx_operational_alerts_occurred_at_id
     ON operational_alerts (occurred_at DESC, alert_id DESC);
 
+CREATE INDEX IF NOT EXISTS idx_ledger_entries_wallet_id_occurred_at
+    ON ledger_entries (wallet_id, occurred_at);
+
+CREATE INDEX IF NOT EXISTS idx_transaction_history_wallet_id_occurred_at
+    ON transaction_history (wallet_id, occurred_at);
+
+CREATE INDEX IF NOT EXISTS idx_operation_outbox_events_status_occurred_at
+    ON operation_outbox_events (status, occurred_at, outbox_event_id);
+
 CREATE SEQUENCE IF NOT EXISTS transaction_id_seq START WITH 3;
 CREATE SEQUENCE IF NOT EXISTS operation_id_seq START WITH 1;
 CREATE SEQUENCE IF NOT EXISTS ledger_entry_id_seq START WITH 1;

--- a/src/test/java/com/imwoo/airepo/wallet/infra/JdbcWalletRepositoryTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/infra/JdbcWalletRepositoryTest.java
@@ -214,6 +214,30 @@ class JdbcWalletRepositoryTest {
     }
 
     @Test
+    void outboxBatchClaimMovesAllReadyEventsToProcessing() {
+        commandService.charge("member-001", "wallet-001", new WalletChargeCommand(money("5000"), "charge-db-001", "DB 충전"));
+        commandService.transfer("member-001", "wallet-001", new WalletTransferCommand("wallet-002", money("1000"), "transfer-db-001", "DB 송금"));
+
+        assertThat(repository.findPendingOutboxEvents(10)).hasSize(2);
+
+        assertThat(repository.claimReadyOutboxEvents(
+                10,
+                Instant.parse("2026-05-01T00:01:00Z"),
+                Instant.parse("2026-05-01T00:02:00Z")
+        ))
+                .hasSize(2)
+                .allSatisfy(outboxEvent -> {
+                    assertThat(outboxEvent.status()).isEqualTo(OperationOutboxStatus.PROCESSING);
+                    assertThat(outboxEvent.nextRetryAt()).isNull();
+                    assertThat(outboxEvent.claimedAt()).isEqualTo(Instant.parse("2026-05-01T00:01:00Z"));
+                    assertThat(outboxEvent.leaseExpiresAt()).isEqualTo(Instant.parse("2026-05-01T00:02:00Z"));
+                    assertThat(outboxEvent.lastError()).isNull();
+                    assertThat(outboxEvent.publishedAt()).isNull();
+                });
+        assertThat(repository.findPendingOutboxEvents(10)).isEmpty();
+    }
+
+    @Test
     void outboxClaimWaitsUntilFailedEventRetryTime() {
         commandService.charge("member-001", "wallet-001", new WalletChargeCommand(money("5000"), "charge-db-001", "DB 충전"));
         repository.markOutboxEventFailed(

--- a/wiki-drafts/Release-Notes.md
+++ b/wiki-drafts/Release-Notes.md
@@ -48,6 +48,7 @@
 - Broker consumer endpoint 인증 — `/internal/broker/outbox-events`에 `X-Broker-Token` shared secret(전용 Order 3 체인, 상수시간 비교, 미인증 401), publisher 동반 부착, 배포 프로파일 기본 토큰 `BrokerTokenGuard` fail-fast (ADR-0065)
 - Grafana `ai-repo Overview` 대시보드에 Loki 로그 섹션 추가 — 로그 볼륨(level별 시계열)·앱 로그 스트림·오류/경고 로그 패널로 메트릭+로그를 한 화면에서 관측
 - 배포 broker 토큰 주입 — `deploy/k8s` secret/env에 broker 토큰이 없어 `BrokerTokenGuard`가 배포 앱을 CrashLoopBackOff시키던 회귀 수정
+- 핫 쿼리 인덱스와 outbox claim 배치 업데이트 — 지갑별 원장/거래내역·outbox relay claim 스캔을 복합 인덱스(V19)로 커버하고 claim UPDATE 행 단위 루프를 단일 IN 배치로 전환 (ADR-0071, #148)
 
 ## 릴리스 후보 검증
 


### PR DESCRIPTION
## 요약

Issue #148의 핫 쿼리 인덱스 부재와 outbox claim 행 단위 루프 부채를 해소한다.

- `ledger_entries(wallet_id, occurred_at)`, `transaction_history(wallet_id, occurred_at)`, `operation_outbox_events(status, occurred_at, outbox_event_id)` 복합 인덱스를 `V19__add_hot_query_indexes.sql` 마이그레이션과 통합 스키마(`db/postgresql/schema.sql`) 양쪽에 추가.
- `JdbcOutboxRelayRepository.claimReadyOutboxEvents`의 claim 대상 행 단위 UPDATE 루프를 `where outbox_event_id in (...)` 단일 배치 UPDATE로 교체. 세팅 값(status=PROCESSING, claimed_at, lease_expires_at, next_retry_at/published_at/last_error=null), `for update skip locked` 선행 claim, 트랜잭션 경계는 그대로 유지.
- 배치 claim 회귀 테스트를 `JdbcWalletRepositoryTest`에 추가(N개 ready 이벤트를 한 번에 claim 시 전부 PROCESSING 전이 검증).
- 동반 문서: ADR-0071, progress-0082, issue-draft-0082, unreleased/wiki-drafts 갱신.

`PUBLISHED` outbox 행 pruning은 이번 범위에서 제외하고 ADR/progress "남은 일"에 후속 과제로 기록했다.

## 검증

- `./gradlew compileTestJava` 성공
- `./gradlew test --tests '*JdbcWalletRepositoryTest'` 통과
- `AI_REPO_DEV_RULES_BASE=origin/main bash scripts/check-dev-rules.sh` = PASS

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)