### PR TITLE
[Fix] 송금 멱등 조회를 잔액 검사보다 먼저 수행 (#146)

### DIFF
--- a/docs/adr/0069-transfer-idempotency-resolution-ordering.md
+++ b/docs/adr/0069-transfer-idempotency-resolution-ordering.md
@@ -1,0 +1,44 @@
+# ADR-0069: Transfer Idempotency Resolution Ordering
+
+## 상태
+
+Accepted
+
+## 배경
+
+`InMemoryWalletCommandService.transfer`는 멱등 조회(`resolveIdempotency`)보다 잔액 선검사(`sourceBalance.money().lessThan`)를 먼저 수행했다. 그래서 source 잔액을 전액 송금해 0으로 만든 뒤 같은 `idempotencyKey`로 동일 요청을 재시도하면, 이미 기록된 결과를 돌려주기 전에 `0 < 금액` 조건에 걸려 `InsufficientBalanceException`(422)로 거부됐다.
+
+`charge`는 이런 선검사가 없어 `resolveIdempotency`를 먼저 호출하고 없을 때만 `applyCharge`를 수행한다. 즉 두 경로의 검사 순서가 비대칭이었고, 멱등 재시도가 잔액 상태에 의존해 실패하는 것은 멱등 계약 위반이다.
+
+이 결함은 #104의 duplicate-key race(같은 키 동시 삽입 경합)와는 별개다. #104는 동시성 하에서 두 쓰기가 경합하는 문제이고, 여기서는 단일 스레드에서도 재현되는 순차 검사 순서(ordering) 결함이다.
+
+## 결정
+
+`transfer`에서 멱등 조회를 잔액 검사보다 먼저 수행한다.
+
+| 단계 | 결정 |
+| --- | --- |
+| wallet 해석 | source/target wallet 해석은 그대로 먼저 수행(소유권·조회 가능 검증 유지) |
+| fingerprint 계산 | `sourceWallet.walletId()`/`targetWallet.walletId()`로 잔액 검사 이전에 계산 |
+| 멱등 조회 우선 | `resolveIdempotency(idempotencyKey, fingerprint)`가 값이 있으면 즉시 반환(`created()==false`) |
+| 잔액 검사 후치 | 기록이 없을 때만 `findBalance` + `lessThan` → `InsufficientBalanceException` 후 `applyTransfer` |
+| conflict 유지 | fingerprint가 잔액 검사 이전에 계산되므로, 같은 키·다른 fingerprint → `IdempotencyKeyConflictException`(409) 감지는 그대로 유지 |
+
+`charge` 로직과 시그니처는 건드리지 않는다.
+
+## 트레이드오프
+
+### 장점
+
+- 전액 송금 후 동일 키 재시도가 잔액 상태와 무관하게 저장된 결과를 돌려줘 멱등 계약을 지킨다.
+- `charge`와 `transfer`의 검사 순서가 "멱등 조회 우선, 부작용 전 검증 후치"로 일관된다.
+- fingerprint를 잔액 검사 이전에 계산해 conflict(409) 감지를 그대로 보존한다.
+
+### 비용
+
+- 잔액이 부족한 신규(미기록) 요청은 여전히 wallet 해석과 멱등 조회를 거친 뒤 422가 나므로, 미세하게 조회 한 번을 더 지난 후 거부된다(부작용은 없음).
+
+## 대안
+
+- 잔액 검사를 유지하되 예외를 잡아 멱등 결과로 복구: 흐름이 복잡해지고 정상 부족 케이스와 재시도 케이스를 예외로 구분해야 해 취약하다.
+- `charge`처럼 잔액 선검사를 제거: transfer는 부작용 전 잔액 보장이 필요하므로 검사 자체는 유지하고 순서만 바꾸는 것이 옳다.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -82,3 +82,4 @@ ADR은 이 저장소에서 중요한 결정의 source of truth입니다. README�
 | ADR-0064 | JDBC Persistence Adapter Decomposition | Accepted |
 | ADR-0065 | Broker Consumer Endpoint Authentication | Accepted |
 | ADR-0066 | 학습용 opt-in ELK 로깅 스택 | Accepted |
+| ADR-0069 | Transfer Idempotency Resolution Ordering | Accepted |

--- a/docs/progress/0080-transfer-idempotency-resolution-ordering.md
+++ b/docs/progress/0080-transfer-idempotency-resolution-ordering.md
@@ -1,0 +1,30 @@
+# 0080. Transfer Idempotency Resolution Ordering
+
+## 스펙 목표
+
+- Issue #146의 송금 멱등 재시도가 잔액 부족(422)으로 거부되는 결함을 고친다.
+- `transfer`의 멱등 조회를 잔액 검사보다 먼저 수행하도록 검사 순서를 바로잡는다.
+- `charge`와의 검사 순서 비대칭을 제거하되 `charge` 로직/시그니처는 건드리지 않는다.
+
+## 완료 결과
+
+- `InMemoryWalletCommandService.transfer`에서 fingerprint를 잔액 검사 이전에 계산하고, `resolveIdempotency`를 먼저 호출해 기록이 있으면 즉시 반환하도록 순서를 변경했다.
+- 기록이 없을 때만 `findBalance` + `lessThan` 잔액 검사 후 `applyTransfer`를 수행한다.
+- fingerprint를 잔액 검사 이전에 계산하므로 같은 키·다른 fingerprint conflict(409) 감지는 그대로 유지된다.
+- 회귀 테스트를 추가했다: source 전액을 송금해 잔액을 0으로 만든 뒤 동일 `idempotencyKey`로 재시도하면 저장된 결과(`created()==false`)를 돌려주고 `InsufficientBalanceException`을 던지지 않는다.
+- ADR-0069로 검사 순서 결정을 기록하고, #104(duplicate-key race)와 별개의 순서 결함임을 명시했다.
+
+## 검증
+
+- `./gradlew compileTestJava`
+- `./gradlew test --tests '*InMemoryWalletCommandServiceTest'`
+- `AI_REPO_DEV_RULES_BASE=origin/main bash scripts/check-dev-rules.sh`
+
+## 남은 일
+
+- 없음. JDBC 경로는 멱등 저장 시점의 unique 제약으로 동일 보장을 하며 별도 순서 검사가 없다.
+
+## 관련 문서
+
+- `docs/adr/0069-transfer-idempotency-resolution-ordering.md`
+- `docs/releases/unreleased.md`

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -93,6 +93,7 @@ ADR은 “왜 그렇게 결정했는가”를 기록하고, 이 폴더는 “각
 | 0075 | [Admin Path Drift Guard](0075-admin-path-drift-guard.md) | 완료 |
 | 0076 | [JDBC Persistence Adapter Decomposition](0076-jdbc-persistence-adapter-decomposition.md) | 완료 |
 | 0077 | [ELK 2단계 로깅 스택 (학습용 opt-in)](0077-elk-logging-stack.md) | 완료 |
+| 0080 | [Transfer Idempotency Resolution Ordering](0080-transfer-idempotency-resolution-ordering.md) | 완료 |
 
 ## 현재 기준선
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -44,6 +44,7 @@
 - JDBC persistence adapter 분해 — `JdbcWalletRepository`를 PostgreSQL profile composite bean으로 유지하면서 wallet/ledger, outbox relay, outbox consumer, operational alert, admin audit SQL을 context별 package-private adapter로 분리하고 ArchUnit 레이어 규칙을 추가
 - `POST /internal/broker/outbox-events` shared secret 헤더(`X-Broker-Token`) 인증 — 전용 SecurityFilterChain(Order 3) + 상수시간 토큰 비교로 미인증 event 주입 차단, publisher가 같은 secret 부착(#123)
 - opt-in ELK 로깅 스택 — 학습용 Filebeat→Logstash(grok)→Elasticsearch(역색인)→Kibana를 `logging` 네임스페이스에 PLG(Loki)와 병존시키되 ArgoCD 미포함·`scripts/elk-local-up.sh`/`down.sh` 수동 기동, 로컬 학습 전제(security off·단일노드·ephemeral), Spring 로그 grok 파싱과 `spring-logs-*` KQL 검색. `AI_REPO_ELK_ENABLED` 토글·독립 스크립트·별도 ArgoCD Application(수동 sync)로 on/off (ADR-0066)
+- 송금 멱등 조회를 잔액 검사보다 먼저 수행 — 전액 송금으로 잔액이 0이 된 뒤 동일 `idempotencyKey` 재시도가 `InsufficientBalanceException`(422)으로 거부되던 회귀 수정. `transfer`에서 fingerprint 계산 후 멱등 조회를 먼저 하고 없을 때만 잔액 검사·`applyTransfer`, conflict(409) 감지는 유지, `charge`와 순서 일관화 (#146, ADR-0069)
 
 ## MVP 출시 판단 기준
 

--- a/issue-drafts/0080-transfer-idempotency-order.md
+++ b/issue-drafts/0080-transfer-idempotency-order.md
@@ -1,0 +1,23 @@
+# 송금 멱등 재시도가 잔액 부족(422)으로 거부됨
+
+## 증상
+
+전액 송금으로 source 잔액이 0이 된 뒤 같은 `idempotencyKey`로 동일 송금을 재시도하면, 저장된 결과를 돌려주지 않고 `InsufficientBalanceException`(422)으로 거부된다. 멱등 재시도가 잔액 상태에 의존해 실패하므로 멱등 계약 위반이다.
+
+근본 원인은 `InMemoryWalletCommandService.transfer`가 잔액 선검사(`sourceBalance.money().lessThan`)를 멱등 조회(`resolveIdempotency`)보다 먼저 수행하는 것이다. `charge`는 이런 선검사가 없어 멱등 조회를 먼저 하므로 두 경로의 순서가 비대칭이었다. 이는 #104(duplicate-key race)와는 별개의 순차 검사 순서 결함이다.
+
+## 결정
+
+- `transfer`에서 source/target wallet 해석 후 fingerprint를 계산하고, `resolveIdempotency`를 먼저 호출해 기록이 있으면 즉시 반환한다.
+- 기록이 없을 때만 `findBalance` + `lessThan` 잔액 검사 후 `applyTransfer`를 수행한다.
+- fingerprint를 잔액 검사 이전에 계산하므로 같은 키·다른 fingerprint conflict(409) 감지는 유지된다.
+- `charge` 로직/시그니처는 건드리지 않는다.
+
+## 검증
+
+- [x] 회귀 테스트: 전액 송금 후 동일 키 재시도 → 저장된 결과(`created()==false`) 반환, 예외 없음
+- [x] 기존 conflict/정상/잔액 부족 테스트 유지
+- `./gradlew compileTestJava`
+- `./gradlew test --tests '*InMemoryWalletCommandServiceTest'`
+
+관련: ADR-0069, progress 0080.

--- a/issue-drafts/README.md
+++ b/issue-drafts/README.md
@@ -137,6 +137,8 @@
 - `0076-jdbc-persistence-adapter-decomposition.md`: JdbcWalletRepository bounded-context 분해와 ArchUnit 레이어 규칙 작업 초안
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/125
 - `0077-elk-logging-stack.md`: ELK 2단계 로깅 스택(Filebeat→Logstash grok→ES→Kibana) 학습용 opt-in 작업 초안
+- `0080-transfer-idempotency-order.md`: 송금 멱등 조회를 잔액 검사보다 먼저 수행하는 검사 순서 결함 수정 초안
+  - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/146
 
 ## GitHub CLI로 생성
 

--- a/src/main/java/com/imwoo/airepo/wallet/application/InMemoryWalletCommandService.java
+++ b/src/main/java/com/imwoo/airepo/wallet/application/InMemoryWalletCommandService.java
@@ -55,26 +55,31 @@ public class InMemoryWalletCommandService implements WalletCommandService {
 
         WalletAccount sourceWallet = findOperableWallet(memberId, sourceWalletId);
         WalletAccount targetWallet = WalletAccessPolicy.findQueryableWallet(walletCommandRepository, command.targetWalletId());
+
+        String fingerprint = transferFingerprint(sourceWallet.walletId(), targetWallet.walletId(), command);
+        Optional<WalletCommandResult> recorded = resolveIdempotency(command.idempotencyKey(), fingerprint);
+        if (recorded.isPresent()) {
+            return recorded.get();
+        }
+
         WalletBalance sourceBalance = walletCommandRepository.findBalance(sourceWallet.walletId())
                 .orElseThrow(() -> new WalletNotFoundException(sourceWallet.walletId()));
         if (sourceBalance.money().lessThan(command.money())) {
             throw new InsufficientBalanceException(sourceWallet.walletId());
         }
 
-        String fingerprint = transferFingerprint(sourceWallet.walletId(), targetWallet.walletId(), command);
-        return resolveIdempotency(command.idempotencyKey(), fingerprint)
-                .orElseGet(() -> new WalletCommandResult(
-                        walletCommandRepository.applyTransfer(
-                                command.idempotencyKey(),
-                                fingerprint,
-                                sourceWallet.walletId(),
-                                targetWallet.walletId(),
-                                command.money(),
-                                command.description(),
-                                Instant.now(clock)
-                        ).result(),
-                        true
-                ));
+        return new WalletCommandResult(
+                walletCommandRepository.applyTransfer(
+                        command.idempotencyKey(),
+                        fingerprint,
+                        sourceWallet.walletId(),
+                        targetWallet.walletId(),
+                        command.money(),
+                        command.description(),
+                        Instant.now(clock)
+                ).result(),
+                true
+        );
     }
 
     private Optional<WalletCommandResult> resolveIdempotency(String idempotencyKey, String fingerprint) {

--- a/src/test/java/com/imwoo/airepo/wallet/application/InMemoryWalletCommandServiceTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/application/InMemoryWalletCommandServiceTest.java
@@ -85,6 +85,22 @@ class InMemoryWalletCommandServiceTest {
     }
 
     @Test
+    void sameTransferIdempotencyKeyReturnsExistingResultEvenWhenBalanceDrainedToZero() {
+        WalletTransferCommand command =
+                new WalletTransferCommand("wallet-002", money("125000"), "transfer-001", "테스트 송금");
+
+        WalletCommandResult first = service.transfer("member-001", "wallet-001", command);
+        assertThat(first.created()).isTrue();
+        assertThat(repository.findBalance("wallet-001").orElseThrow().money()).isEqualTo(money("0"));
+
+        WalletCommandResult second = service.transfer("member-001", "wallet-001", command);
+
+        assertThat(second.created()).isFalse();
+        assertThat(second.operation().transactionId()).isEqualTo(first.operation().transactionId());
+        assertThat(repository.findBalance("wallet-001").orElseThrow().money()).isEqualTo(money("0"));
+    }
+
+    @Test
     void transferRejectsInsufficientBalance() {
         assertThatThrownBy(() -> service.transfer(
                 "member-002",

--- a/wiki-drafts/Release-Notes.md
+++ b/wiki-drafts/Release-Notes.md
@@ -48,6 +48,7 @@
 - Broker consumer endpoint 인증 — `/internal/broker/outbox-events`에 `X-Broker-Token` shared secret(전용 Order 3 체인, 상수시간 비교, 미인증 401), publisher 동반 부착, 배포 프로파일 기본 토큰 `BrokerTokenGuard` fail-fast (ADR-0065)
 - Grafana `ai-repo Overview` 대시보드에 Loki 로그 섹션 추가 — 로그 볼륨(level별 시계열)·앱 로그 스트림·오류/경고 로그 패널로 메트릭+로그를 한 화면에서 관측
 - 배포 broker 토큰 주입 — `deploy/k8s` secret/env에 broker 토큰이 없어 `BrokerTokenGuard`가 배포 앱을 CrashLoopBackOff시키던 회귀 수정
+- 송금 멱등 조회 순서 수정 — `transfer`가 멱등 조회를 잔액 검사보다 먼저 수행하도록 변경, 전액 송금 후 동일 키 재시도가 잔액 부족(422)으로 거부되던 회귀 수정, conflict(409) 감지 유지 (ADR-0069, #146)
 
 ## 릴리스 후보 검증
 


### PR DESCRIPTION
## 요약

전액 송금으로 source 잔액이 0이 된 뒤 같은 `idempotencyKey`로 동일 송금을 재시도하면 저장된 결과를 돌려주지 않고 `InsufficientBalanceException`(422)으로 거부되던 결함을 수정한다.

근본 원인은 `InMemoryWalletCommandService.transfer`가 잔액 선검사(`sourceBalance.money().lessThan`)를 멱등 조회(`resolveIdempotency`)보다 먼저 수행하는 것이다. `charge`에는 이런 선검사가 없어 두 경로의 순서가 비대칭이었다. 이는 #104(duplicate-key race)와는 별개의 순차 검사 순서 결함이다.

## 변경

- `transfer`에서 source/target wallet 해석 후 fingerprint를 계산하고 `resolveIdempotency`를 먼저 호출해 기록이 있으면 즉시 반환.
- 기록이 없을 때만 `findBalance` + `lessThan` 잔액 검사 후 `applyTransfer`.
- fingerprint를 잔액 검사 이전에 계산하므로 conflict(409) 감지는 유지. `charge` 로직/시그니처는 미변경.
- 회귀 테스트 추가: 전액 송금 후 동일 키 재시도 → 저장된 결과(`created()==false`) 반환, 예외 없음.
- 동반 문서: ADR-0069, progress 0080, issue-draft 0080, unreleased, wiki-drafts.

## 검증

- `./gradlew compileTestJava` 성공
- `./gradlew test --tests '*InMemoryWalletCommandServiceTest'` 통과
- `AI_REPO_DEV_RULES_BASE=origin/main bash scripts/check-dev-rules.sh` → PASS

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)