### PR TITLE
[Fix] 멱등키를 지갑 스코프로 한정해 회원 간 충돌 차단 (#149)

### DIFF
--- a/docs/adr/0072-wallet-scoped-idempotency-keys.md
+++ b/docs/adr/0072-wallet-scoped-idempotency-keys.md
@@ -1,0 +1,48 @@
+# ADR-0072: Wallet-Scoped Idempotency Keys
+
+## 상태
+
+Accepted
+
+## 배경
+
+`wallet_operations` 테이블의 PK는 `idempotency_key` 단일 컬럼이었다. 즉 멱등키가 전역(global) 네임스페이스였다. 클라이언트가 지갑별로 멱등키를 발급하는데, 서로 다른 회원/지갑이 우연히(또는 의도적으로) 같은 문자열을 멱등키로 쓰면 전역 유니크 제약과 `findOperation` 조회가 지갑을 넘나들며 서로 간섭했다.
+
+구체적 영향:
+
+- 회원 A가 이미 쓴 멱등키를 회원 B가 같은 값으로 충전/송금하면, B의 `findOperation(key)`가 A의 레코드를 찾아 fingerprint 불일치로 `IdempotencyKeyConflictException`(409)이 났다. 즉 한 회원이 상대 회원의 요청을 예측 가능한 멱등키 문자열만으로 막을 수 있는 cross-tenant 간섭(409 DoS 가능성)이 존재했다.
+- 반대로 fingerprint까지 우연히 같으면 B가 A의 과거 operation 결과를 그대로 되돌려받을 수 있어, 멱등 재생(replay)이 지갑 경계를 넘었다.
+
+멱등키는 본질적으로 "이 지갑에 대한 이 명령"을 식별하는 스코프이므로, 네임스페이스를 지갑 단위로 한정하는 것이 자연스럽다.
+
+## 결정
+
+멱등키의 유일성 범위를 전역에서 지갑 스코프로 한정한다.
+
+| 항목 | 결정 |
+| --- | --- |
+| PK 변경 | `wallet_operations` PK를 `(idempotency_key)` → `(wallet_id, idempotency_key)` 복합 PK로 전환 (`V20`) |
+| 마이그레이션 | `ALTER TABLE ... DROP CONSTRAINT IF EXISTS wallet_operations_pkey` 후 복합 PK 추가. `wallet_id`는 NOT NULL이고 기존 키가 전역 유니크였으므로 복합 PK도 유니크가 보장돼 기존 데이터에 안전 |
+| 조회 시그니처 | `WalletCommandRepository.findOperation(String walletId, String idempotencyKey)`로 변경, JDBC 조회에 `and wallet_id = ?` 추가 |
+| InMemory 어댑터 | operation 저장/조회 키를 `walletId + idempotencyKey` 복합으로 전환 |
+| 서비스 스코프 | `resolveIdempotency`에 지갑을 전달. charge는 `walletAccount.walletId()`, transfer는 `sourceWallet.walletId()`(출금 지갑)를 스코프로 사용 |
+
+멱등 스코프의 기준 지갑은 명령이 소유권을 강제하는 지갑, 즉 charge의 대상 지갑과 transfer의 출금(source) 지갑이다. 이는 ADR-0056의 소유권 강제 지갑과 동일한 축이다.
+
+## 트레이드오프
+
+### 장점
+
+- 서로 다른 지갑이 같은 멱등키 문자열을 써도 충돌하지 않아 cross-tenant 409 간섭(DoS 가능성)이 닫힌다.
+- 멱등 재생(replay)이 지갑 경계 안으로 한정돼 다른 지갑의 operation 결과가 새지 않는다.
+- 복합 PK가 여전히 유니크하므로 지갑 내부의 멱등 보장(같은 키 → 같은 결과, 다른 fingerprint → 409)은 그대로 유지된다.
+
+### 비용
+
+- `findOperation` 시그니처가 바뀌어 콜사이트(서비스·JDBC·InMemory·테스트)를 모두 갱신해야 한다.
+- 조회 파라미터가 하나 늘어난다(운영 부담은 사실상 없음, PK 인덱스 그대로 사용).
+
+## 대안 / 맥락
+
+- **전역 유니크 유지 + fingerprint에 walletId 포함**: 재생 격리는 되지만 전역 네임스페이스가 그대로라 다른 지갑이 같은 키를 쓰면 여전히 PK 충돌(409)이 난다. cross-tenant 간섭을 닫지 못해 채택하지 않음.
+- **지갑 존재 오라클(404 vs 403) 열거 축소는 이번 범위 밖**: 이슈 #149에는 "없는 지갑(404)"과 "남의 지갑(403)"을 구별 가능한 존재 열거 문제도 언급됐으나, 이 트레이드오프는 ADR-0056이 명시적으로 "수용"한 결정이다(비소유자에 403, 404 collapse 안 함). `WalletAccessPolicy`는 변경하지 않고 그 결정을 의도적으로 유지한다. 본 ADR은 멱등키 스코핑만 다룬다.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -82,3 +82,4 @@ ADR은 이 저장소에서 중요한 결정의 source of truth입니다. README�
 | ADR-0064 | JDBC Persistence Adapter Decomposition | Accepted |
 | ADR-0065 | Broker Consumer Endpoint Authentication | Accepted |
 | ADR-0066 | 학습용 opt-in ELK 로깅 스택 | Accepted |
+| ADR-0072 | Wallet-Scoped Idempotency Keys | Accepted |

--- a/docs/progress/0083-wallet-scoped-idempotency-keys.md
+++ b/docs/progress/0083-wallet-scoped-idempotency-keys.md
@@ -1,0 +1,30 @@
+# 0083. Wallet-Scoped Idempotency Keys
+
+## 스펙 목표
+
+- Issue #149의 멱등키 전역 네임스페이스로 인한 회원 간 간섭(409 DoS 가능성)을 닫는다.
+- `wallet_operations` 멱등키를 지갑 스코프로 한정하고 회귀 테스트로 고정한다.
+
+## 완료 결과
+
+- `wallet_operations` PK를 `(idempotency_key)` → `(wallet_id, idempotency_key)` 복합 PK로 전환했다(`V20` 마이그레이션 + `schema.sql` 반영).
+- `WalletCommandRepository.findOperation`을 `(walletId, idempotencyKey)` 시그니처로 바꾸고 JDBC 조회에 `and wallet_id = ?`를 추가했다.
+- `InMemoryWalletRepository`의 operation 저장/조회를 `walletId + idempotencyKey` 복합 키로 전환했다.
+- `InMemoryWalletCommandService.resolveIdempotency`가 지갑을 전달하도록 하고, charge는 대상 지갑, transfer는 출금(source) 지갑을 스코프로 넘긴다.
+- 멱등키 스코핑 결정을 ADR-0072로 기록하고, 지갑 존재 오라클(404/403) 트레이드오프는 ADR-0056 근거로 의도적으로 유지함을 명시했다.
+
+## 검증
+
+- `./gradlew compileTestJava`
+- `./gradlew test --tests '*InMemoryWalletCommandServiceTest' --tests '*JdbcWalletRepositoryTest'`
+- `AI_REPO_DEV_RULES_BASE=origin/main bash scripts/check-dev-rules.sh`
+
+## 남은 일
+
+- 지갑 존재 오라클(404 vs 403) 열거 축소는 ADR-0056이 수용한 트레이드오프로, 별도 결정 없이는 다루지 않는다.
+
+## 관련 문서
+
+- `docs/adr/0072-wallet-scoped-idempotency-keys.md`
+- `docs/adr/0056-enduser-jwt-auth-wallet-ownership.md`
+- `docs/releases/unreleased.md`

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -93,6 +93,7 @@ ADR은 “왜 그렇게 결정했는가”를 기록하고, 이 폴더는 “각
 | 0075 | [Admin Path Drift Guard](0075-admin-path-drift-guard.md) | 완료 |
 | 0076 | [JDBC Persistence Adapter Decomposition](0076-jdbc-persistence-adapter-decomposition.md) | 완료 |
 | 0077 | [ELK 2단계 로깅 스택 (학습용 opt-in)](0077-elk-logging-stack.md) | 완료 |
+| 0083 | [Wallet-Scoped Idempotency Keys](0083-wallet-scoped-idempotency-keys.md) | 완료 |
 
 ## 현재 기준선
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -44,6 +44,7 @@
 - JDBC persistence adapter 분해 — `JdbcWalletRepository`를 PostgreSQL profile composite bean으로 유지하면서 wallet/ledger, outbox relay, outbox consumer, operational alert, admin audit SQL을 context별 package-private adapter로 분리하고 ArchUnit 레이어 규칙을 추가
 - `POST /internal/broker/outbox-events` shared secret 헤더(`X-Broker-Token`) 인증 — 전용 SecurityFilterChain(Order 3) + 상수시간 토큰 비교로 미인증 event 주입 차단, publisher가 같은 secret 부착(#123)
 - opt-in ELK 로깅 스택 — 학습용 Filebeat→Logstash(grok)→Elasticsearch(역색인)→Kibana를 `logging` 네임스페이스에 PLG(Loki)와 병존시키되 ArgoCD 미포함·`scripts/elk-local-up.sh`/`down.sh` 수동 기동, 로컬 학습 전제(security off·단일노드·ephemeral), Spring 로그 grok 파싱과 `spring-logs-*` KQL 검색. `AI_REPO_ELK_ENABLED` 토글·독립 스크립트·별도 ArgoCD Application(수동 sync)로 on/off (ADR-0066)
+- 멱등키를 지갑 스코프로 한정 — `wallet_operations` PK를 `(idempotency_key)`에서 `(wallet_id, idempotency_key)` 복합 PK로 전환(V20)하고 `findOperation(walletId, idempotencyKey)`로 조회를 지갑 스코프화해 회원 간 멱등키 충돌(409 DoS 가능성)과 cross-tenant operation 재생을 차단 (ADR-0072, #149)
 
 ## MVP 출시 판단 기준
 

--- a/issue-drafts/0083-wallet-scoped-idempotency-keys.md
+++ b/issue-drafts/0083-wallet-scoped-idempotency-keys.md
@@ -1,0 +1,19 @@
+# [Fix] 멱등키를 지갑 스코프로 한정해 회원 간 충돌 차단
+
+## 증상
+
+`wallet_operations` PK가 `idempotency_key` 단일 컬럼(전역 유니크)이라 멱등키가 전역 네임스페이스였다. 서로 다른 회원/지갑이 같은 멱등키 문자열을 쓰면 `findOperation`이 지갑을 넘어 상대 레코드를 찾아 fingerprint 불일치로 409(`IdempotencyKeyConflictException`)를 냈다. 한 회원이 예측 가능한 멱등키만으로 상대 요청을 막을 수 있는 cross-tenant 간섭(409 DoS 가능성)이 있었고, fingerprint까지 같으면 다른 지갑의 operation 결과가 재생됐다.
+
+## 결정
+
+멱등키 유일성 범위를 지갑 스코프로 한정한다.
+
+- `wallet_operations` PK를 `(wallet_id, idempotency_key)` 복합 PK로 전환(`V20`).
+- `findOperation(walletId, idempotencyKey)`로 조회 시그니처 변경, JDBC에 `and wallet_id = ?` 추가.
+- InMemory 어댑터는 복합 키 저장/조회, 서비스는 charge=대상 지갑, transfer=출금 지갑을 스코프로 전달.
+- 지갑 존재 오라클(404/403)은 ADR-0056이 수용한 트레이드오프로 이번 범위에서 변경하지 않음(`WalletAccessPolicy` 불변).
+
+## 검증
+
+- `./gradlew test --tests '*InMemoryWalletCommandServiceTest' --tests '*JdbcWalletRepositoryTest'`
+- 서로 다른 두 지갑이 같은 멱등키를 써도 충돌하지 않음, 같은 지갑+같은 키+다른 fingerprint는 여전히 409.

--- a/issue-drafts/README.md
+++ b/issue-drafts/README.md
@@ -137,6 +137,8 @@
 - `0076-jdbc-persistence-adapter-decomposition.md`: JdbcWalletRepository bounded-context 분해와 ArchUnit 레이어 규칙 작업 초안
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/125
 - `0077-elk-logging-stack.md`: ELK 2단계 로깅 스택(Filebeat→Logstash grok→ES→Kibana) 학습용 opt-in 작업 초안
+- `0083-wallet-scoped-idempotency-keys.md`: 멱등키를 지갑 스코프로 한정해 회원 간 409 간섭 차단 작업 초안
+  - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/149
 
 ## GitHub CLI로 생성
 

--- a/src/main/java/com/imwoo/airepo/wallet/application/InMemoryWalletCommandService.java
+++ b/src/main/java/com/imwoo/airepo/wallet/application/InMemoryWalletCommandService.java
@@ -29,7 +29,7 @@ public class InMemoryWalletCommandService implements WalletCommandService {
 
         WalletAccount walletAccount = findOperableWallet(memberId, walletId);
         String fingerprint = chargeFingerprint(walletAccount.walletId(), command);
-        return resolveIdempotency(command.idempotencyKey(), fingerprint)
+        return resolveIdempotency(walletAccount.walletId(), command.idempotencyKey(), fingerprint)
                 .orElseGet(() -> new WalletCommandResult(
                         walletCommandRepository.applyCharge(
                                 command.idempotencyKey(),
@@ -62,7 +62,7 @@ public class InMemoryWalletCommandService implements WalletCommandService {
         }
 
         String fingerprint = transferFingerprint(sourceWallet.walletId(), targetWallet.walletId(), command);
-        return resolveIdempotency(command.idempotencyKey(), fingerprint)
+        return resolveIdempotency(sourceWallet.walletId(), command.idempotencyKey(), fingerprint)
                 .orElseGet(() -> new WalletCommandResult(
                         walletCommandRepository.applyTransfer(
                                 command.idempotencyKey(),
@@ -77,8 +77,8 @@ public class InMemoryWalletCommandService implements WalletCommandService {
                 ));
     }
 
-    private Optional<WalletCommandResult> resolveIdempotency(String idempotencyKey, String fingerprint) {
-        return walletCommandRepository.findOperation(idempotencyKey)
+    private Optional<WalletCommandResult> resolveIdempotency(String walletId, String idempotencyKey, String fingerprint) {
+        return walletCommandRepository.findOperation(walletId, idempotencyKey)
                 .map(record -> {
                     if (!record.fingerprint().equals(fingerprint)) {
                         throw new IdempotencyKeyConflictException(idempotencyKey);

--- a/src/main/java/com/imwoo/airepo/wallet/application/WalletCommandRepository.java
+++ b/src/main/java/com/imwoo/airepo/wallet/application/WalletCommandRepository.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 
 public interface WalletCommandRepository extends WalletQueryRepository {
 
-    Optional<WalletOperationRecord> findOperation(String idempotencyKey);
+    Optional<WalletOperationRecord> findOperation(String walletId, String idempotencyKey);
 
     WalletOperationRecord applyCharge(
             String idempotencyKey,

--- a/src/main/java/com/imwoo/airepo/wallet/infra/InMemoryWalletRepository.java
+++ b/src/main/java/com/imwoo/airepo/wallet/infra/InMemoryWalletRepository.java
@@ -793,8 +793,12 @@ public class InMemoryWalletRepository implements
     }
 
     @Override
-    public synchronized Optional<WalletOperationRecord> findOperation(String idempotencyKey) {
-        return Optional.ofNullable(operations.get(idempotencyKey));
+    public synchronized Optional<WalletOperationRecord> findOperation(String walletId, String idempotencyKey) {
+        return Optional.ofNullable(operations.get(operationKey(walletId, idempotencyKey)));
+    }
+
+    private static String operationKey(String walletId, String idempotencyKey) {
+        return walletId + " " + idempotencyKey;
     }
 
     @Override
@@ -861,7 +865,7 @@ public class InMemoryWalletRepository implements
                 description
         );
         WalletOperationRecord record = new WalletOperationRecord(idempotencyKey, fingerprint, result);
-        operations.put(idempotencyKey, record);
+        operations.put(operationKey(walletId, idempotencyKey), record);
         addStepLog(operationId, OperationStep.IDEMPOTENCY_RECORDED, occurredAt, "Idempotency record stored for operation " + operationId);
         addOutboxEvent(result);
         return record;
@@ -963,7 +967,7 @@ public class InMemoryWalletRepository implements
                 description
         );
         WalletOperationRecord record = new WalletOperationRecord(idempotencyKey, fingerprint, result);
-        operations.put(idempotencyKey, record);
+        operations.put(operationKey(sourceWalletId, idempotencyKey), record);
         addStepLog(operationId, OperationStep.IDEMPOTENCY_RECORDED, occurredAt, "Idempotency record stored for operation " + operationId);
         addOutboxEvent(result);
         return record;

--- a/src/main/java/com/imwoo/airepo/wallet/infra/JdbcWalletLedgerRepository.java
+++ b/src/main/java/com/imwoo/airepo/wallet/infra/JdbcWalletLedgerRepository.java
@@ -170,16 +170,17 @@ final class JdbcWalletLedgerRepository implements WalletCommandRepository, Walle
     }
 
     @Override
-    public Optional<WalletOperationRecord> findOperation(String idempotencyKey) {
+    public Optional<WalletOperationRecord> findOperation(String walletId, String idempotencyKey) {
         return support.queryOptional(
                 """
                         select idempotency_key, fingerprint, operation_id, transaction_id, wallet_id,
                                counterparty_wallet_id, occurred_at, type, status, direction, amount, currency,
                                balance_wallet_id, balance_amount, balance_currency, balance_as_of, description
                         from wallet_operations
-                        where idempotency_key = ?
+                        where wallet_id = ? and idempotency_key = ?
                         """,
                 support.operationRecordMapper(),
+                walletId,
                 idempotencyKey
         );
     }

--- a/src/main/java/com/imwoo/airepo/wallet/infra/JdbcWalletRepository.java
+++ b/src/main/java/com/imwoo/airepo/wallet/infra/JdbcWalletRepository.java
@@ -135,8 +135,8 @@ public class JdbcWalletRepository implements
     }
 
     @Override
-    public Optional<WalletOperationRecord> findOperation(String idempotencyKey) {
-        return walletLedger.findOperation(idempotencyKey);
+    public Optional<WalletOperationRecord> findOperation(String walletId, String idempotencyKey) {
+        return walletLedger.findOperation(walletId, idempotencyKey);
     }
 
     @Override

--- a/src/main/resources/db/migration/V20__scope_wallet_operations_idempotency.sql
+++ b/src/main/resources/db/migration/V20__scope_wallet_operations_idempotency.sql
@@ -1,0 +1,4 @@
+-- 멱등키를 전역 유니크에서 지갑 스코프로 한정한다(#149).
+-- wallet_id 는 NOT NULL 이고 기존 idempotency_key 가 유니크였으므로 복합 PK 도 유니크가 보장된다.
+ALTER TABLE wallet_operations DROP CONSTRAINT IF EXISTS wallet_operations_pkey;
+ALTER TABLE wallet_operations ADD PRIMARY KEY (wallet_id, idempotency_key);

--- a/src/main/resources/db/postgresql/schema.sql
+++ b/src/main/resources/db/postgresql/schema.sql
@@ -31,7 +31,7 @@ CREATE TABLE IF NOT EXISTS transaction_history (
 );
 
 CREATE TABLE IF NOT EXISTS wallet_operations (
-    idempotency_key VARCHAR(128) PRIMARY KEY,
+    idempotency_key VARCHAR(128) NOT NULL,
     fingerprint VARCHAR(512) NOT NULL,
     operation_id VARCHAR(64) NOT NULL,
     transaction_id VARCHAR(64) NOT NULL,
@@ -47,7 +47,8 @@ CREATE TABLE IF NOT EXISTS wallet_operations (
     balance_amount NUMERIC(19, 2) NOT NULL,
     balance_currency VARCHAR(3) NOT NULL,
     balance_as_of TIMESTAMP WITH TIME ZONE NOT NULL,
-    description VARCHAR(255) NOT NULL
+    description VARCHAR(255) NOT NULL,
+    PRIMARY KEY (wallet_id, idempotency_key)
 );
 
 CREATE TABLE IF NOT EXISTS ledger_entries (

--- a/src/test/java/com/imwoo/airepo/wallet/application/InMemoryWalletCommandServiceTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/application/InMemoryWalletCommandServiceTest.java
@@ -148,6 +148,39 @@ class InMemoryWalletCommandServiceTest {
                 .hasMessage("currency must be KRW");
     }
 
+    @Test
+    void differentWalletsMayReuseSameIdempotencyKeyWithoutConflict() {
+        WalletCommandResult first = service.charge(
+                "member-001",
+                "wallet-001",
+                new WalletChargeCommand(money("5000"), "shared-key", "테스트 충전")
+        );
+        WalletCommandResult second = service.charge(
+                "member-002",
+                "wallet-002",
+                new WalletChargeCommand(money("7000"), "shared-key", "테스트 충전")
+        );
+
+        assertThat(first.created()).isTrue();
+        assertThat(second.created()).isTrue();
+        assertThat(second.operation().operationId()).isNotEqualTo(first.operation().operationId());
+        assertThat(repository.findBalance("wallet-001").orElseThrow().money()).isEqualTo(money("130000"));
+        assertThat(repository.findBalance("wallet-002").orElseThrow().money()).isEqualTo(money("37000"));
+    }
+
+    @Test
+    void sameWalletAndKeyWithDifferentFingerprintStillConflicts() {
+        service.charge("member-001", "wallet-001", new WalletChargeCommand(money("5000"), "shared-key", "테스트 충전"));
+
+        assertThatThrownBy(() -> service.charge(
+                "member-001",
+                "wallet-001",
+                new WalletChargeCommand(money("6000"), "shared-key", "테스트 충전")
+        ))
+                .isInstanceOf(IdempotencyKeyConflictException.class)
+                .hasMessage("Idempotency key already used for different request: shared-key");
+    }
+
     private Money money(String amount) {
         return new Money(new BigDecimal(amount), "KRW");
     }

--- a/src/test/java/com/imwoo/airepo/wallet/infra/JdbcWalletRepositoryTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/infra/JdbcWalletRepositoryTest.java
@@ -9,6 +9,7 @@ import com.imwoo.airepo.wallet.application.InMemoryWalletLedgerQueryService;
 import com.imwoo.airepo.wallet.application.InvalidWalletOperationException;
 import com.imwoo.airepo.wallet.application.WalletChargeCommand;
 import com.imwoo.airepo.wallet.application.WalletCommandResult;
+import com.imwoo.airepo.wallet.application.WalletOperationRecord;
 import com.imwoo.airepo.wallet.application.WalletTransferCommand;
 import com.imwoo.airepo.wallet.domain.AdminApiAccessAudit;
 import com.imwoo.airepo.wallet.domain.AdminApiAccessOutcome;
@@ -121,7 +122,7 @@ class JdbcWalletRepositoryTest {
                     assertThat(outboxEvent.lastError()).isNull();
                     assertThat(outboxEvent.payload()).contains("\"operationId\":\"op-001\"");
                 });
-        assertThat(repository.findOperation("charge-db-001")).isPresent();
+        assertThat(repository.findOperation("wallet-001", "charge-db-001")).isPresent();
     }
 
     @Test
@@ -888,6 +889,25 @@ class JdbcWalletRepositoryTest {
                     assertThat(outboxEvent.eventType()).isEqualTo("TRANSFER_COMPLETED");
                     assertThat(outboxEvent.payload()).contains("\"counterpartyWalletId\":\"wallet-002\"");
                 });
+    }
+
+    @Test
+    void findOperationIsScopedByWalletSoDifferentWalletsMayShareIdempotencyKey() {
+        commandService.charge("member-001", "wallet-001",
+                new WalletChargeCommand(money("5000"), "shared-db-key", "DB 충전"));
+        commandService.charge("member-002", "wallet-002",
+                new WalletChargeCommand(money("7000"), "shared-db-key", "DB 충전"));
+
+        WalletOperationRecord firstWalletOperation =
+                repository.findOperation("wallet-001", "shared-db-key").orElseThrow();
+        WalletOperationRecord secondWalletOperation =
+                repository.findOperation("wallet-002", "shared-db-key").orElseThrow();
+
+        assertThat(firstWalletOperation.result().walletId()).isEqualTo("wallet-001");
+        assertThat(secondWalletOperation.result().walletId()).isEqualTo("wallet-002");
+        assertThat(secondWalletOperation.result().operationId())
+                .isNotEqualTo(firstWalletOperation.result().operationId());
+        assertThat(repository.findOperation("wallet-001", "unknown-key")).isEmpty();
     }
 
     private Money money(String amount) {

--- a/src/test/java/com/imwoo/airepo/wallet/infra/PostgresContainerWalletRepositoryTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/infra/PostgresContainerWalletRepositoryTest.java
@@ -257,8 +257,8 @@ class PostgresContainerWalletRepositoryTest {
             assertThat(ledgerQueryService.getLedgerEntries("member-002", "wallet-002")).hasSize(1);
             assertThat(ledgerQueryService.getAuditEvents()).hasSize(1);
             assertThat(
-                    repository.findOperation("postgres-concurrent-transfer-001").isPresent()
-                            ^ repository.findOperation("postgres-concurrent-transfer-002").isPresent()
+                    repository.findOperation("wallet-001", "postgres-concurrent-transfer-001").isPresent()
+                            ^ repository.findOperation("wallet-001", "postgres-concurrent-transfer-002").isPresent()
             ).isTrue();
         } finally {
             executorService.shutdownNow();
@@ -291,7 +291,7 @@ class PostgresContainerWalletRepositoryTest {
             assertThat(ledgerQueryService.getAuditEvents()).isEmpty();
             assertThat(repository.findOperationStepLogs("op-001")).isEmpty();
             assertThat(repository.findOperationOutboxEvents("op-001")).isEmpty();
-            assertThat(repository.findOperation("postgres-lock-timeout-001")).isEmpty();
+            assertThat(repository.findOperation("wallet-001", "postgres-lock-timeout-001")).isEmpty();
         } finally {
             releaseLatch.countDown();
             lockHolder.get(5, TimeUnit.SECONDS);

--- a/wiki-drafts/Release-Notes.md
+++ b/wiki-drafts/Release-Notes.md
@@ -74,6 +74,7 @@
 ## 다음 후보
 
 - opt-in ELK 로깅 스택(Filebeat→Logstash grok→Elasticsearch→Kibana) — `logging` 네임스페이스에 PLG와 병존, 기본 ArgoCD 자동배포에는 미포함(항상 켜짐 방지), 로그 파싱·역색인 검색 학습용. on/off는 독립 스크립트·`AI_REPO_ELK_ENABLED` env·별도 ArgoCD 수동 sync App(`deploy/argocd/logging-application.yaml`) 3가지 중 택1 (ADR-0066)
+- 멱등키를 지갑 스코프로 한정 — `wallet_operations`를 `(wallet_id, idempotency_key)` 복합 PK로 전환해 회원 간 멱등키 충돌(409)과 cross-tenant operation 재생 차단 (ADR-0072, #149)
 - JWT refresh token 기반 만료/갱신 정책 강화(현재는 401 시 password-less 재발급)
 - 로그인 회원의 실제 보유 지갑 조회 API(현재는 fixture 기반 파생)
 - broker-specific Testcontainers contract


### PR DESCRIPTION
## 요약

`wallet_operations`의 멱등키가 전역 유니크(PK=`idempotency_key`)라 서로 다른 회원/지갑이 같은 멱등키 문자열을 쓰면 `findOperation`이 지갑을 넘어 상대 레코드를 찾아 409(`IdempotencyKeyConflictException`) 충돌이 났고(cross-tenant 409 DoS 가능성), fingerprint까지 같으면 다른 지갑의 operation 결과가 재생됐다.

멱등키 유일성 범위를 지갑 스코프로 한정한다.

- `wallet_operations` PK를 `(idempotency_key)` → `(wallet_id, idempotency_key)` 복합 PK로 전환 (`V20` + `schema.sql`).
- `WalletCommandRepository.findOperation(walletId, idempotencyKey)`로 조회 시그니처 변경, JDBC에 `and wallet_id = ?` 추가.
- `InMemoryWalletRepository`는 operation 저장/조회를 복합 키로 전환, 서비스는 charge=대상 지갑 / transfer=출금 지갑을 스코프로 전달.
- 지갑 존재 오라클(404 vs 403)은 ADR-0056이 수용한 트레이드오프로 이번 범위에서 변경하지 않음(`WalletAccessPolicy` 불변). ADR-0072 "대안/맥락"에 기록.

문서: ADR-0072, progress 0083, issue-draft 0083, unreleased/wiki-drafts 반영.

## 검증

- `./gradlew compileTestJava` 성공
- `./gradlew test --tests '*InMemoryWalletCommandServiceTest' --tests '*JdbcWalletRepositoryTest'` 통과 (서로 다른 지갑의 같은 멱등키 비충돌 + 같은 지갑/키/다른 fingerprint 409 회귀 포함)
- `AI_REPO_DEV_RULES_BASE=origin/main bash scripts/check-dev-rules.sh` → PASS

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)