### PR TITLE
[Fix] 미검증 입력/응답 경계 하드닝 — description 길이·401 본문·last_error 절단 (#147)

### DIFF
--- a/docs/adr/0070-input-response-boundary-hardening.md
+++ b/docs/adr/0070-input-response-boundary-hardening.md
@@ -1,0 +1,41 @@
+# ADR-0070: Input and Response Boundary Hardening
+
+## 상태
+
+Accepted
+
+## 배경
+
+지갑 command/응답 경계에 검증되지 않은 3개 지점이 있었다.
+
+1. **description 길이**: `charge`/`transfer` 요청의 `description`은 `required(...)`로 null만 막고 길이는 검증하지 않았다. `operation` 관련 테이블의 `description` 컬럼은 `VARCHAR(255)`이므로 256자 이상이 들어오면 서비스/영속화 단계에서 DB 제약 위반으로 500이 났다. 잘못된 입력은 경계에서 400으로 막아야 한다.
+2. **지갑 401 본문**: `walletSecurityFilterChain`(Order 4)에는 `authenticationEntryPoint`가 없어, JWT가 없거나 유효하지 않으면 Spring Security 기본 401(빈 본문)이 나갔다. 프론트가 응답 본문을 `response.json()`으로 파싱하다 빈 본문에서 `SyntaxError`를 던져 사용자에게 인증 오류 대신 깨진 에러가 노출됐다. admin/broker chain은 이미 JSON error handler로 401 형태를 통일해 두었다.
+3. **last_error 절단**: outbox 실패 기록(`markOutboxEventFailed`/`markClaimedOutboxEventFailed`)이 `last_error VARCHAR(255)` 컬럼에 예외 메시지를 그대로 썼다. 긴 스택/메시지가 들어오면 실패 기록 UPDATE 자체가 DB 제약 위반으로 실패해, 실패 사유를 남기지도 못하고 claim이 꼬였다.
+
+## 결정
+
+세 경계를 각각 최소·외과적으로 하드닝한다.
+
+| 항목 | 결정 |
+| --- | --- |
+| description 길이 | `WalletCommandController`에 `MAX_DESCRIPTION_LENGTH = 255` 상수와 `description(...)` 헬퍼를 두고, 255자 초과 시 기존 `InvalidWalletOperationException`을 던진다(`WalletApiExceptionHandler`가 400 `INVALID_WALLET_OPERATION`으로 매핑) |
+| 지갑 401 본문 | broker/admin과 동일 패턴의 `WalletSecurityErrorHandler`(`AuthenticationEntryPoint`)를 추가해 `{"code","message","timestamp"}` JSON으로 `WALLET_AUTHENTICATION_REQUIRED` 401을 쓴다. `walletSecurityFilterChain`의 `exceptionHandling`과 `oauth2ResourceServer` 양쪽에 entrypoint로 연결 |
+| last_error 절단 | `JdbcOutboxRelayRepository`에 널 안전한 package-private static `truncateLastError(...)`(255자 substring)를 두고 두 실패 기록 UPDATE의 `last_error` 바인딩에 적용 |
+
+## 트레이드오프
+
+### 장점
+
+- 잘못된 입력과 미인증 요청을 경계에서 400/401로 명확히 막고, admin/broker와 동일한 JSON error 형태로 통일해 프론트 파싱이 안정된다.
+- outbox 실패 기록이 메시지 길이와 무관하게 항상 성공해 claim 회수/재시도 흐름이 끊기지 않는다.
+
+### 비용
+
+- description 길이 한도(255)와 last_error 절단 한도(255)가 각각 `VARCHAR(255)` 스키마 값과 코드 상수로 이원화된다. 스키마가 바뀌면 두 상수도 함께 조정해야 한다.
+- last_error를 절단하면 원본 예외 메시지 뒷부분이 유실될 수 있다(전체 스택은 애플리케이션 로그에 남는 것을 전제).
+
+## 대안
+
+- description 길이를 Bean Validation(`@Size`)으로 검증: 요청 record에 애노테이션과 `@Valid`를 도입해야 하고, 현재 command controller는 수동 `required(...)` 검증 패턴을 쓰므로 일관성상 헬퍼 방식을 택했다.
+- 지갑 401을 controller/`@RestControllerAdvice`에서 처리: 인증 예외는 필터 단계에서 발생하므로 advice가 잡지 못한다. admin/broker와 같은 entrypoint 축이 정석이다.
+- last_error 컬럼을 `TEXT`로 확장: 스키마 마이그레이션이 필요하고 실패 메시지에 무한 길이를 허용하는 것은 과하다. 경계 절단이 더 작은 변경이다.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -82,3 +82,4 @@ ADR은 이 저장소에서 중요한 결정의 source of truth입니다. README�
 | ADR-0064 | JDBC Persistence Adapter Decomposition | Accepted |
 | ADR-0065 | Broker Consumer Endpoint Authentication | Accepted |
 | ADR-0066 | 학습용 opt-in ELK 로깅 스택 | Accepted |
+| ADR-0070 | Input and Response Boundary Hardening | Accepted |

--- a/docs/progress/0081-input-response-bounds.md
+++ b/docs/progress/0081-input-response-bounds.md
@@ -1,0 +1,33 @@
+# 0081. Input and Response Boundary Hardening
+
+## 스펙 목표
+
+- Issue #147의 미검증 경계 3건을 각각 최소·외과적으로 막는다.
+- description 256자 이상 → 500이 아니라 400.
+- 지갑 미인증 요청 → 빈 본문이 아니라 JSON error 401.
+- outbox 실패 기록의 last_error가 컬럼 한도를 넘겨 UPDATE 자체가 실패하지 않게 절단한다.
+
+## 완료 결과
+
+- `WalletCommandController`에 `description(...)` 헬퍼와 `MAX_DESCRIPTION_LENGTH = 255`를 추가해 charge/transfer의 description 255자 초과를 `InvalidWalletOperationException`(400 `INVALID_WALLET_OPERATION`)으로 막았다.
+- `WalletSecurityErrorHandler`(`AuthenticationEntryPoint`)를 추가하고 `walletSecurityFilterChain`의 `exceptionHandling`/`oauth2ResourceServer`에 연결해, 미인증/유효하지 않은 JWT에 `WALLET_AUTHENTICATION_REQUIRED` JSON 401을 반환한다.
+- `JdbcOutboxRelayRepository`에 널 안전한 `truncateLastError(...)`(255자)를 추가하고 `markOutboxEventFailed`/`markClaimedOutboxEventFailed`의 last_error 바인딩에 적용했다.
+- 프론트 `App.tsx`에 `parseError(response)` 헬퍼를 두어 빈 본문 응답에서 `SyntaxError` 대신 상태코드 기반 인증 오류 메시지를 던지도록 두 파싱 지점을 공통화했다.
+- ADR-0070, ADR index, unreleased release note, issue draft, wiki draft를 갱신했다.
+
+## 검증
+
+- `./gradlew compileTestJava`
+- `./gradlew test --tests '*WalletCommandControllerTest' --tests '*WalletQueryControllerTest' --tests '*JdbcOutboxRelayRepositoryLastErrorTest'`
+- `npm --prefix frontend run test`
+- `AI_REPO_DEV_RULES_BASE=origin/main bash scripts/check-dev-rules.sh` → PASS
+
+## 남은 일
+
+- description 길이 한도와 last_error 절단 한도가 `VARCHAR(255)` 스키마와 코드 상수로 이원화되어 있어, 스키마 변경 시 함께 조정해야 한다.
+
+## 관련 문서
+
+- `docs/adr/0070-input-response-boundary-hardening.md`
+- `docs/releases/unreleased.md`
+- `issue-drafts/0081-input-response-bounds.md`

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -93,6 +93,7 @@ ADR은 “왜 그렇게 결정했는가”를 기록하고, 이 폴더는 “각
 | 0075 | [Admin Path Drift Guard](0075-admin-path-drift-guard.md) | 완료 |
 | 0076 | [JDBC Persistence Adapter Decomposition](0076-jdbc-persistence-adapter-decomposition.md) | 완료 |
 | 0077 | [ELK 2단계 로깅 스택 (학습용 opt-in)](0077-elk-logging-stack.md) | 완료 |
+| 0081 | [미검증 입력/응답 경계 하드닝](0081-input-response-bounds.md) | 완료 |
 
 ## 현재 기준선
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -44,6 +44,7 @@
 - JDBC persistence adapter 분해 — `JdbcWalletRepository`를 PostgreSQL profile composite bean으로 유지하면서 wallet/ledger, outbox relay, outbox consumer, operational alert, admin audit SQL을 context별 package-private adapter로 분리하고 ArchUnit 레이어 규칙을 추가
 - `POST /internal/broker/outbox-events` shared secret 헤더(`X-Broker-Token`) 인증 — 전용 SecurityFilterChain(Order 3) + 상수시간 토큰 비교로 미인증 event 주입 차단, publisher가 같은 secret 부착(#123)
 - opt-in ELK 로깅 스택 — 학습용 Filebeat→Logstash(grok)→Elasticsearch(역색인)→Kibana를 `logging` 네임스페이스에 PLG(Loki)와 병존시키되 ArgoCD 미포함·`scripts/elk-local-up.sh`/`down.sh` 수동 기동, 로컬 학습 전제(security off·단일노드·ephemeral), Spring 로그 grok 파싱과 `spring-logs-*` KQL 검색. `AI_REPO_ELK_ENABLED` 토글·독립 스크립트·별도 ArgoCD Application(수동 sync)로 on/off (ADR-0066)
+- 미검증 입력/응답 경계 하드닝 — charge/transfer description 255자 초과를 400(`INVALID_WALLET_OPERATION`)으로 차단, 지갑 미인증 요청에 `WALLET_AUTHENTICATION_REQUIRED` JSON 401(`WalletSecurityErrorHandler`) 반환, outbox 실패 기록 `last_error`를 255자로 절단, 프론트가 빈 401 본문을 `SyntaxError` 대신 인증 오류로 처리(ADR-0070, #147)
 
 ## MVP 출시 판단 기준
 

--- a/frontend/e2e/wallet-flow.spec.ts
+++ b/frontend/e2e/wallet-flow.spec.ts
@@ -168,7 +168,8 @@ test('description가 255자를 넘는 충전은 400 검증 오류로 표시된�
 
   await page.getByLabel('회원 ID').fill('member-001');
   await page.getByRole('button', { name: '로그인' }).click();
-  await expect(page.locator('.balance-card').getByText('125,000 KRW')).toBeVisible();
+  // 앞선 테스트가 member-001 잔액을 바꾸므로 특정 금액 대신 로그인 완료만 확인한다(직렬 실행·공유 백엔드).
+  await expect(page.getByText('로그인되었습니다.')).toBeVisible();
 
   await page.getByLabel('충전 금액').fill('5000');
   await page.getByLabel('거래 설명').fill('a'.repeat(256));

--- a/frontend/e2e/wallet-flow.spec.ts
+++ b/frontend/e2e/wallet-flow.spec.ts
@@ -162,3 +162,17 @@ test('운영자는 manual review requeue 요청을 반려하고 audit 없이 상
   await expect(operatorConsole.getByText('아직 requeue audit이 없습니다.')).toBeVisible();
   await expect(operatorConsole.getByText('MANUAL_REVIEW').first()).toBeVisible();
 });
+
+test('description가 255자를 넘는 충전은 400 검증 오류로 표시된다', async ({ page }) => {
+  await page.goto('/');
+
+  await page.getByLabel('회원 ID').fill('member-001');
+  await page.getByRole('button', { name: '로그인' }).click();
+  await expect(page.locator('.balance-card').getByText('125,000 KRW')).toBeVisible();
+
+  await page.getByLabel('충전 금액').fill('5000');
+  await page.getByLabel('거래 설명').fill('a'.repeat(256));
+  await page.getByRole('button', { name: '충전하기' }).click();
+
+  await expect(page.getByText('INVALID_WALLET_OPERATION: description must not exceed 255 characters')).toBeVisible();
+});

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -332,6 +332,7 @@ function jsonResponse(body: unknown, status = 200) {
     ok: status >= 200 && status < 300,
     status,
     json: async () => body,
+    text: async () => JSON.stringify(body),
   } as Response;
 }
 
@@ -340,6 +341,7 @@ function emptyResponse(status = 204) {
     ok: status >= 200 && status < 300,
     status,
     json: async () => null,
+    text: async () => '',
   } as Response;
 }
 
@@ -458,6 +460,31 @@ describe('App', () => {
     const tokenCall = fetchMock.mock.calls.find(([url]) => url.toString().endsWith('/api/v1/auth/tokens'));
     expect(tokenCall).toBeDefined();
     expect(balanceCalls).toBeGreaterThanOrEqual(2);
+  });
+
+  it('401 응답 본문이 비어 있어도 SyntaxError 대신 인증 오류 메시지를 표시한다', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? 'GET';
+      if (url.endsWith('/api/v1/auth/tokens') && method === 'POST') {
+        const body = JSON.parse(String(init?.body));
+        return jsonResponse({ token: `fresh-${body.memberId}`, memberId: body.memberId, expiresAt: '2099-01-01T00:00:00Z' });
+      }
+      if (url.endsWith('/balance')) {
+        return emptyResponse(401);
+      }
+      if (url.endsWith('/transactions') || url.endsWith('/ledger-entries') || url.endsWith('/audit-events')) {
+        return jsonResponse([]);
+      }
+      throw new Error(`Unhandled request: ${method} ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText('인증이 필요합니다. 다시 로그인하세요.')).toBeVisible();
+    });
   });
 
   it('초기 지갑 잔액을 렌더링한다', async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -150,6 +150,22 @@ const initialApiState: ApiState = {
   auditEvents: [],
 };
 
+async function parseError(response: Response): Promise<Error> {
+  const body = (await response.text()).trim();
+  if (!body) {
+    if (response.status === 401) {
+      return new Error('인증이 필요합니다. 다시 로그인하세요.');
+    }
+    return new Error(`요청이 실패했습니다. (HTTP ${response.status})`);
+  }
+  try {
+    const error = JSON.parse(body) as ApiError;
+    return new Error(`${error.code}: ${error.message}`);
+  } catch {
+    return new Error(`요청이 실패했습니다. (HTTP ${response.status})`);
+  }
+}
+
 async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, {
     ...init,
@@ -160,8 +176,7 @@ async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
   });
 
   if (!response.ok) {
-    const error = (await response.json()) as ApiError;
-    throw new Error(`${error.code}: ${error.message}`);
+    throw await parseError(response);
   }
 
   return response.json() as Promise<T>;
@@ -323,8 +338,7 @@ export function App() {
       if (response.status === 401) {
         persistAuth(null);
       }
-      const error = (await response.json()) as ApiError;
-      throw new Error(`${error.code}: ${error.message}`);
+      throw await parseError(response);
     }
     return response.json() as Promise<T>;
   }

--- a/issue-drafts/0081-input-response-bounds.md
+++ b/issue-drafts/0081-input-response-bounds.md
@@ -1,0 +1,20 @@
+# 미검증 입력/응답 경계 하드닝 (#147)
+
+## 증상
+
+1. charge/transfer의 `description`이 256자 이상이면 `VARCHAR(255)` 제약 위반으로 500이 난다(경계에서 막지 않음).
+2. 지갑 API에 JWT가 없거나 유효하지 않으면 Spring Security 기본 401이 빈 본문으로 나가고, 프론트가 `response.json()`으로 파싱하다 `SyntaxError`를 던진다.
+3. outbox 실패 기록의 `last_error`가 `VARCHAR(255)`를 넘기면 실패 기록 UPDATE 자체가 실패해 사유를 남기지 못한다.
+
+## 결정
+
+- description 255자 초과 → `InvalidWalletOperationException`(400 `INVALID_WALLET_OPERATION`).
+- `WalletSecurityErrorHandler`로 `WALLET_AUTHENTICATION_REQUIRED` JSON 401 반환(admin/broker와 동일 형태).
+- `JdbcOutboxRelayRepository.truncateLastError(...)`로 last_error 255자 절단(널 안전).
+- 프론트 `parseError(response)`로 빈 본문 401을 친절한 인증 오류로 변환.
+
+## 검증
+
+- `./gradlew test --tests '*WalletCommandControllerTest' --tests '*WalletQueryControllerTest' --tests '*JdbcOutboxRelayRepositoryLastErrorTest'`
+- `npm --prefix frontend run test`
+- description 256자 → 400, 미인증 → JSON 401, 긴 last_error 절단 단위 테스트, 빈 본문 401 프론트 테스트.

--- a/issue-drafts/README.md
+++ b/issue-drafts/README.md
@@ -137,6 +137,8 @@
 - `0076-jdbc-persistence-adapter-decomposition.md`: JdbcWalletRepository bounded-context 분해와 ArchUnit 레이어 규칙 작업 초안
   - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/125
 - `0077-elk-logging-stack.md`: ELK 2단계 로깅 스택(Filebeat→Logstash grok→ES→Kibana) 학습용 opt-in 작업 초안
+- `0081-input-response-bounds.md`: 미검증 입력/응답 경계 하드닝(description 길이·401 본문·last_error 절단) 작업 초안
+  - GitHub Issue: https://github.com/IMWoo94/ai-repo/issues/147
 
 ## GitHub CLI로 생성
 

--- a/src/main/java/com/imwoo/airepo/wallet/api/SecurityConfig.java
+++ b/src/main/java/com/imwoo/airepo/wallet/api/SecurityConfig.java
@@ -103,7 +103,11 @@ public class SecurityConfig {
 
     @Bean
     @Order(4)
-    SecurityFilterChain walletSecurityFilterChain(HttpSecurity http, JwtDecoder walletJwtDecoder) throws Exception {
+    SecurityFilterChain walletSecurityFilterChain(
+            HttpSecurity http,
+            JwtDecoder walletJwtDecoder,
+            WalletSecurityErrorHandler walletSecurityErrorHandler
+    ) throws Exception {
         return http
                 .securityMatcher("/api/v1/wallets/**")
                 .csrf(AbstractHttpConfigurer::disable)
@@ -111,8 +115,12 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .logout(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exceptionHandling -> exceptionHandling
+                        .authenticationEntryPoint(walletSecurityErrorHandler))
                 .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
-                .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.decoder(walletJwtDecoder)))
+                .oauth2ResourceServer(oauth2 -> oauth2
+                        .authenticationEntryPoint(walletSecurityErrorHandler)
+                        .jwt(jwt -> jwt.decoder(walletJwtDecoder)))
                 .build();
     }
 

--- a/src/main/java/com/imwoo/airepo/wallet/api/WalletCommandController.java
+++ b/src/main/java/com/imwoo/airepo/wallet/api/WalletCommandController.java
@@ -22,6 +22,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/wallets")
 public class WalletCommandController {
 
+    private static final int MAX_DESCRIPTION_LENGTH = 255;
+
     private final WalletCommandService walletCommandService;
 
     public WalletCommandController(WalletCommandService walletCommandService) {
@@ -40,7 +42,7 @@ public class WalletCommandController {
                 new WalletChargeCommand(
                         money(request.amount(), request.currency()),
                         required("idempotencyKey", request.idempotencyKey()),
-                        required("description", request.description())
+                        description(request.description())
                 )
         );
         return ResponseEntity.status(status(result)).body(result.operation());
@@ -59,7 +61,7 @@ public class WalletCommandController {
                         required("targetWalletId", request.targetWalletId()),
                         money(request.amount(), request.currency()),
                         required("idempotencyKey", request.idempotencyKey()),
-                        required("description", request.description())
+                        description(request.description())
                 )
         );
         return ResponseEntity.status(status(result)).body(result.operation());
@@ -91,5 +93,14 @@ public class WalletCommandController {
             throw new InvalidWalletOperationException(fieldName + " must not be null");
         }
         return value;
+    }
+
+    private String description(String value) {
+        String description = required("description", value);
+        if (description.length() > MAX_DESCRIPTION_LENGTH) {
+            throw new InvalidWalletOperationException(
+                    "description must not exceed " + MAX_DESCRIPTION_LENGTH + " characters");
+        }
+        return description;
     }
 }

--- a/src/main/java/com/imwoo/airepo/wallet/api/WalletSecurityErrorHandler.java
+++ b/src/main/java/com/imwoo/airepo/wallet/api/WalletSecurityErrorHandler.java
@@ -1,0 +1,43 @@
+package com.imwoo.airepo.wallet.api;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WalletSecurityErrorHandler implements AuthenticationEntryPoint {
+
+    private final Clock clock;
+
+    public WalletSecurityErrorHandler(Clock clock) {
+        this.clock = clock;
+    }
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException, ServletException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write("""
+                {"code":"%s","message":"%s","timestamp":"%s"}"""
+                .formatted("WALLET_AUTHENTICATION_REQUIRED", message(authException), Instant.now(clock)));
+    }
+
+    private String message(AuthenticationException exception) {
+        if (exception == null || exception.getMessage() == null || exception.getMessage().isBlank()) {
+            return "wallet authentication is required";
+        }
+        return exception.getMessage();
+    }
+}

--- a/src/main/java/com/imwoo/airepo/wallet/infra/JdbcOutboxRelayRepository.java
+++ b/src/main/java/com/imwoo/airepo/wallet/infra/JdbcOutboxRelayRepository.java
@@ -21,6 +21,8 @@ import org.springframework.transaction.support.TransactionTemplate;
  */
 final class JdbcOutboxRelayRepository implements OperationOutboxRelayRepository, OperationOutboxRelayRunRepository {
 
+    private static final int MAX_LAST_ERROR_LENGTH = 255;
+
     private final WalletJdbcSupport support;
     private final JdbcTemplate jdbcTemplate;
     private final TransactionTemplate transactionTemplate;
@@ -216,7 +218,7 @@ final class JdbcOutboxRelayRepository implements OperationOutboxRelayRepository,
                 OperationOutboxStatus.FAILED.name(),
                 maxAttempts,
                 support.timestamp(nextRetryAt),
-                lastError,
+                truncateLastError(lastError),
                 outboxEventId
         );
     }
@@ -254,7 +256,7 @@ final class JdbcOutboxRelayRepository implements OperationOutboxRelayRepository,
                         OperationOutboxStatus.FAILED.name(),
                         maxAttempts,
                         support.timestamp(nextRetryAt),
-                        lastError,
+                        truncateLastError(lastError),
                         outboxEventId,
                         OperationOutboxStatus.PROCESSING.name(),
                         support.timestamp(claimedAt),
@@ -654,5 +656,12 @@ final class JdbcOutboxRelayRepository implements OperationOutboxRelayRepository,
                 requestId
         )
                 .orElseThrow(() -> new InvalidWalletOperationException("requeue request not found: " + requestId));
+    }
+
+    static String truncateLastError(String lastError) {
+        if (lastError == null || lastError.length() <= MAX_LAST_ERROR_LENGTH) {
+            return lastError;
+        }
+        return lastError.substring(0, MAX_LAST_ERROR_LENGTH);
     }
 }

--- a/src/test/java/com/imwoo/airepo/wallet/api/WalletCommandControllerTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/api/WalletCommandControllerTest.java
@@ -142,6 +142,42 @@ class WalletCommandControllerTest {
     }
 
     @Test
+    void rejectsChargeWithDescriptionOverMaxLengthAsBadRequest() throws Exception {
+        String tooLongDescription = "a".repeat(256);
+        mockMvc.perform(post("/api/v1/wallets/wallet-001/charges")
+                        .with(member("member-001"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "amount": 5000,
+                                  "currency": "KRW",
+                                  "idempotencyKey": "charge-api-001",
+                                  "description": "%s"
+                                }
+                                """.formatted(tooLongDescription)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_WALLET_OPERATION"))
+                .andExpect(jsonPath("$.message").value("description must not exceed 255 characters"));
+    }
+
+    @Test
+    void returnsJsonBodyForUnauthenticatedRequest() throws Exception {
+        mockMvc.perform(post("/api/v1/wallets/wallet-001/charges")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "amount": 5000,
+                                  "currency": "KRW",
+                                  "idempotencyKey": "charge-api-001",
+                                  "description": "API 충전"
+                                }
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("WALLET_AUTHENTICATION_REQUIRED"))
+                .andExpect(jsonPath("$.message").isNotEmpty());
+    }
+
+    @Test
     void rejectsChargeWhenMemberDoesNotOwnWallet() throws Exception {
         mockMvc.perform(post("/api/v1/wallets/wallet-001/charges")
                         .with(member("member-002"))

--- a/src/test/java/com/imwoo/airepo/wallet/infra/JdbcOutboxRelayRepositoryLastErrorTest.java
+++ b/src/test/java/com/imwoo/airepo/wallet/infra/JdbcOutboxRelayRepositoryLastErrorTest.java
@@ -1,0 +1,25 @@
+package com.imwoo.airepo.wallet.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class JdbcOutboxRelayRepositoryLastErrorTest {
+
+    @Test
+    void keepsNullLastError() {
+        assertThat(JdbcOutboxRelayRepository.truncateLastError(null)).isNull();
+    }
+
+    @Test
+    void keepsLastErrorWithinColumnLimit() {
+        String message = "a".repeat(255);
+        assertThat(JdbcOutboxRelayRepository.truncateLastError(message)).isEqualTo(message);
+    }
+
+    @Test
+    void truncatesLastErrorExceedingColumnLimit() {
+        String message = "a".repeat(300);
+        assertThat(JdbcOutboxRelayRepository.truncateLastError(message)).hasSize(255);
+    }
+}

--- a/wiki-drafts/Release-Notes.md
+++ b/wiki-drafts/Release-Notes.md
@@ -74,6 +74,7 @@
 ## 다음 후보
 
 - opt-in ELK 로깅 스택(Filebeat→Logstash grok→Elasticsearch→Kibana) — `logging` 네임스페이스에 PLG와 병존, 기본 ArgoCD 자동배포에는 미포함(항상 켜짐 방지), 로그 파싱·역색인 검색 학습용. on/off는 독립 스크립트·`AI_REPO_ELK_ENABLED` env·별도 ArgoCD 수동 sync App(`deploy/argocd/logging-application.yaml`) 3가지 중 택1 (ADR-0066)
+- 미검증 입력/응답 경계 하드닝 — description 255자 초과 400, 지갑 미인증 JSON 401(`WALLET_AUTHENTICATION_REQUIRED`), outbox `last_error` 255자 절단, 프론트 빈 401 본문 방어 (ADR-0070, #147)
 - JWT refresh token 기반 만료/갱신 정책 강화(현재는 401 시 password-less 재발급)
 - 로그인 회원의 실제 보유 지갑 조회 API(현재는 fixture 기반 파생)
 - broker-specific Testcontainers contract


### PR DESCRIPTION
## 요약

Issue #147의 미검증 경계 3건을 각각 최소·외과적으로 하드닝했다.

- **description 길이**: charge/transfer의 `description`이 255자를 초과하면 `InvalidWalletOperationException`을 던져 400(`INVALID_WALLET_OPERATION`)으로 막는다. 기존에는 `VARCHAR(255)` 제약 위반으로 500이 났다.
- **지갑 401 본문**: `WalletSecurityErrorHandler`(admin/broker와 동일 패턴)를 추가해 미인증/유효하지 않은 JWT에 `WALLET_AUTHENTICATION_REQUIRED` JSON 401을 반환한다. `walletSecurityFilterChain`의 `exceptionHandling`/`oauth2ResourceServer`에 연결.
- **last_error 절단**: `JdbcOutboxRelayRepository.truncateLastError(...)`(널 안전, 255자)로 outbox 실패 기록 UPDATE가 컬럼 한도 위반으로 실패하지 않게 한다.
- **프론트**: `parseError(response)` 헬퍼로 빈 401 본문을 `SyntaxError` 대신 친절한 인증 오류 메시지로 처리(두 파싱 지점 공통화).

## 검증

- `./gradlew compileTestJava` 성공
- `./gradlew test --tests '*WalletCommandControllerTest' --tests '*WalletQueryControllerTest' --tests '*JdbcOutboxRelayRepositoryLastErrorTest'` 통과
- `npm --prefix frontend run test` 통과 (11 tests)
- `AI_REPO_DEV_RULES_BASE=origin/main bash scripts/check-dev-rules.sh` → PASS
- Playwright e2e는 파일만 추가(실행 안 함)

## 문서

ADR-0070, progress 0081, unreleased, issue-draft 0081(#147), wiki-drafts Release-Notes 동반 갱신.

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)